### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -1,5 +1,8 @@
 name: Bazel Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -1,5 +1,8 @@
 name: Emacs Init Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Go Test
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
This change adds explicit `permissions` to the following workflow files:
- .github/workflows/bazel-test.yml
- .github/workflows/emacs.yml
- .github/workflows/go.yml

This is done to adhere to the principle of least privilege and enhance security by preventing accidental or malicious writes.

For most workflows, `contents: read` is sufficient. For `go.yml`, which uploads coverage reports via the Codecov action, `actions: read` is also included.