### PR TITLE
Fix: Correct git cherry logic in cleanup-repo.sh

### DIFF
--- a/devtools/gh-nudge/cleanup-repo.sh
+++ b/devtools/gh-nudge/cleanup-repo.sh
@@ -53,7 +53,7 @@ for branch in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
     #   + <commit hash>  => commit not in main
     #   - <commit hash>  => commit is in main
     # If there's no lines starting with '+', then no unique commits.
-    if git cherry "$MAIN_BRANCH" "$branch" | grep -q -v '^+'; then
+    if ! git cherry "$MAIN_BRANCH" "$branch" | grep -q '^+'; then
         branches_to_delete+=("$branch")
     fi
 done


### PR DESCRIPTION
The previous logic for identifying branches to delete was flawed. It would incorrectly mark branches for deletion if they contained a mix of commits unique to the branch and commits already in the main branch.

The condition `git cherry "$MAIN_BRANCH" "$branch" | grep -q -v '^+'` would evaluate to true if *any* commit was shared with main (i.e., any line *not* starting with '+'), leading to the deletion of branches that still had unique work.

The corrected logic `! git cherry "$MAIN_BRANCH" "$branch" | grep -q '^+'` accurately identifies branches for deletion only if `git cherry` produces *no* lines starting with '+', meaning the branch contains no commits that are not already in the main branch.