### PR TITLE
fix(ansible): drop repo-sync from vibe-coding completion message

### DIFF
--- a/devtools/setup-dev/ansible/setup-vibe-coding.yml
+++ b/devtools/setup-dev/ansible/setup-vibe-coding.yml
@@ -30,4 +30,4 @@
 
     - name: Vibe coding environment setup completed
       debug:
-        msg: "All vibe coding tools have been installed: gh-nudge tools, repo-sync, perplexity MCP, claudelytics, grok, herdr"
+        msg: "All vibe coding tools have been installed: gh-nudge tools, perplexity MCP, claudelytics, grok, herdr"


### PR DESCRIPTION
## Summary

The `setup-vibe-coding` completion message still listed `repo-sync` after that playbook was dropped from the profile in 0906194. Same stale-message drift as `gherun`.

This updates the debug message to match the playbooks that are actually imported. `repo-sync.yml` is unchanged and can still be installed with `ensure.sh repo-sync`.

## Test plan

- [x] `make check` (format, lint, `//...` tests, generators, semgrep)
- [ ] Confirm `setup-vibe-coding.yml` no longer mentions `repo-sync`
- [ ] Confirm `repo-sync.yml` still exists for direct install