### PR TITLE
fix(gh-nudge): fetch all open PRs instead of capping at 10

### DIFF
--- a/devtools/gh-nudge/internal/github/github.go
+++ b/devtools/gh-nudge/internal/github/github.go
@@ -55,12 +55,23 @@ func NewClientWithExecutor(executor CommandExecutor) *Client {
 	return &Client{executor: executor}
 }
 
+// pullRequestListLimit caps how many pull requests are fetched. The gh CLI's
+// `pr list` defaults to 30; we raise it well past that so users with many open
+// PRs are not silently truncated (the previous `pr status` command was capped
+// at 10 with no way to override).
+const pullRequestListLimit = 100
+
 // GetPendingPullRequests fetches pending pull requests using the gh CLI.
-// It fetches PRs created by the current user.
+// It fetches open PRs created by the current user.
 func (c *Client) GetPendingPullRequests() ([]models.PullRequest, error) {
-	// Construct the gh command to get PR information
-	// This command fetches PRs with their title, URL, review requests, and files
-	output, err := c.executor.Execute("gh", "pr", "status", "--json", "url,title,reviewRequests,files,mergeable,headRefName,statusCheckRollup", "-q", ".createdBy")
+	// Construct the gh command to get PR information.
+	// This fetches open PRs authored by the current user with their title, URL,
+	// review requests, and files. We use `pr list --author @me` instead of
+	// `pr status` because `pr status` is hardcoded to return at most 10 PRs.
+	output, err := c.executor.Execute("gh", "pr", "list",
+		"--author", "@me",
+		"--limit", fmt.Sprintf("%d", pullRequestListLimit),
+		"--json", "url,title,reviewRequests,files,mergeable,headRefName,statusCheckRollup")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute gh command: %w", err)
 	}


### PR DESCRIPTION
## Summary

`gh-nudge` (and `gh-merge`, which shares the same fetch path) only ever processed 10 pull requests. The root cause was in `GetPendingPullRequests` (`devtools/gh-nudge/internal/github/github.go`), which used:

```
gh pr status -q ".createdBy"
```

`gh pr status` is hardcoded to return at most **10** PRs and exposes **no `--limit` flag**, so any user with more than 10 open PRs silently lost the rest.

## Fix

Switch to `gh pr list --author "@me" --limit 100 --json ...`, which:

- Preserves the "open PRs created by the current user, in this repo" semantics.
- Returns the same JSON array shape, so the parser is unchanged.
- Supports an explicit limit, set via a new `pullRequestListLimit = 100` constant (gh's own default is only 30).

`GetMergeablePullRequests` (used by `gh-merge`) is fixed transitively since it calls `GetPendingPullRequests`.

## Testing

- `make format`, `make lint` (0 issues), `make test` — all pass.
- Existing `TestGetPendingPullRequests` cases only feed mock JSON output and don't assert command args for this function, so they remain valid unchanged.