### PR TITLE
fix(ansible): pin community.general so Galaxy cannot shadow apt

### DIFF
--- a/devtools/setup-dev/ansible/BUILD.bazel
+++ b/devtools/setup-dev/ansible/BUILD.bazel
@@ -41,6 +41,13 @@ org_lint_tests([
 sh_binary(
     name = "ensure",
     srcs = ["ensure.sh"],
+    data = ["community_general.sh"],
+)
+
+sh_test(
+    name = "community_general_test",
+    srcs = ["community_general_test.sh"],
+    data = ["community_general.sh"],
 )
 
 # GENERATED ANSIBLE TESTS - DO NOT EDIT BELOW THIS LINE

--- a/devtools/setup-dev/ansible/README.org
+++ b/devtools/setup-dev/ansible/README.org
@@ -33,8 +33,21 @@ resolves modules at parse time, so even Debian-only tasks fail on Ubuntu when
 the installed Ansible is too old.
 
 On Debian/Ubuntu, =ensure.sh= also installs =python3-debian= (the runtime
-library =deb822_repository= imports). After an Ansible upgrade it force-refreshes
-the =community.general= collection so collection metadata matches the new core.
+library =deb822_repository= imports).
+
+=ensure.sh= installs =community.general= so a Galaxy copy cannot shadow a
+compatible bundled collection:
+
+- On Debian/Ubuntu it prefers the collection shipped with the *active*
+  ansible (the python module tree, not a leftover apt path). If that
+  bundled collection is missing, it installs a Galaxy version pinned to
+  the installed ansible-core (2.15–2.18).
+- After a pip =--user= ansible-core upgrade it ignores leftover apt
+  collections and force-installs a pin for the new core.
+- On macOS and Termux it installs the latest collection from Galaxy
+  (=--force= after an upgrade).
+- A failed =ansible-galaxy= install aborts the run and does not refresh
+  the daily cache.
 
 * Design
 The purpose of this Ansible Setup Dev is to set up my development environment

--- a/devtools/setup-dev/ansible/community_general.sh
+++ b/devtools/setup-dev/ansible/community_general.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# community.general collection install policy helpers. Sourced by ensure.sh.
+#
+# Policy:
+# - macOS / Termux: latest from Galaxy; --force after an ansible-core upgrade.
+# - Debian/Ubuntu (apt): use the collection shipped with the *active* ansible
+#   unless ansible-core was just upgraded via pip. If there is no bundled
+#   collection, or after an upgrade, install a Galaxy version pinned to core.
+# - Other Linux: latest from Galaxy; --force after an upgrade.
+
+# Galaxy spec compatible with a given ansible-core version (e.g. 2.16.3).
+community_general_spec_for_core() {
+    case "$1" in
+        2.15.*) echo 'community.general:>=10.0.0,<11.0.0' ;;
+        2.16.*) echo 'community.general:>=11.0.0,<12.0.0' ;;
+        2.17.*) echo 'community.general:>=12.0.0,<13.0.0' ;;
+        2.18.*) echo 'community.general:>=13.0.0,<14.0.0' ;;
+        *) echo 'community.general' ;;
+    esac
+}
+
+# True if the collection lives next to the active ansible python module.
+# $1 = "ansible python module location" from `ansible --version`.
+community_general_has_bundled() {
+    [ -n "$1" ] && [ -d "$1/../ansible_collections/community/general" ]
+}
+
+# Decide how to obtain community.general.
+# $1 OS (uname -s), $2 termux (0/1), $3 upgraded (0/1),
+# $4 has_apt (0/1), $5 has_bundled (0/1), $6 ansible-core version.
+# Prints: use_bundled | install SPEC | install SPEC --force
+community_general_plan() {
+    _cgp_os="$1"
+    _cgp_termux="$2"
+    _cgp_upgraded="$3"
+    _cgp_has_apt="$4"
+    _cgp_has_bundled="$5"
+    _cgp_core="$6"
+    _cgp_force=""
+    if [ "$_cgp_upgraded" = 1 ]; then
+        _cgp_force=" --force"
+    fi
+
+    if [ "$_cgp_termux" = 1 ] || [ "$_cgp_os" = "Darwin" ]; then
+        echo "install community.general$_cgp_force"
+        return
+    fi
+
+    if [ "$_cgp_has_apt" = 1 ]; then
+        if [ "$_cgp_upgraded" = 1 ]; then
+            echo "install $(community_general_spec_for_core "$_cgp_core") --force"
+            return
+        fi
+        if [ "$_cgp_has_bundled" = 1 ]; then
+            echo "use_bundled"
+            return
+        fi
+        echo "install $(community_general_spec_for_core "$_cgp_core") --force"
+        return
+    fi
+
+    echo "install community.general$_cgp_force"
+}
+
+# True when a user Galaxy copy would shadow the bundled collection on
+# Debian/Ubuntu. After a pip upgrade, return false so the caller installs
+# instead of deleting Galaxy.
+# $1 has_apt, $2 termux, $3 OS, $4 has_bundled, $5 has_user_galaxy, $6 upgraded.
+community_general_needs_repair() {
+    [ "$6" = 1 ] && return 1
+    [ "$1" = 1 ] || return 1
+    [ "$2" = 1 ] && return 1
+    [ "$3" = "Darwin" ] && return 1
+    [ "$4" = 1 ] || return 1
+    [ "$5" = 1 ]
+}

