### PR TITLE
Add GitHub Actions workflow for Bazel tests

### DIFF
--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -1,0 +1,30 @@
+name: Bazel Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Run Bazel Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Bazel
+      uses: bazelbuild/setup-bazelisk@v3
+
+    - name: Mount Bazel cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/bazel
+        key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-bazel-
+
+    - name: Run tests
+      run: bazel test //...:all


### PR DESCRIPTION
This workflow runs Bazel tests on every push and pull request to the main branch.
It uses a cache for Bazel to speed up the builds.