### PR TITLE
test(ansible): raise Go unit coverage for install methods and generator

### DIFF
--- a/devtools/setup-dev/ansible/BUILD.bazel
+++ b/devtools/setup-dev/ansible/BUILD.bazel
@@ -23,8 +23,10 @@ go_binary(
 go_test(
     name = "go_default_test",
     srcs = [
+        "generate_packages_test.go",
         "install_methods_test.go",
         "packages_data_test.go",
+        "types_test.go",
     ],
     data = glob(["*.yml"]),
     embed = [":go_default_library"],

--- a/devtools/setup-dev/ansible/generate_packages_test.go
+++ b/devtools/setup-dev/ansible/generate_packages_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempDir creates a temporary directory, chdirs into it for the duration
+// of the test, and restores the original working directory afterwards.
+func withTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	return dir
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+func TestGetPlaybookImports(t *testing.T) {
+	withTempDir(t)
+	writeFile(t, "parent.yml", `---
+- import_playbook: child.yml
+- import_playbook: other.yml  # trailing comment
+# - import_playbook: commented.yml
+- name: Some play
+  hosts: all
+`)
+	writeFile(t, "child.yml", "---\n")
+	writeFile(t, "other.yml", "---\n")
+
+	got, err := getPlaybookImports("parent")
+	if err != nil {
+		t.Fatalf("getPlaybookImports: %v", err)
+	}
+	want := []string{"child", "other"}
+	if len(got) != len(want) {
+		t.Fatalf("getPlaybookImports() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("getPlaybookImports()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestGetPlaybookTaskIncludes(t *testing.T) {
+	withTempDir(t)
+	writeFile(t, "play.yml", `---
+- name: demo
+  hosts: all
+  tasks:
+    - name: include something
+      ansible.builtin.include_tasks: tasks/github-release-info.yml
+    # ansible.builtin.include_tasks: tasks/ignored.yml
+    - name: another
+      include_tasks: tasks/other.yml  # comment
+`)
+
+	got, err := getPlaybookTaskIncludes("play.yml")
+	if err != nil {
+		t.Fatalf("getPlaybookTaskIncludes: %v", err)
+	}
+	want := []string{"tasks/github-release-info.yml", "tasks/other.yml"}
+	if len(got) != len(want) {
+		t.Fatalf("getPlaybookTaskIncludes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestGetAllDependencies(t *testing.T) {
+	withTempDir(t)
+	// a -> b -> c, a -> d; cycle b -> a should be ignored via visited.
+	writeFile(t, "a.yml", "- import_playbook: b.yml\n- import_playbook: d.yml\n")
+	writeFile(t, "b.yml", "- import_playbook: c.yml\n- import_playbook: a.yml\n")
+	writeFile(t, "c.yml", "---\n")
+	writeFile(t, "d.yml", "---\n")
+
+	got, err := getAllDependencies("a", map[string]bool{})
+	if err != nil {
+		t.Fatalf("getAllDependencies: %v", err)
+	}
+	seen := make(map[string]bool)
+	for _, d := range got {
+		seen[d] = true
+	}
+	// Direct and transitive deps must appear. Through the b->a cycle, "a" may
+	// also appear as a listed import of b; the important property is that
+	// the cycle does not recurse forever (test would hang/stack overflow).
+	for _, want := range []string{"b", "c", "d"} {
+		if !seen[want] {
+			t.Errorf("missing dependency %q in %v", want, got)
+		}
+	}
+}
+
+func TestGetAllYmlFiles(t *testing.T) {
+	withTempDir(t)
+	writeFile(t, "alpha.yml", "---\n")
+	writeFile(t, "beta.yml", "---\n")
+	writeFile(t, "subdir/nested.yml", "---\n") // should be ignored (contains /)
+	writeFile(t, "notes.txt", "nope")
+
+	got, err := getAllYmlFiles()
+	if err != nil {
+		t.Fatalf("getAllYmlFiles: %v", err)
+	}
+	if len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
+		t.Errorf("getAllYmlFiles() = %v, want [alpha beta]", got)
+	}
+}
+
+func TestReadManualContent(t *testing.T) {
+	withTempDir(t)
+
+	t.Run("missing file returns default", func(t *testing.T) {
+		got, err := readManualContent("BUILD.bazel")
+		if err != nil {
+			t.Fatalf("readManualContent: %v", err)
+		}
+		if got != defaultManualContent {
+			t.Errorf("expected defaultManualContent for missing file")
+		}
+	})
+
+	t.Run("reads content before marker", func(t *testing.T) {
+		writeFile(t, "BUILD.bazel", `load(":x.bzl", "x")
+
+# GENERATED ANSIBLE TESTS - DO NOT EDIT BELOW THIS LINE
+sh_test(name = "foo")
+`)
+		got, err := readManualContent("BUILD.bazel")
+		if err != nil {
+			t.Fatalf("readManualContent: %v", err)
+		}
+		want := "load(\":x.bzl\", \"x\")\n\n"
+		if got != want {
+			t.Errorf("readManualContent() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no marker returns default", func(t *testing.T) {
+		writeFile(t, "BUILD.bazel", "just some content\n")
+		got, err := readManualContent("BUILD.bazel")
+		if err != nil {
+			t.Fatalf("readManualContent: %v", err)
+		}
+		if got != defaultManualContent {
+			t.Errorf("expected defaultManualContent when marker missing")
+		}
+	})
+}
+
+func TestGenerateTestRule(t *testing.T) {
+	withTempDir(t)
+	writeFile(t, "root.yml", `- import_playbook: dep.yml
+- name: play
+  hosts: all
+  tasks:
+    - ansible.builtin.include_tasks: tasks/helper.yml
+`)
+	writeFile(t, "dep.yml", "---\n")
+	writeFile(t, "tasks/helper.yml", "---\n")
+
+	got, err := generateTestRule("root")
+	if err != nil {
+		t.Fatalf("generateTestRule: %v", err)
+	}
+	for _, want := range []string{
+		`name = "root_syntax_test"`,
+		`args = ["root.yml"]`,
+		`"root.yml"`,
+		`"dep.yml"`,
+		`"tasks/helper.yml"`,
+		`"ansible"`,
+		`"local"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("generateTestRule missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteGPGKeySetup(t *testing.T) {
+	t.Run("base64 embedded key", func(t *testing.T) {
+		var sb strings.Builder
+		writeGPGKeySetup(&sb, &AptRepoInstallMethod{
+			GPGKeyBase64: "QUJDRA==",
+			GPGKeyPath:   "/etc/apt/trusted.gpg.d/tool.gpg",
+		})
+		got := sb.String()
+		for _, want := range []string{
+			"base64 -d << 'GPGKEY'",
+			"QUJDRA==",
+			"GPGKEY",
+			"/etc/apt/trusted.gpg.d/tool.gpg",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in:\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "curl") {
+			t.Errorf("should not curl when base64 is set:\n%s", got)
+		}
+	})
+
+	t.Run("curl download", func(t *testing.T) {
+		var sb strings.Builder
+		writeGPGKeySetup(&sb, &AptRepoInstallMethod{
+			GPGKeyURL:  "https://example.com/key.gpg",
+			GPGKeyPath: "/etc/apt/trusted.gpg.d/tool.gpg",
+		})
+		got := sb.String()
+		want := "curl -fsSL 'https://example.com/key.gpg' | gpg --dearmor -o /etc/apt/trusted.gpg.d/tool.gpg\n"
+		if got != want {
+			t.Errorf("writeGPGKeySetup() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestGenerateQubesTemplatevmScript(t *testing.T) {
+	withTempDir(t)
+
+	pkgs := []AptPackageInfo{
+		{PackageName: "curl", SourceType: AptSourceNone},
+		{PackageName: "emacs", SourceType: AptSourcePPA, PPA: "ppa:ubuntuhandbook1/emacs"},
+		{PackageName: "ripgrep", SourceType: AptSourceBackports},
+		{
+			PackageName: "gcloud-cli",
+			SourceType:  AptSourceAptRepo,
+			AptRepo: &AptRepoInstallMethod{
+				Name:           "gcloud-cli",
+				GPGKeyURL:      "https://example.com/key.gpg",
+				GPGKeyPath:     "/etc/apt/trusted.gpg.d/google.gpg",
+				RepoURL:        "https://packages.example.com/apt",
+				RepoComponents: "main",
+				Codename:       "stable",
+				Arch:           "amd64",
+			},
+		},
+	}
+
+	if err := generateQubesTemplatevmScript("minimal", pkgs); err != nil {
+		t.Fatalf("generateQubesTemplatevmScript: %v", err)
+	}
+
+	content, err := os.ReadFile("qubes-templatevm-minimal.sh")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(content)
+	for _, want := range []string{
+		"#!/bin/bash",
+		"set -euo pipefail",
+		"backports",
+		"add-apt-repository -y ppa:ubuntuhandbook1/emacs",
+		"curl -fsSL 'https://example.com/key.gpg'",
+		"arch=amd64",
+		"apt-get update",
+		"apt-get install -y",
+		"curl",
+		"emacs",
+		"ripgrep",
+		"gcloud-cli",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in script:\n%s", want, got)
+		}
+	}
+}
+
+func TestValidatePlatformNames(t *testing.T) {
+	// All current package data should use valid platform constants.
+	if err := validatePlatformNames(); err != nil {
+		t.Errorf("validatePlatformNames() = %v", err)
+	}
+}
+
+func TestGetGeneratedRuleNames(t *testing.T) {
+	names := getGeneratedRuleNames()
+	if len(names) == 0 {
+		t.Fatal("expected non-empty generated rule names")
+	}
+	// Sorted
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("not sorted: %q before %q", names[i-1], names[i])
+		}
+	}
+	// Spot-check known generated packages/tools.
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		seen[n] = true
+	}
+	for _, want := range []string{"curl", "git", "gopls"} {
+		if !seen[want] {
+			// gopls might be named differently; only require common packages.
+			if want == "curl" || want == "git" {
+				t.Errorf("expected generated rule %q", want)
+			}
+		}
+	}
+}

--- a/devtools/setup-dev/ansible/install_methods_test.go
+++ b/devtools/setup-dev/ansible/install_methods_test.go
@@ -1,50 +1,279 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func assertContains(t *testing.T, got string, wants []string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func assertNotContains(t *testing.T, got string, unwanteds []string) {
+	t.Helper()
+	for _, unwanted := range unwanteds {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("unexpectedly contains %q\nfull output:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestIndent(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		spaces int
+		want   string
+	}{
+		{
+			name:   "single line",
+			input:  "hello",
+			spaces: 4,
+			want:   "    hello",
+		},
+		{
+			name:   "multiline",
+			input:  "a\nb\nc",
+			spaces: 2,
+			want:   "  a\n  b\n  c",
+		},
+		{
+			name:   "empty lines stay empty",
+			input:  "a\n\nb",
+			spaces: 2,
+			want:   "  a\n\n  b",
+		},
+		{
+			name:   "zero spaces",
+			input:  "x",
+			spaces: 0,
+			want:   "x",
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			spaces: 4,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := indent(tt.input, tt.spaces); got != tt.want {
+				t.Errorf("indent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripBlockAndIndent(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		spaces int
+		want   string
+	}{
+		{
+			name: "strips name and block",
+			input: `    - name: Ensure foo is present
+      block:
+        - name: Check if foo is installed
+          shell: command -v foo`,
+			spaces: 0,
+			want: `        - name: Check if foo is installed
+          shell: command -v foo`,
+		},
+		{
+			name: "block only without name",
+			input: `      block:
+        - name: Install foo
+          package:
+            name: foo`,
+			spaces: 0,
+			want: `        - name: Install foo
+          package:
+            name: foo`,
+		},
+		{
+			// A leading "- name:" line is always stripped (template already
+			// provides the task name). Content without that header is kept.
+			name:   "no name or block header indents content",
+			input:  "        shell: echo hi",
+			spaces: 2,
+			want:   "          shell: echo hi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripBlockAndIndent(tt.input, tt.spaces); got != tt.want {
+				t.Errorf("stripBlockAndIndent() =\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPackageInstallMethod(t *testing.T) {
+	method := PackageInstallMethod{Name: "silversearcher-ag"}
+	if got := method.GetMethodType(); got != "package" {
+		t.Errorf("GetMethodType() = %q, want package", got)
+	}
+	if imports := method.GetImports(); imports != nil {
+		t.Errorf("GetImports() = %v, want nil", imports)
+	}
+	if setup := method.RenderSetupTasks("ag"); setup != "" {
+		t.Errorf("RenderSetupTasks() = %q, want empty", setup)
+	}
+
+	got := method.RenderInstallTask("ag")
+	assertContains(t, got, []string{
+		"command -v ag",
+		"name: silversearcher-ag",
+		"become: yes",
+		"package:",
+	})
+
+	block := method.RenderBlockInstallTask("ag")
+	assertContains(t, block, []string{"name: silversearcher-ag", "command -v ag"})
+	if strings.HasPrefix(strings.TrimSpace(block), "block:") {
+		t.Errorf("RenderBlockInstallTask should strip leading block:\n%s", block)
+	}
+}
+
+func TestBrewInstallMethod(t *testing.T) {
+	t.Run("without tap or options", func(t *testing.T) {
+		method := BrewInstallMethod{Name: "ripgrep"}
+		if got := method.GetMethodType(); got != "brew" {
+			t.Errorf("GetMethodType() = %q, want brew", got)
+		}
+		if setup := method.RenderSetupTasks("rg"); setup != "" {
+			t.Errorf("RenderSetupTasks() = %q, want empty", setup)
+		}
+		got := method.RenderInstallTask("rg")
+		assertContains(t, got, []string{
+			"command -v rg",
+			"community.general.homebrew:",
+			"name: ripgrep",
+			"state: present",
+		})
+		assertNotContains(t, got, []string{"install_options:"})
+	})
+
+	t.Run("with tap and options", func(t *testing.T) {
+		method := BrewInstallMethod{
+			Name:    "emacs-plus",
+			Tap:     "d12frosted/emacs-plus",
+			Options: []string{"with-native-comp", "with-dbus"},
+		}
+		setup := method.RenderSetupTasks("emacs")
+		assertContains(t, setup, []string{
+			"Tap d12frosted/emacs-plus for emacs",
+			"community.general.homebrew_tap:",
+			"name: d12frosted/emacs-plus",
+			`when: ansible_facts['os_family'] == "Darwin"`,
+		})
+
+		got := method.RenderInstallTask("emacs")
+		assertContains(t, got, []string{
+			"name: emacs-plus",
+			"install_options:",
+			"- with-native-comp",
+			"- with-dbus",
+		})
+	})
+}
+
+func TestBrewCaskInstallMethod(t *testing.T) {
+	method := BrewCaskInstallMethod{Name: "visual-studio-code"}
+	if got := method.GetMethodType(); got != "brew-cask" {
+		t.Errorf("GetMethodType() = %q, want brew-cask", got)
+	}
+	got := method.RenderInstallTask("code")
+	assertContains(t, got, []string{
+		"community.general.homebrew_cask:",
+		"name: visual-studio-code",
+		"Install code on MacOS via cask",
+	})
+	block := method.RenderBlockInstallTask("code")
+	assertContains(t, block, []string{"name: visual-studio-code"})
+}
+
+func TestTermuxPkgInstallMethod(t *testing.T) {
+	method := TermuxPkgInstallMethod{Name: "git"}
+	if got := method.GetMethodType(); got != "termux-pkg" {
+		t.Errorf("GetMethodType() = %q, want termux-pkg", got)
+	}
+	got := method.RenderInstallTask("git")
+	assertContains(t, got, []string{
+		"Install git on Termux",
+		"pkg install -y git",
+		"command -v git",
+	})
+}
+
+func TestPipInstallMethod(t *testing.T) {
+	method := PipInstallMethod{Name: "yt-dlp"}
+	if got := method.GetMethodType(); got != "pip" {
+		t.Errorf("GetMethodType() = %q, want pip", got)
+	}
+	got := method.RenderInstallTask("yt-dlp")
+	assertContains(t, got, []string{
+		"ansible.builtin.pip:",
+		"name: yt-dlp",
+		"state: latest",
+	})
+	// RenderBlockInstallTask should indent the task.
+	block := method.RenderBlockInstallTask("yt-dlp")
+	if !strings.HasPrefix(block, "    ") {
+		t.Errorf("RenderBlockInstallTask should be indented:\n%s", block)
+	}
+}
 
 func TestGoInstallMethodRenderInstallTask(t *testing.T) {
 	method := GoInstallMethod{PkgPath: "example.com/mytool@latest"}
 	got := method.RenderInstallTask("my-tool")
 
 	// Hyphens in the command name must become underscores in Ansible vars.
-	for _, want := range []string{
+	assertContains(t, got, []string{
 		"my_tool_installed",
 		"my_tool_module_version",
 		"my_tool_latest",
 		"my_tool_build_go",
 		"my_tool_upgrade",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("RenderInstallTask() missing variable %q", want)
-		}
-	}
+	})
 
 	// Build Go version is extracted from the binary metadata.
-	if !strings.Contains(got, "go version -m $(command -v my-tool)") {
-		t.Error("RenderInstallTask() missing go version -m for build Go version")
-	}
-	if !strings.Contains(got, "my_tool_build_go") {
-		t.Error("RenderInstallTask() missing build Go version register")
-	}
+	assertContains(t, got, []string{
+		"go version -m $(command -v my-tool)",
+		"my_tool_build_go",
+	})
 
 	// Upgrade when module is missing/outdated OR built with a different toolchain.
-	for _, want := range []string{
+	assertContains(t, got, []string{
 		"my_tool_module_version is not defined",
 		"my_tool_module_version == \"\"",
 		"my_tool_module_version != my_tool_latest.stdout",
 		"my_tool_build_go.stdout | default('') != go_toolchain_version",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("RenderInstallTask() missing upgrade condition fragment %q\nfull output:\n%s", want, got)
-		}
-	}
+	})
 
 	// Install uses the configured package path.
-	if !strings.Contains(got, "go install example.com/mytool@latest") {
-		t.Error("RenderInstallTask() missing go install package path")
+	assertContains(t, got, []string{"go install example.com/mytool@latest"})
+
+	if got := method.GetMethodType(); got != "go" {
+		t.Errorf("GetMethodType() = %q, want go", got)
+	}
+	if setup := method.RenderSetupTasks("my-tool"); setup != "" {
+		t.Errorf("RenderSetupTasks() = %q, want empty", setup)
+	}
+	block := method.RenderBlockInstallTask("my-tool")
+	if !strings.HasPrefix(block, "    ") {
+		t.Errorf("RenderBlockInstallTask should indent:\n%s", block)
 	}
 }
 
@@ -53,5 +282,395 @@ func TestGoInstallMethodGetImports(t *testing.T) {
 	imports := method.GetImports()
 	if len(imports) != 1 || imports[0].Playbook != "setup-user-go-bin-directory" {
 		t.Errorf("GetImports() = %v, want setup-user-go-bin-directory", imports)
+	}
+}
+
+func TestRustupComponentMethod(t *testing.T) {
+	method := RustupComponentMethod{Name: "rustfmt"}
+	if got := method.GetMethodType(); got != "rustup-component" {
+		t.Errorf("GetMethodType() = %q, want rustup-component", got)
+	}
+	imports := method.GetImports()
+	if len(imports) != 1 || imports[0].Playbook != "setup-cargo" {
+		t.Errorf("GetImports() = %v, want setup-cargo", imports)
+	}
+	got := method.RenderInstallTask("rustfmt")
+	assertContains(t, got, []string{
+		"rustup component add rustfmt",
+		"rustfmt_installed",
+		".cargo/bin",
+	})
+}
+
+func TestCargoInstallMethod(t *testing.T) {
+	method := CargoInstallMethod{Name: "ripgrep"}
+	if got := method.GetMethodType(); got != "cargo" {
+		t.Errorf("GetMethodType() = %q, want cargo", got)
+	}
+	imports := method.GetImports()
+	wantImports := []Import{
+		{Playbook: "setup-cargo"},
+		{Playbook: "cargo-install-update"},
+	}
+	if !reflect.DeepEqual(imports, wantImports) {
+		t.Errorf("GetImports() = %v, want %v", imports, wantImports)
+	}
+
+	got := method.RenderInstallTask("rg")
+	assertContains(t, got, []string{
+		"rg_installed",
+		"cargo install ripgrep",
+		"cargo install-update ripgrep",
+		"rg_update_result",
+		"CARGO_BUILD_JOBS",
+	})
+}
+
+func TestNpmInstallMethod(t *testing.T) {
+	t.Run("without install args", func(t *testing.T) {
+		method := NpmInstallMethod{Name: "prettier"}
+		if got := method.GetMethodType(); got != "npm" {
+			t.Errorf("GetMethodType() = %q, want npm", got)
+		}
+		imports := method.GetImports()
+		if len(imports) != 1 || imports[0].Playbook != "setup-npm" {
+			t.Errorf("GetImports() = %v, want setup-npm", imports)
+		}
+		got := method.RenderInstallTask("prettier")
+		assertContains(t, got, []string{
+			"npm install -g prettier",
+			"prettier_installed",
+		})
+	})
+
+	t.Run("with install args", func(t *testing.T) {
+		method := NpmInstallMethod{Name: "some-pkg", InstallArgs: []string{"--legacy-peer-deps", "--force"}}
+		got := method.RenderInstallTask("some-pkg")
+		assertContains(t, got, []string{
+			"npm install -g some-pkg --legacy-peer-deps --force",
+		})
+	})
+}
+
+func TestNvmInstallMethod(t *testing.T) {
+	method := NvmInstallMethod{Name: "@biomejs/biome"}
+	if got := method.GetMethodType(); got != "nvm" {
+		t.Errorf("GetMethodType() = %q, want nvm", got)
+	}
+	imports := method.GetImports()
+	if len(imports) != 1 || imports[0].Playbook != "setup-nvm" {
+		t.Errorf("GetImports() = %v, want setup-nvm", imports)
+	}
+	got := method.RenderInstallTask("biome")
+	assertContains(t, got, []string{
+		"detected_nvm_dir",
+		"nvm use --delete-prefix default --silent",
+		"npm install -g @biomejs/biome",
+		"biome_installed",
+	})
+}
+
+func TestUvInstallMethod(t *testing.T) {
+	method := UvInstallMethod{Name: "ruff"}
+	if got := method.GetMethodType(); got != "uv" {
+		t.Errorf("GetMethodType() = %q, want uv", got)
+	}
+	imports := method.GetImports()
+	if len(imports) != 1 || imports[0].Playbook != "uv" {
+		t.Errorf("GetImports() = %v, want uv", imports)
+	}
+	got := method.RenderInstallTask("ruff")
+	assertContains(t, got, []string{
+		"uv tool install ruff",
+		"creates: ~/.local/bin/ruff",
+	})
+}
+
+func TestUbuntuPkgInstallMethod(t *testing.T) {
+	t.Run("without PPA", func(t *testing.T) {
+		method := UbuntuPkgInstallMethod{Name: "curl"}
+		if got := method.GetMethodType(); got != "ubuntu" {
+			t.Errorf("GetMethodType() = %q, want ubuntu", got)
+		}
+		if setup := method.RenderSetupTasks("curl"); setup != "" {
+			t.Errorf("RenderSetupTasks() = %q, want empty", setup)
+		}
+		got := method.RenderInstallTask("curl")
+		assertContains(t, got, []string{"name: curl", "package:"})
+	})
+
+	t.Run("with PPA", func(t *testing.T) {
+		method := UbuntuPkgInstallMethod{Name: "emacs", PPA: "ppa:ubuntuhandbook1/emacs"}
+		setup := method.RenderSetupTasks("emacs")
+		assertContains(t, setup, []string{
+			`repo: "ppa:ubuntuhandbook1/emacs"`,
+			"apt_repository:",
+			`ansible_facts['distribution'] == "Ubuntu"`,
+			"become: yes",
+		})
+	})
+}
+
+func TestDebianPkgInstallMethod(t *testing.T) {
+	method := DebianPkgInstallMethod{Name: "emacs"}
+	if got := method.GetMethodType(); got != "debian" {
+		t.Errorf("GetMethodType() = %q, want debian", got)
+	}
+	setup := method.RenderSetupTasks("emacs")
+	assertContains(t, setup, []string{
+		"deb822_repository:",
+		"backports",
+		`ansible_facts['distribution'] == "Debian"`,
+	})
+	got := method.RenderInstallTask("emacs")
+	assertContains(t, got, []string{"name: emacs", "package:"})
+}
+
+func TestShellInstallMethodSimple(t *testing.T) {
+	method := ShellInstallMethod{
+		InstallCommand: "curl -fsSL https://example.com/install.sh | bash",
+	}
+	if got := method.GetMethodType(); got != "shell" {
+		t.Errorf("GetMethodType() = %q, want shell", got)
+	}
+	if imports := method.GetImports(); imports != nil {
+		t.Errorf("GetImports() = %v, want nil", imports)
+	}
+
+	got := method.RenderInstallTask("my-tool")
+	assertContains(t, got, []string{
+		"my_tool_installed",
+		"command -v my-tool",
+		"curl -fsSL https://example.com/install.sh | bash",
+		"when: my_tool_installed.rc != 0",
+	})
+	// Simple path should not do version checks.
+	assertNotContains(t, got, []string{
+		"_installed_version",
+		"Get latest available",
+	})
+}
+
+func TestShellInstallMethodWithVersionCheck(t *testing.T) {
+	method := ShellInstallMethod{
+		InstallCommand:    "curl -fsSL https://example.com/install.sh | bash",
+		VersionCommand:    "my-tool --version",
+		VersionRegex:      `([0-9.]+)`,
+		LatestVersionURL:  "https://api.github.com/repos/owner/repo/releases/latest",
+		LatestVersionPath: "tag_name",
+	}
+
+	got := method.RenderInstallTask("my-tool")
+	assertContains(t, got, []string{
+		"my_tool_command_check",
+		"my-tool --version",
+		"my_tool_installed_version",
+		"my_tool_latest_version",
+		"github-release-info.yml",
+		"github_release_owner: owner",
+		"github_release_repo: repo",
+		"when: my_tool_installed_version != my_tool_latest_version",
+		`regex_search('([0-9.]+)'`,
+		"tag_name",
+	})
+}
+
+func TestShellInstallMethodBecomeAndEnvironment(t *testing.T) {
+	method := ShellInstallMethod{
+		InstallCommand: "installer.sh",
+		Become:         true,
+		Environment: map[string]string{
+			"FOO": "bar",
+			"BAZ": "qux",
+		},
+	}
+
+	if got := method.renderBecome(); got != "\n          become: yes" {
+		t.Errorf("renderBecome() = %q", got)
+	}
+	env := method.renderEnvironment()
+	// Keys must be sorted.
+	assertContains(t, env, []string{
+		"environment:",
+		"BAZ: qux",
+		"FOO: bar",
+	})
+	if strings.Index(env, "BAZ") > strings.Index(env, "FOO") {
+		t.Errorf("environment keys should be sorted alphabetically:\n%s", env)
+	}
+
+	got := method.RenderInstallTask("nix")
+	assertContains(t, got, []string{
+		"become: yes",
+		"environment:",
+		"FOO: bar",
+		"BAZ: qux",
+		"installer.sh",
+	})
+}
+
+func TestShellInstallMethodNoBecomeNoEnv(t *testing.T) {
+	method := ShellInstallMethod{InstallCommand: "echo hi"}
+	if got := method.renderBecome(); got != "" {
+		t.Errorf("renderBecome() = %q, want empty", got)
+	}
+	if got := method.renderEnvironment(); got != "" {
+		t.Errorf("renderEnvironment() = %q, want empty", got)
+	}
+}
+
+func TestRenderGitHubReleaseInfoTasks(t *testing.T) {
+	t.Run("cached github latest release", func(t *testing.T) {
+		got := renderGitHubReleaseInfoTasks(
+			"tool",
+			"https://api.github.com/repos/cli/cli/releases/latest",
+			"tool_latest_release",
+		)
+		assertContains(t, got, []string{
+			"include_tasks: tasks/github-release-info.yml",
+			"github_release_name: tool",
+			"github_release_owner: cli",
+			"github_release_repo: cli",
+			"github_release_register: tool_latest_release",
+		})
+		assertNotContains(t, got, []string{"uri:", "Rate limit exceeded"})
+	})
+
+	t.Run("non-cacheable url uses uri module", func(t *testing.T) {
+		got := renderGitHubReleaseInfoTasks(
+			"tool",
+			"https://example.com/version.json",
+			"tool_latest_release",
+		)
+		assertContains(t, got, []string{
+			"uri:",
+			"url: https://example.com/version.json",
+			"register: tool_latest_release",
+			"Rate limit exceeded",
+			"status_code: [200, 403]",
+		})
+		assertNotContains(t, got, []string{"github-release-info.yml"})
+	})
+}
+
+func TestGhExtensionInstallMethod(t *testing.T) {
+	method := GhExtensionInstallMethod{Repo: "jaeyeom/gh-repox"}
+	if got := method.GetMethodType(); got != "gh-extension" {
+		t.Errorf("GetMethodType() = %q, want gh-extension", got)
+	}
+	imports := method.GetImports()
+	if len(imports) != 1 || imports[0].Playbook != "gh" {
+		t.Errorf("GetImports() = %v, want gh", imports)
+	}
+	if got := method.extensionName(); got != "gh-repox" {
+		t.Errorf("extensionName() = %q, want gh-repox", got)
+	}
+
+	got := method.RenderInstallTask("gh-repox")
+	assertContains(t, got, []string{
+		"gh_repox_installed",
+		"gh extension list | grep -q 'gh-repox'",
+		"gh extension install jaeyeom/gh-repox",
+		"gh extension upgrade gh-repox",
+		"when: gh_repox_installed.rc != 0",
+		"when: gh_repox_installed.rc == 0",
+	})
+}
+
+func TestAptRepoInstallMethod(t *testing.T) {
+	method := AptRepoInstallMethod{
+		Name:           "gcloud-cli",
+		GPGKeyURL:      "https://packages.cloud.google.com/apt/doc/apt-key.gpg",
+		GPGKeyPath:     "/etc/apt/trusted.gpg.d/google.gpg",
+		RepoURL:        "https://packages.cloud.google.com/apt",
+		RepoComponents: "main",
+		Codename:       "cloud-sdk",
+		Arch:           "amd64",
+	}
+	if got := method.GetMethodType(); got != "apt-repo" {
+		t.Errorf("GetMethodType() = %q, want apt-repo", got)
+	}
+
+	setup := method.RenderSetupTasks("gcloud")
+	assertContains(t, setup, []string{
+		"gcloud_gpg_key",
+		"https://packages.cloud.google.com/apt/doc/apt-key.gpg",
+		"/etc/apt/trusted.gpg.d/google.gpg",
+		"uris: \"https://packages.cloud.google.com/apt\"",
+		"suites: \"cloud-sdk\"",
+		"architectures: amd64",
+		"- main",
+		"deb822_repository:",
+	})
+
+	// Default when uses WhenDebianLike.
+	assertContains(t, setup, []string{WhenDebianLike})
+
+	got := method.RenderInstallTask("gcloud")
+	assertContains(t, got, []string{
+		"ansible.builtin.apt:",
+		"name: gcloud-cli",
+		"update_cache: yes",
+	})
+
+	block := method.RenderBlockInstallTask("gcloud")
+	if strings.HasPrefix(strings.TrimSpace(block), "block:") {
+		t.Errorf("RenderBlockInstallTask should strip leading block:\n%s", block)
+	}
+}
+
+func TestAptRepoInstallMethodCustomWhenAndAutoCodename(t *testing.T) {
+	method := AptRepoInstallMethod{
+		Name:           "emacs",
+		GPGKeyURL:      "https://example.com/key.gpg",
+		GPGKeyPath:     "/etc/apt/trusted.gpg.d/emacs.gpg",
+		RepoURL:        "https://example.com/apt",
+		RepoComponents: "main contrib",
+		// Codename empty → auto-detect
+		When: WhenUbuntu,
+	}
+	setup := method.RenderSetupTasks("emacs")
+	assertContains(t, setup, []string{
+		WhenUbuntu,
+		"{{ ansible_facts['distribution_release'] }}",
+		"- main",
+		"- contrib",
+	})
+	// Custom When should replace the default debian-like condition.
+	// The Ubuntu when is more specific; ensure we don't only use WhenDebianLike alone as the only condition.
+	if !strings.Contains(setup, WhenUbuntu) {
+		t.Error("expected custom When condition")
+	}
+}
+
+func TestInstallMethodInterfaceCompliance(t *testing.T) {
+	// Compile-time style check that all concrete methods implement InstallMethod.
+	methods := []InstallMethod{
+		PackageInstallMethod{Name: "x"},
+		BrewInstallMethod{Name: "x"},
+		BrewCaskInstallMethod{Name: "x"},
+		TermuxPkgInstallMethod{Name: "x"},
+		PipInstallMethod{Name: "x"},
+		GoInstallMethod{PkgPath: "x"},
+		RustupComponentMethod{Name: "x"},
+		CargoInstallMethod{Name: "x"},
+		NpmInstallMethod{Name: "x"},
+		NvmInstallMethod{Name: "x"},
+		UvInstallMethod{Name: "x"},
+		UbuntuPkgInstallMethod{Name: "x"},
+		DebianPkgInstallMethod{Name: "x"},
+		ShellInstallMethod{InstallCommand: "x"},
+		GhExtensionInstallMethod{Repo: "a/b"},
+		AptRepoInstallMethod{Name: "x", GPGKeyURL: "u", GPGKeyPath: "p", RepoURL: "r", RepoComponents: "main"},
+	}
+	for _, m := range methods {
+		if m.GetMethodType() == "" {
+			t.Errorf("%T GetMethodType() returned empty", m)
+		}
+		// Rendering should not panic for minimal configs.
+		_ = m.RenderSetupTasks("cmd")
+		_ = m.RenderInstallTask("cmd")
+		_ = m.RenderBlockInstallTask("cmd")
+		_ = m.GetImports()
 	}
 }

--- a/devtools/setup-dev/ansible/types_test.go
+++ b/devtools/setup-dev/ansible/types_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPackageDataDefaults(t *testing.T) {
+	pkg := PackageData{command: "curl"}
+	if got := pkg.Command(); got != "curl" {
+		t.Errorf("Command() = %q, want curl", got)
+	}
+	if got := pkg.CheckCommand(); got != "command -v curl" {
+		t.Errorf("CheckCommand() = %q, want default command -v", got)
+	}
+	if got := pkg.DebianPkgName(); got != "curl" {
+		t.Errorf("DebianPkgName() = %q, want curl", got)
+	}
+	if got := pkg.TermuxPkgName(); got != "curl" {
+		t.Errorf("TermuxPkgName() = %q, want curl", got)
+	}
+	if got := pkg.BrewPkgName(); got != "curl" {
+		t.Errorf("BrewPkgName() = %q, want curl", got)
+	}
+	if got := pkg.BrewTap(); got != "" {
+		t.Errorf("BrewTap() = %q, want empty", got)
+	}
+	if got := pkg.BrewOptions(); got != nil {
+		t.Errorf("BrewOptions() = %v, want nil", got)
+	}
+	if got := pkg.CommandID(); got != "curl" {
+		t.Errorf("CommandID() = %q, want curl", got)
+	}
+}
+
+func TestPackageDataOverrides(t *testing.T) {
+	pkg := PackageData{
+		command:       "ag",
+		checkCommand:  "which ag",
+		debianPkgName: "silversearcher-ag",
+		termuxPkgName: "silversearcher-ag",
+		brewPkgName:   "the_silver_searcher",
+		brewTap:       "homebrew/core",
+		brewOptions:   []string{"with-pcre"},
+	}
+	if got := pkg.CheckCommand(); got != "which ag" {
+		t.Errorf("CheckCommand() = %q", got)
+	}
+	if got := pkg.DebianPkgName(); got != "silversearcher-ag" {
+		t.Errorf("DebianPkgName() = %q", got)
+	}
+	if got := pkg.TermuxPkgName(); got != "silversearcher-ag" {
+		t.Errorf("TermuxPkgName() = %q", got)
+	}
+	if got := pkg.BrewPkgName(); got != "the_silver_searcher" {
+		t.Errorf("BrewPkgName() = %q", got)
+	}
+	if got := pkg.BrewTap(); got != "homebrew/core" {
+		t.Errorf("BrewTap() = %q", got)
+	}
+	if !reflect.DeepEqual(pkg.BrewOptions(), []string{"with-pcre"}) {
+		t.Errorf("BrewOptions() = %v", pkg.BrewOptions())
+	}
+}
+
+func TestCommandIDHyphenAndLeadingDigit(t *testing.T) {
+	tests := []struct {
+		command string
+		want    string
+	}{
+		{command: "my-tool", want: "my_tool"},
+		{command: "7z", want: "cmd_7z"},
+		{command: "plain", want: "plain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			pkg := PackageData{command: tt.command}
+			if got := pkg.CommandID(); got != tt.want {
+				t.Errorf("PackageData.CommandID() = %q, want %q", got, tt.want)
+			}
+			tool := PlatformSpecificTool{command: tt.command}
+			if got := tool.CommandID(); got != tt.want {
+				t.Errorf("PlatformSpecificTool.CommandID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlatformSpecificToolHasPlatform(t *testing.T) {
+	tool := PlatformSpecificTool{
+		command: "prettier",
+		platforms: map[PlatformName]InstallMethod{
+			PlatformDarwin:     BrewInstallMethod{Name: "prettier"},
+			PlatformTermux:     NpmInstallMethod{Name: "prettier"},
+			PlatformDebianLike: NvmInstallMethod{Name: "prettier"},
+		},
+	}
+
+	if !tool.HasDarwin() || tool.DarwinMethod() == nil {
+		t.Error("expected Darwin method")
+	}
+	if !tool.HasTermux() || tool.TermuxMethod() == nil {
+		t.Error("expected Termux method")
+	}
+	if !tool.HasDebianLike() || tool.DebianLikeMethod() == nil {
+		t.Error("expected DebianLike method")
+	}
+	if tool.HasAll() || tool.AllMethod() != nil {
+		t.Error("did not expect All method")
+	}
+	if tool.HasDebian() || tool.DebianMethod() != nil {
+		t.Error("did not expect Debian method")
+	}
+	if tool.HasUbuntu() || tool.UbuntuMethod() != nil {
+		t.Error("did not expect Ubuntu method")
+	}
+	if tool.Command() != "prettier" {
+		t.Errorf("Command() = %q", tool.Command())
+	}
+}
+
+func TestCombineWhenConditions(t *testing.T) {
+	tests := []struct {
+		name  string
+		whens []string
+		want  string
+	}{
+		{
+			name:  "single condition unchanged",
+			whens: []string{WhenDarwin},
+			want:  WhenDarwin,
+		},
+		{
+			name:  "two conditions joined with or",
+			whens: []string{WhenTermux, WhenDebianLike},
+			want:  "(" + WhenTermux + ") or (" + WhenDebianLike + ")",
+		},
+		{
+			name:  "duplicates removed",
+			whens: []string{WhenDarwin, WhenDarwin, WhenTermux},
+			want:  "(" + WhenDarwin + ") or (" + WhenTermux + ")",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := combineWhenConditions(tt.whens); got != tt.want {
+				t.Errorf("combineWhenConditions() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoTool(t *testing.T) {
+	tool := GoTool("gopls", "golang.org/x/tools/gopls@latest", Import{Playbook: "go"})
+	if tool.Command() != "gopls" {
+		t.Errorf("Command() = %q", tool.Command())
+	}
+	if !tool.HasAll() {
+		t.Error("GoTool should use PlatformAll")
+	}
+	method, ok := tool.AllMethod().(GoInstallMethod)
+	if !ok {
+		t.Fatalf("AllMethod type = %T, want GoInstallMethod", tool.AllMethod())
+	}
+	if method.PkgPath != "golang.org/x/tools/gopls@latest" {
+		t.Errorf("PkgPath = %q", method.PkgPath)
+	}
+	if len(tool.Imports) != 1 || tool.Imports[0].Playbook != "go" {
+		t.Errorf("Imports = %v", tool.Imports)
+	}
+}
+
+func TestGhExtension(t *testing.T) {
+	tool := GhExtension("gh-dash", "dlvhdr/gh-dash")
+	if tool.Command() != "gh-dash" {
+		t.Errorf("Command() = %q", tool.Command())
+	}
+	if !tool.HasAll() {
+		t.Error("GhExtension should use PlatformAll")
+	}
+	method, ok := tool.AllMethod().(GhExtensionInstallMethod)
+	if !ok {
+		t.Fatalf("AllMethod type = %T, want GhExtensionInstallMethod", tool.AllMethod())
+	}
+	if method.Repo != "dlvhdr/gh-dash" {
+		t.Errorf("Repo = %q", method.Repo)
+	}
+}


### PR DESCRIPTION
## Summary

- Expand unit tests for the Ansible playbook generator in `devtools/setup-dev/ansible` from ~**26%** to ~**78%** statement coverage.
- Cover all `InstallMethod` implementations (render output, imports, setup tasks, block variants), not just `GoInstallMethod`.
- Add pure helper tests (`indent`, `stripBlockAndIndent`, GitHub release task rendering, become/environment).
- Add `types_test.go` for package/tool defaults, `CommandID`, platform helpers, and factory constructors.
- Add fixture-based `generate_packages_test.go` for playbook import/include parsing, dependency graphs, BUILD rule generation, GPG key setup, and Qubes TemplateVM script generation.

## Test plan

- [x] `go test -cover ./...` in `devtools/setup-dev/ansible` (~78% coverage)
- [x] `make check` (format, lint, bazel tests, semgrep, bazel Go file check)
- [x] Pre-commit hooks passed on commit