### PR TITLE
feat(Ansible): Leave a simple log

### DIFF
--- a/devtools/setup-dev/ansible/ensure.sh
+++ b/devtools/setup-dev/ansible/ensure.sh
@@ -1,6 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script ensure.sh runs the provided playbooks with the provided arguments.
+
+LOG_FILE="$HOME/.cache/ensure_sh.log"
+SESSION_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16 ; echo '')
+
+echo "---" >> "$LOG_FILE"
+echo "Session ID: $SESSION_ID" >> "$LOG_FILE"
+echo "Start Time: $(date)" >> "$LOG_FILE"
+echo "Arguments: $@" >> "$LOG_FILE"
+
+finish() {
+    EXIT_CODE=$?
+    echo "Finish Time: $(date)" >> "$LOG_FILE"
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo "Finish Reason: Success" >> "$LOG_FILE"
+    else
+        echo "Finish Reason: Failure (Exit Code: $EXIT_CODE)" >> "$LOG_FILE"
+    fi
+}
+trap finish EXIT
+
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 CACHE_DIR="$HOME/.cache/last_upgrade"
 mkdir -p "$CACHE_DIR"


### PR DESCRIPTION
This change adds comprehensive logging to the `ensure.sh` script in the Ansible setup. It captures a unique session ID, start and end timestamps, and the script's final exit status in a log file. This will improve debugging and provide a persistent record of each execution.

Fixes #120

---
*PR created automatically by Jules for task [11969771900419034947](https://jules.google.com/task/11969771900419034947) started by @jaeyeom*