--- a/devtools/setup-dev/ansible/community_general_test.sh
+++ b/devtools/setup-dev/ansible/community_general_test.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# Tests for community.general collection install policy helpers.
+set -eu
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_eq() {
+    _label="$1"
+    _got="$2"
+    _want="$3"
+    if [ "$_got" != "$_want" ]; then
+        fail "$_label: got '$_got', want '$_want'"
+    fi
+}
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+sh -n "$SCRIPT_DIR/community_general.sh"
+sh -n "$SCRIPT_DIR/community_general_test.sh"
+# shellcheck disable=SC1091  # Sourced from the same directory as this script
+. "$SCRIPT_DIR/community_general.sh"
+
+# --- community_general_spec_for_core ---
+
+assert_eq "2.15 pin" \
+    "$(community_general_spec_for_core "2.15.3")" \
+    "community.general:>=10.0.0,<11.0.0"
+assert_eq "2.16 pin" \
+    "$(community_general_spec_for_core "2.16.14")" \
+    "community.general:>=11.0.0,<12.0.0"
+assert_eq "2.17 pin" \
+    "$(community_general_spec_for_core "2.17.0")" \
+    "community.general:>=12.0.0,<13.0.0"
+assert_eq "2.18 pin" \
+    "$(community_general_spec_for_core "2.18.9")" \
+    "community.general:>=13.0.0,<14.0.0"
+assert_eq "2.19 unpinned" \
+    "$(community_general_spec_for_core "2.19.1")" \
+    "community.general"
+assert_eq "empty core unpinned" \
+    "$(community_general_spec_for_core "")" \
+    "community.general"
+
+# --- community_general_has_bundled ---
+# Only the collection next to the *active* ansible python tree counts.
+
+if community_general_has_bundled ""; then
+    fail "empty python module location must not count as bundled"
+fi
+
+_tmp=$(mktemp -d)
+trap 'rm -rf "$_tmp"' EXIT
+
+_active="$_tmp/pip/ansible"
+_leftover="$_tmp/dist-packages/ansible_collections/community/general"
+mkdir -p "$_active" "$_leftover"
+if community_general_has_bundled "$_active"; then
+    fail "leftover apt collection must not count when active tree has none"
+fi
+
+mkdir -p "$_tmp/pip/ansible_collections/community/general"
+if ! community_general_has_bundled "$_active"; then
+    fail "collection next to active ansible python module must count"
+fi
+
+# --- community_general_plan ---
+# Args: OS TERMUX UPGRADED HAS_APT HAS_BUNDLED CORE
+# TERMUX/UPGRADED/HAS_APT/HAS_BUNDLED are 0 or 1.
+
+assert_eq "darwin latest" \
+    "$(community_general_plan Darwin 0 0 0 0 "2.16.3")" \
+    "install community.general"
+assert_eq "darwin after upgrade forces latest" \
+    "$(community_general_plan Darwin 0 1 0 0 "2.16.3")" \
+    "install community.general --force"
+assert_eq "termux latest even if apt present" \
+    "$(community_general_plan Linux 1 0 1 1 "2.16.3")" \
+    "install community.general"
+assert_eq "termux after upgrade forces latest" \
+    "$(community_general_plan Linux 1 1 0 0 "2.18.0")" \
+    "install community.general --force"
+
+assert_eq "apt with bundled collection uses it" \
+    "$(community_general_plan Linux 0 0 1 1 "2.16.3")" \
+    "use_bundled"
+assert_eq "apt without bundled pins for 2.16" \
+    "$(community_general_plan Linux 0 0 1 0 "2.16.3")" \
+    "install community.general:>=11.0.0,<12.0.0 --force"
+assert_eq "apt without bundled pins for 2.15" \
+    "$(community_general_plan Linux 0 0 1 0 "2.15.0")" \
+    "install community.general:>=10.0.0,<11.0.0 --force"
+assert_eq "apt upgrade ignores leftover bundled and pins with force" \
+    "$(community_general_plan Linux 0 1 1 1 "2.18.1")" \
+    "install community.general:>=13.0.0,<14.0.0 --force"
+assert_eq "apt upgrade without bundled still pins with force" \
+    "$(community_general_plan Linux 0 1 1 0 "2.17.5")" \
+    "install community.general:>=12.0.0,<13.0.0 --force"
+
+assert_eq "other linux latest" \
+    "$(community_general_plan Linux 0 0 0 0 "2.16.3")" \
+    "install community.general"
+assert_eq "other linux after upgrade forces latest" \
+    "$(community_general_plan Linux 0 1 0 0 "2.16.3")" \
+    "install community.general --force"
+
+# --- community_general_needs_repair ---
+# Args: HAS_APT TERMUX OS HAS_BUNDLED HAS_USER_GALAXY UPGRADED
+
+if ! community_general_needs_repair 1 0 Linux 1 1 0; then
+    fail "debian with bundled + user galaxy should need repair"
+fi
+if community_general_needs_repair 1 0 Linux 1 1 1; then
+    fail "after pip upgrade, do not repair (install instead)"
+fi
+if community_general_needs_repair 1 0 Linux 1 0 0; then
+    fail "no user galaxy: nothing to repair"
+fi
+if community_general_needs_repair 1 0 Linux 0 1 0; then
+    fail "no bundled collection: do not delete user galaxy"
+fi
+if community_general_needs_repair 0 0 Linux 1 1 0; then
+    fail "no apt: not a debian repair case"
+fi
+if community_general_needs_repair 1 1 Linux 1 1 0; then
+    fail "termux: not a debian repair case"
+fi
+if community_general_needs_repair 1 0 Darwin 1 1 0; then
+    fail "darwin: not a debian repair case"
+fi
+
+echo "All community_general policy tests passed."

--- a/devtools/setup-dev/ansible/ensure.sh
+++ b/devtools/setup-dev/ansible/ensure.sh
@@ -699,14 +699,72 @@ if command -v rustup >/dev/null 2>&1; then
     fi
 fi
 
-# Install community.general collection if not already installed.
-# Force-reinstall after an ansible-core upgrade so collection metadata matches.
-if [ "$ANSIBLE_WAS_UPGRADED" = true ] || [ ! -f "$ANSIBLE_GALAXY_CACHE" ] || [ "$(find "$ANSIBLE_GALAXY_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
-    if [ "$ANSIBLE_WAS_UPGRADED" = true ]; then
-        ansible-galaxy collection install community.general --force
-    else
-        ansible-galaxy collection install community.general
-    fi
+# community.general collection install policy (see community_general.sh).
+# - macOS / Termux: latest from Galaxy; --force after an ansible-core upgrade.
+# - Debian/Ubuntu: prefer the collection shipped with the *active* ansible so
+#   Galaxy cannot shadow apt ansible-core. After a pip upgrade, or if no
+#   bundled collection exists, install a Galaxy version pinned to this core.
+# - Other Linux: latest from Galaxy; --force after an upgrade.
+# Re-check at most once per day, but always repair a shadowing user install
+# and always refresh after an ansible-core upgrade.
+# shellcheck disable=SC1091  # Sourced from the same directory as this script
+. "$(dirname "$0")/community_general.sh"
+
+USER_COMMUNITY_GENERAL="${HOME}/.ansible/collections/ansible_collections/community/general"
+USER_LIBRARY_FILTERING="${HOME}/.ansible/collections/ansible_collections/community/library_inventory_filtering_v1"
+
+_cg_py_mod_loc=$(ansible --version 2>/dev/null | sed -n 's/^ *ansible python module location = //p' | head -n 1)
+_cg_core=$(ansible --version 2>/dev/null | sed -n 's/^ansible \[core \([0-9.]*\)\].*/\1/p' | head -n 1)
+_cg_has_bundled=0
+if community_general_has_bundled "$_cg_py_mod_loc"; then
+    _cg_has_bundled=1
+fi
+_cg_has_apt=0
+if command -v apt >/dev/null 2>&1; then
+    _cg_has_apt=1
+fi
+_cg_termux=0
+if [ -n "$TERMUX_VERSION" ]; then
+    _cg_termux=1
+fi
+_cg_upgraded=0
+if [ "$ANSIBLE_WAS_UPGRADED" = true ]; then
+    _cg_upgraded=1
+fi
+_cg_has_user_galaxy=0
+if [ -d "$USER_COMMUNITY_GENERAL" ]; then
+    _cg_has_user_galaxy=1
+fi
+
+if community_general_needs_repair "$_cg_has_apt" "$_cg_termux" "$OS" \
+    "$_cg_has_bundled" "$_cg_has_user_galaxy" "$_cg_upgraded" ||
+    [ "$ANSIBLE_WAS_UPGRADED" = true ] ||
+    [ ! -f "$ANSIBLE_GALAXY_CACHE" ] ||
+    [ "$(find "$ANSIBLE_GALAXY_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+    _cg_plan=$(community_general_plan "$OS" "$_cg_termux" "$_cg_upgraded" \
+        "$_cg_has_apt" "$_cg_has_bundled" "$_cg_core")
+    case "$_cg_plan" in
+        use_bundled)
+            echo "Using bundled community.general (compatible with this ansible-core)."
+            if [ -d "$USER_COMMUNITY_GENERAL" ] || [ -d "$USER_LIBRARY_FILTERING" ]; then
+                echo "Removing user Galaxy community.general (avoids shadowing bundled collection)..."
+                rm -rf "$USER_COMMUNITY_GENERAL" "$USER_LIBRARY_FILTERING"
+            fi
+            ;;
+        install\ *)
+            _cg_install_args=${_cg_plan#install }
+            echo "Installing $_cg_install_args..."
+            # shellcheck disable=SC2086  # Intentional word splitting — spec and --force
+            if ! ansible-galaxy collection install $_cg_install_args; then
+                echo "Error: failed to install community.general collection." >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Error: unknown community.general plan: $_cg_plan" >&2
+            exit 1
+            ;;
+    esac
     touch "$ANSIBLE_GALAXY_CACHE"
 fi
 

--- a/devtools/setup-dev/ansible/macos.org
+++ b/devtools/setup-dev/ansible/macos.org
@@ -14,11 +14,20 @@ Ansible does support MacOS Homebrew through the =community.general.homebrew= mod
 - Upgrade all packages
 - Install packages with specific options
 
-The module is part of the community.general collection and can be installed with:
+The module is part of the community.general collection. On macOS (and Termux),
+=ensure.sh= installs the latest collection from Galaxy (rolling ansible),
+using =--force= after an ansible-core upgrade:
 
 #+begin_src sh
 ansible-galaxy collection install community.general
 #+end_src
+
+On Debian/Ubuntu, =ensure.sh= prefers the =community.general= shipped with the
+*active* ansible python tree (not a leftover apt path). That avoids an
+unpinned Galaxy install shadowing apt =ansible-core=. If no bundled
+collection is present, or after a pip =--user= core upgrade, it pins Galaxy
+to a range compatible with the installed =ansible-core= (2.15–2.18). A
+failed Galaxy install aborts and does not refresh the daily cache.
 
 * Implementation Plan
 


### PR DESCRIPTION
## Summary
- Stop the daily unpinned `ansible-galaxy collection install community.general` on Debian/Ubuntu so a newer Galaxy collection cannot shadow apt ansible-core.
- Prefer the collection shipped with the *active* ansible python tree. After a pip `--user` core upgrade, ignore leftover apt collections and force-install a pin for the new core.
- Pin Galaxy to ansible-core 2.15–2.18; install latest on macOS/Termux (`--force` after an upgrade). Failed Galaxy installs abort and do not refresh the daily cache.

## Why
Latest `community.general` (13.x) requires ansible-core ≥ 2.18. An unpinned Galaxy install on Ubuntu/Debian with 2.15–2.17 breaks playbooks. After #208 upgrades core via pip, a leftover apt collection is not the active one and must not be treated as bundled.

## Test plan
- [x] `make check`
- [x] `community_general_test.sh` (pins, bundled-path detection, plan/repair cases)
- [x] `shellcheck -x` / `sh -n` on `ensure.sh` and the new helpers
- [ ] On Ubuntu with apt ansible-core 2.16 and a user Galaxy 13.x, run `./ensure.sh` and confirm the shadowing copy is removed
- [ ] After a pip `--user` core upgrade, confirm a pinned Galaxy install is forced