### PR TITLE
feat(prsync): scaffold cobra CLI, KEY=VALUE config, and version

### DIFF
--- a/devtools/prsync/BUILD.bazel
+++ b/devtools/prsync/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/org-lint:defs.bzl", "org_lint_tests")
+
+org_lint_tests(["README.org"])

--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -1,0 +1,6 @@
+#+TITLE: prsync
+
+* Overview
+
+prsync surveys open GitHub pull requests and matches them to running herdr
+agent tabs.

--- a/devtools/prsync/cmd/prsync/BUILD.bazel
+++ b/devtools/prsync/cmd/prsync/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/cmd/prsync",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//devtools/prsync/internal/cli:go_default_library",
+        "@com_github_jaeyeom_go_cmdexec//:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "prsync",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+)

--- a/devtools/prsync/cmd/prsync/main.go
+++ b/devtools/prsync/cmd/prsync/main.go
@@ -1,0 +1,23 @@
+// Command prsync surveys open GitHub PRs and matches them to herdr agent tabs.
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/signal"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/cli"
+	executor "github.com/jaeyeom/go-cmdexec"
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), unix.SIGINT, unix.SIGTERM)
+	defer stop()
+	return cli.Execute(ctx, args, stdout, stderr, executor.NewBasicExecutor())
+}

--- a/devtools/prsync/cmd/prsync/main_test.go
+++ b/devtools/prsync/cmd/prsync/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRunVersionExitOK(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if got["version"] == "" {
+		t.Fatalf("missing version in %s", stdout.String())
+	}
+}
+
+func TestRunUnknownCommandExitUsage(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"not-a-command"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "exit.go",
+        "root.go",
+        "version.go",
+    ],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/cli",
+    visibility = ["//devtools/prsync:__subpackages__"],
+    deps = [
+        "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/version:go_default_library",
+        "@com_github_jaeyeom_go_cmdexec//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cli_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/version:go_default_library",
+    ],
+)

--- a/devtools/prsync/internal/cli/cli_test.go
+++ b/devtools/prsync/internal/cli/cli_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/version"
+)
+
+func TestVersionJSON(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"version"}, &stdout, &stderr, nil)
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if got["version"] != version.Version {
+		t.Fatalf("version = %q, want %q", got["version"], version.Version)
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"not-a-command"}, &stdout, &stderr, nil)
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestReportKeyError(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	err := &config.KeyError{Key: "title_id_pattern", Reason: "error parsing regexp: missing closing ]: `[A-Z+`"}
+	code := report(&stderr, err)
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	want := "prsync: config error: key title_id_pattern: error parsing regexp: missing closing ]: `[A-Z+`\n"
+	if got := stderr.String(); got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestReportExitError(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	code := report(&stderr, &ExitError{Code: ExitPrecondition, Err: errors.New("gh missing")})
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d", code, ExitPrecondition)
+	}
+	if !strings.Contains(stderr.String(), "gh missing") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestReportNil(t *testing.T) {
+	t.Parallel()
+	if code := report(&bytes.Buffer{}, nil); code != ExitOK {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+}

--- a/devtools/prsync/internal/cli/exit.go
+++ b/devtools/prsync/internal/cli/exit.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+)
+
+const (
+	// ExitOK is a successful run.
+	ExitOK = 0
+	// ExitUnsafe is gate only: busy set non-empty.
+	ExitUnsafe = 1
+	// ExitUsage is usage, config, or flag errors.
+	ExitUsage = 2
+	// ExitPrecondition is a missing tool or auth failure.
+	ExitPrecondition = 3
+	// ExitGateTimeout is a live dispatch that timed out on the gate.
+	ExitGateTimeout = 4
+)
+
+// ExitError carries a process exit code.
+type ExitError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("exit %d", e.Code)
+}
+
+func (e *ExitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func report(stderr io.Writer, err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	var keyErr *config.KeyError
+	if errors.As(err, &keyErr) {
+		fmt.Fprintf(stderr, "prsync: config error: %s\n", keyErr)
+		return ExitUsage
+	}
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.Err != nil {
+			fmt.Fprintf(stderr, "prsync: %v\n", exitErr.Err)
+		}
+		return exitErr.Code
+	}
+	fmt.Fprintf(stderr, "prsync: %v\n", err)
+	return ExitUsage
+}

--- a/devtools/prsync/internal/cli/root.go
+++ b/devtools/prsync/internal/cli/root.go
@@ -1,0 +1,33 @@
+// Package cli implements the prsync cobra command tree.
+package cli
+
+import (
+	"context"
+	"io"
+
+	executor "github.com/jaeyeom/go-cmdexec"
+	"github.com/spf13/cobra"
+)
+
+// Execute runs the prsync CLI with injected IO and returns an exit code.
+func Execute(ctx context.Context, args []string, stdout, stderr io.Writer, exec executor.Executor) int {
+	_ = exec
+	root := newRoot(stdout)
+	root.SetArgs(args)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	return report(stderr, root.ExecuteContext(ctx))
+}
+
+func newRoot(stdout io.Writer) *cobra.Command {
+	root := &cobra.Command{
+		Use:           "prsync",
+		Short:         "Survey open GitHub PRs and match them to herdr agent tabs",
+		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			cmd.SilenceUsage = true
+		},
+	}
+	root.AddCommand(newVersionCmd(stdout))
+	return root
+}

--- a/devtools/prsync/internal/cli/version.go
+++ b/devtools/prsync/internal/cli/version.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd(stdout io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the prsync version as JSON",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			out, err := json.Marshal(map[string]string{"version": version.Version})
+			if err != nil {
+				return fmt.Errorf("encode version: %w", err)
+			}
+			_, err = fmt.Fprintf(stdout, "%s\n", out)
+			if err != nil {
+				return fmt.Errorf("write version: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/devtools/prsync/internal/config/BUILD.bazel
+++ b/devtools/prsync/internal/config/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "parse.go",
+    ],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/config",
+    visibility = ["//devtools/prsync:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    embed = [":go_default_library"],
+)

--- a/devtools/prsync/internal/config/config.go
+++ b/devtools/prsync/internal/config/config.go
@@ -1,0 +1,369 @@
+// Package config loads the shell-sourceable prsync KEY=VALUE file.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultPromptTemplate = `Address the unresolved review comments on PR #{number} ({url}).
+
+Unaddressed threads:
+{comments}
+
+For each thread: understand the reviewer's ask, make the change (or reply if you
+disagree, with reasoning), resolve the thread, and push. Do not touch other PRs.`
+
+var repoPattern = regexp.MustCompile(`^[^/\s]+/[^/\s]+$`)
+
+// Config is the resolved prsync configuration.
+type Config struct {
+	Repos             []string
+	Author            string
+	TitleIDPattern    *regexp.Regexp
+	TabLabelTemplate  string
+	HerdrBin          string
+	GHBin             string
+	ConcurrencyWaitOn string
+	GatePoll          time.Duration
+	GateTimeout       time.Duration
+	PromptTemplate    string
+	IncludeDrafts     bool
+	WaitUntil         []string
+	DispatchTimeout   time.Duration
+	StateFile         string
+	DryRun            bool
+
+	// SourcePath is empty if defaults only; for stderr diagnostics.
+	SourcePath string
+}
+
+// KeyError is a config parse or validation failure mapped to exit 2.
+type KeyError struct {
+	Key    string
+	Line   int
+	Reason string
+}
+
+func (e *KeyError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Key != "" {
+		return fmt.Sprintf("key %s: %s", e.Key, e.Reason)
+	}
+	if e.Line > 0 {
+		return fmt.Sprintf("line %d: %s", e.Line, e.Reason)
+	}
+	return e.Reason
+}
+
+// Defaults returns the built-in configuration.
+func Defaults() Config {
+	return Config{
+		TitleIDPattern:    regexp.MustCompile(`[A-Z]+-[0-9]+`),
+		TabLabelTemplate:  "{id}",
+		HerdrBin:          "herdr",
+		GHBin:             "gh",
+		ConcurrencyWaitOn: "any",
+		GatePoll:          2000 * time.Millisecond,
+		GateTimeout:       1800000 * time.Millisecond,
+		PromptTemplate:    defaultPromptTemplate,
+		WaitUntil:         []string{"idle", "done"},
+		DispatchTimeout:   1800000 * time.Millisecond,
+		StateFile:         "~/.config/prsync/state.json",
+		DryRun:            true,
+	}
+}
+
+// Load applies search order, then Validate.
+// explicitPath is the --config value (empty if unset).
+func Load(explicitPath string) (Config, error) {
+	cfg := Defaults()
+	path, err := resolvePath(explicitPath)
+	if err != nil {
+		return Config{}, err
+	}
+	if path != "" {
+		cfg.SourcePath = path
+		kv, err := parseFile(path)
+		if err != nil {
+			return Config{}, err
+		}
+		if err := apply(&cfg, kv); err != nil {
+			return Config{}, err
+		}
+	}
+	cfg.StateFile = expandTilde(cfg.StateFile)
+	cfg.GHBin = expandTilde(cfg.GHBin)
+	cfg.HerdrBin = expandTilde(cfg.HerdrBin)
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Validate compiles regexes and checks enums. Returns *KeyError.
+func (c Config) Validate() error {
+	if c.TitleIDPattern == nil {
+		return &KeyError{Key: "title_id_pattern", Reason: "missing pattern"}
+	}
+	if c.TabLabelTemplate == "" {
+		return &KeyError{Key: "tab_label_template", Reason: "must be non-empty"}
+	}
+	if c.HerdrBin == "" {
+		return &KeyError{Key: "herdr_bin", Reason: "must be non-empty"}
+	}
+	if c.GHBin == "" {
+		return &KeyError{Key: "gh_bin", Reason: "must be non-empty"}
+	}
+	if c.ConcurrencyWaitOn != "any" && c.ConcurrencyWaitOn != "managed" {
+		return &KeyError{Key: "concurrency_wait_on", Reason: fmt.Sprintf("invalid value %q", c.ConcurrencyWaitOn)}
+	}
+	if c.GatePoll < time.Millisecond {
+		return &KeyError{Key: "gate_poll_ms", Reason: "must be >= 1"}
+	}
+	if c.GateTimeout < time.Millisecond {
+		return &KeyError{Key: "gate_timeout_ms", Reason: "must be >= 1"}
+	}
+	if c.DispatchTimeout < time.Millisecond {
+		return &KeyError{Key: "dispatch_timeout_ms", Reason: "must be >= 1"}
+	}
+	if len(c.WaitUntil) == 0 {
+		return &KeyError{Key: "dispatch_wait_until", Reason: "at least one token required"}
+	}
+	if c.StateFile == "" {
+		return &KeyError{Key: "state_file", Reason: "must be non-empty"}
+	}
+	for _, repo := range c.Repos {
+		if !repoPattern.MatchString(repo) {
+			return &KeyError{Key: "repos", Reason: fmt.Sprintf("invalid repo %q", repo)}
+		}
+	}
+	return nil
+}
+
+func parseFile(path string) (map[string]string, error) {
+	f, err := os.Open(path) //nolint:gosec // path is an operator-supplied config file
+	if err != nil {
+		return nil, &KeyError{Reason: fmt.Sprintf("open %s: %v", path, err)}
+	}
+	defer f.Close() //nolint:errcheck
+	return Parse(f)
+}
+
+func resolvePath(explicit string) (string, error) {
+	if explicit != "" {
+		info, err := os.Stat(explicit)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return "", &KeyError{Reason: fmt.Sprintf("config file not found: %s", explicit)}
+			}
+			return "", &KeyError{Reason: fmt.Sprintf("stat %s: %v", explicit, err)}
+		}
+		if info.IsDir() {
+			return "", &KeyError{Reason: fmt.Sprintf("config file not found: %s", explicit)}
+		}
+		return explicit, nil
+	}
+	if path := filepath.Join(configCWD(), "prsync.config"); fileExists(path) {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	if path := filepath.Join(home, ".config", "prsync", "prsync.config"); fileExists(path) {
+		return path, nil
+	}
+	return "", nil
+}
+
+func configCWD() string {
+	if wd := os.Getenv("BUILD_WORKING_DIRECTORY"); wd != "" {
+		return wd
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return wd
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func apply(cfg *Config, kv map[string]string) error {
+	for key, val := range kv {
+		if err := applyKey(cfg, key, val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyKey(cfg *Config, key, val string) error {
+	switch key {
+	case "repos":
+		return applyRepos(cfg, val)
+	case "author":
+		cfg.Author = val
+	case "title_id_pattern":
+		return applyTitleIDPattern(cfg, val)
+	case "tab_label_template":
+		cfg.TabLabelTemplate = val
+	case "herdr_bin":
+		cfg.HerdrBin = val
+	case "gh_bin":
+		cfg.GHBin = val
+	case "concurrency_wait_on":
+		cfg.ConcurrencyWaitOn = val
+	case "gate_poll_ms", "gate_timeout_ms", "dispatch_timeout_ms":
+		return applyMillis(cfg, key, val)
+	case "dispatch_prompt_template":
+		return applyPrompt(cfg, val)
+	case "dispatch_include_drafts":
+		return applyIncludeDrafts(cfg, val)
+	case "dispatch_wait_until":
+		return applyWaitUntil(cfg, val)
+	case "state_file":
+		cfg.StateFile = val
+	case "dry_run":
+		return applyDryRun(cfg, val)
+	}
+	return nil
+}
+
+func applyRepos(cfg *Config, val string) error {
+	fields := strings.Fields(val)
+	for _, repo := range fields {
+		if !repoPattern.MatchString(repo) {
+			return &KeyError{Key: "repos", Reason: fmt.Sprintf("invalid repo %q", repo)}
+		}
+	}
+	cfg.Repos = fields
+	return nil
+}
+
+func applyTitleIDPattern(cfg *Config, val string) error {
+	re, err := regexp.Compile(val)
+	if err != nil {
+		return &KeyError{Key: "title_id_pattern", Reason: err.Error()}
+	}
+	cfg.TitleIDPattern = re
+	return nil
+}
+
+func applyMillis(cfg *Config, key, val string) error {
+	d, err := parseMillis(key, val)
+	if err != nil {
+		return err
+	}
+	switch key {
+	case "gate_poll_ms":
+		cfg.GatePoll = d
+	case "gate_timeout_ms":
+		cfg.GateTimeout = d
+	case "dispatch_timeout_ms":
+		cfg.DispatchTimeout = d
+	}
+	return nil
+}
+
+func applyPrompt(cfg *Config, val string) error {
+	text, err := resolvePrompt(val)
+	if err != nil {
+		return err
+	}
+	cfg.PromptTemplate = text
+	return nil
+}
+
+func applyIncludeDrafts(cfg *Config, val string) error {
+	b, err := parseBool("dispatch_include_drafts", val)
+	if err != nil {
+		return err
+	}
+	cfg.IncludeDrafts = b
+	return nil
+}
+
+func applyWaitUntil(cfg *Config, val string) error {
+	fields := strings.Fields(val)
+	if len(fields) == 0 {
+		return &KeyError{Key: "dispatch_wait_until", Reason: "at least one token required"}
+	}
+	cfg.WaitUntil = fields
+	return nil
+}
+
+func applyDryRun(cfg *Config, val string) error {
+	b, err := parseBool("dry_run", val)
+	if err != nil {
+		return err
+	}
+	cfg.DryRun = b
+	return nil
+}
+
+func resolvePrompt(val string) (string, error) {
+	if !strings.HasPrefix(val, "@") {
+		return val, nil
+	}
+	path := expandTilde(val[1:])
+	data, err := os.ReadFile(path) //nolint:gosec // path is an operator-supplied prompt file
+	if err != nil {
+		return "", &KeyError{Key: "dispatch_prompt_template", Reason: fmt.Sprintf("read %s: %v", path, err)}
+	}
+	return string(data), nil
+}
+
+func parseMillis(key, val string) (time.Duration, error) {
+	n, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return 0, &KeyError{Key: key, Reason: "not an integer"}
+	}
+	if n < 1 {
+		return 0, &KeyError{Key: key, Reason: "must be >= 1"}
+	}
+	if n > math.MaxInt64/int64(time.Millisecond) {
+		return 0, &KeyError{Key: key, Reason: "overflow"}
+	}
+	return time.Duration(n) * time.Millisecond, nil
+}
+
+func parseBool(key, val string) (bool, error) {
+	switch val {
+	case "true", "1":
+		return true, nil
+	case "false", "0":
+		return false, nil
+	default:
+		return false, &KeyError{Key: key, Reason: fmt.Sprintf("invalid bool %q", val)}
+	}
+}
+
+func expandTilde(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return path
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/devtools/prsync/internal/config/config_test.go
+++ b/devtools/prsync/internal/config/config_test.go
@@ -1,0 +1,494 @@
+package config
+
+import (
+	"errors"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+		errLine int
+		errKey  string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  map[string]string{},
+		},
+		{
+			name:  "blank lines and comments",
+			input: "# header\n\n  \n  # indented comment\nfoo=bar\n",
+			want:  map[string]string{"foo": "bar"},
+		},
+		{
+			name:  "trim key and value",
+			input: "  foo  =  bar  \n",
+			want:  map[string]string{"foo": "bar"},
+		},
+		{
+			name:  "value may contain hash",
+			input: "prompt=hello # still value\n",
+			want:  map[string]string{"prompt": "hello # still value"},
+		},
+		{
+			name:  "double quotes stripped",
+			input: `foo="bar baz"` + "\n",
+			want:  map[string]string{"foo": "bar baz"},
+		},
+		{
+			name:  "double quote escapes",
+			input: `foo="bar\"baz\\qux"` + "\n",
+			want:  map[string]string{"foo": `bar"baz\qux`},
+		},
+		{
+			name:  "single quotes literal",
+			input: `foo='bar\'baz'` + "\n",
+			want:  map[string]string{"foo": `bar\'baz`},
+		},
+		{
+			name:  "unmatched quotes kept",
+			input: `foo="bar` + "\n",
+			want:  map[string]string{"foo": `"bar`},
+		},
+		{
+			name:  "duplicate last wins",
+			input: "foo=1\nfoo=2\n",
+			want:  map[string]string{"foo": "2"},
+		},
+		{
+			name:  "empty value",
+			input: "foo=\n",
+			want:  map[string]string{"foo": ""},
+		},
+		{
+			name:    "missing equals",
+			input:   "just-a-key\n",
+			wantErr: true,
+			errLine: 1,
+		},
+		{
+			name:    "empty key",
+			input:   "=value\n",
+			wantErr: true,
+			errLine: 1,
+		},
+		{
+			name:    "invalid key",
+			input:   "foo-bar=1\n",
+			wantErr: true,
+			errLine: 1,
+			errKey:  "foo-bar",
+		},
+		{
+			name:    "error names line number after comments",
+			input:   "# ok\n\nbad line\n",
+			wantErr: true,
+			errLine: 3,
+		},
+		{
+			name:  "underscore and digit keys",
+			input: "A1_b=ok\n_hidden=yes\n",
+			want:  map[string]string{"A1_b": "ok", "_hidden": "yes"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(strings.NewReader(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				var keyErr *KeyError
+				if !errors.As(err, &keyErr) {
+					t.Fatalf("error type %T: %v", err, err)
+				}
+				if tc.errLine != 0 && keyErr.Line != tc.errLine {
+					t.Fatalf("Line = %d, want %d", keyErr.Line, tc.errLine)
+				}
+				if tc.errKey != "" && keyErr.Key != tc.errKey {
+					t.Fatalf("Key = %q, want %q", keyErr.Key, tc.errKey)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if !maps.Equal(got, tc.want) {
+				t.Fatalf("Parse = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadSearchOrder(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) (explicit string)
+		wantAuthor  string
+		wantSource  func(home, cwd, bazelWD string) string
+		wantErr     bool
+		wantDefault bool
+	}{
+		{
+			name: "explicit path wins",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				home, cwd := isolateConfigEnv(t)
+				mustWrite(t, filepath.Join(home, ".config", "prsync", "prsync.config"), "author=from-home\n")
+				mustWrite(t, filepath.Join(cwd, "prsync.config"), "author=from-cwd\n")
+				explicit := filepath.Join(t.TempDir(), "custom.config")
+				mustWrite(t, explicit, "author=from-explicit\n")
+				return explicit
+			},
+			wantAuthor: "from-explicit",
+			wantSource: func(_, _, _ string) string { return "" }, // filled below via explicit
+		},
+		{
+			name: "explicit missing is error",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				isolateConfigEnv(t)
+				return filepath.Join(t.TempDir(), "missing.config")
+			},
+			wantErr: true,
+		},
+		{
+			name: "cwd file before home",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				home, cwd := isolateConfigEnv(t)
+				mustWrite(t, filepath.Join(home, ".config", "prsync", "prsync.config"), "author=from-home\n")
+				mustWrite(t, filepath.Join(cwd, "prsync.config"), "author=from-cwd\n")
+				return ""
+			},
+			wantAuthor: "from-cwd",
+			wantSource: func(_, cwd, _ string) string {
+				return filepath.Join(cwd, "prsync.config")
+			},
+		},
+		{
+			name: "home file when cwd missing",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				home, _ := isolateConfigEnv(t)
+				mustWrite(t, filepath.Join(home, ".config", "prsync", "prsync.config"), "author=from-home\n")
+				return ""
+			},
+			wantAuthor: "from-home",
+			wantSource: func(home, _, _ string) string {
+				return filepath.Join(home, ".config", "prsync", "prsync.config")
+			},
+		},
+		{
+			name: "BUILD_WORKING_DIRECTORY replaces cwd",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				home, cwd := isolateConfigEnv(t)
+				mustWrite(t, filepath.Join(cwd, "prsync.config"), "author=from-cwd\n")
+				bazelWD := t.TempDir()
+				mustWrite(t, filepath.Join(bazelWD, "prsync.config"), "author=from-bazel-wd\n")
+				mustWrite(t, filepath.Join(home, ".config", "prsync", "prsync.config"), "author=from-home\n")
+				t.Setenv("BUILD_WORKING_DIRECTORY", bazelWD)
+				return ""
+			},
+			wantAuthor: "from-bazel-wd",
+			wantSource: func(_, _, bazelWD string) string {
+				return filepath.Join(bazelWD, "prsync.config")
+			},
+		},
+		{
+			name: "missing files use defaults",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				isolateConfigEnv(t)
+				return ""
+			},
+			wantDefault: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			explicit := tc.setup(t)
+			home := os.Getenv("HOME")
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			bazelWD := os.Getenv("BUILD_WORKING_DIRECTORY")
+
+			got, err := Load(explicit)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				var keyErr *KeyError
+				if !errors.As(err, &keyErr) {
+					t.Fatalf("error type %T: %v", err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if tc.wantDefault {
+				want := Defaults()
+				if got.SourcePath != "" {
+					t.Fatalf("SourcePath = %q, want empty", got.SourcePath)
+				}
+				if got.Author != want.Author || got.GHBin != want.GHBin || !slices.Equal(got.WaitUntil, want.WaitUntil) {
+					t.Fatalf("defaults mismatch: %#v", got)
+				}
+				return
+			}
+			if got.Author != tc.wantAuthor {
+				t.Fatalf("Author = %q, want %q (source %q)", got.Author, tc.wantAuthor, got.SourcePath)
+			}
+			if explicit != "" {
+				if got.SourcePath != explicit {
+					t.Fatalf("SourcePath = %q, want %q", got.SourcePath, explicit)
+				}
+				return
+			}
+			if tc.wantSource != nil {
+				wantPath := tc.wantSource(home, cwd, bazelWD)
+				if got.SourcePath != wantPath {
+					t.Fatalf("SourcePath = %q, want %q", got.SourcePath, wantPath)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadAppliesKnownKeys(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.txt")
+	mustWrite(t, promptFile, "from-file")
+	cfgPath := filepath.Join(dir, "prsync.config")
+	mustWrite(t, cfgPath, strings.Join([]string{
+		"repos=acme/widgets other/repo",
+		"author=alice",
+		"title_id_pattern=TICKET-[0-9]+",
+		"tab_label_template=wip/{id}",
+		"herdr_bin=/bin/herdr",
+		"gh_bin=/bin/gh",
+		"concurrency_wait_on=managed",
+		"gate_poll_ms=5",
+		"gate_timeout_ms=50",
+		"dispatch_prompt_template=@" + promptFile,
+		"dispatch_include_drafts=1",
+		"dispatch_wait_until=idle done",
+		"dispatch_timeout_ms=100",
+		"state_file=" + filepath.Join(dir, "state.json"),
+		"dry_run=false",
+		"unknown_future_key=ignored",
+	}, "\n")+"\n")
+
+	got, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !slices.Equal(got.Repos, []string{"acme/widgets", "other/repo"}) {
+		t.Fatalf("Repos = %#v", got.Repos)
+	}
+	if got.Author != "alice" {
+		t.Fatalf("Author = %q", got.Author)
+	}
+	if got.TitleIDPattern == nil || got.TitleIDPattern.String() != `TICKET-[0-9]+` {
+		t.Fatalf("TitleIDPattern = %v", got.TitleIDPattern)
+	}
+	if got.TabLabelTemplate != "wip/{id}" {
+		t.Fatalf("TabLabelTemplate = %q", got.TabLabelTemplate)
+	}
+	if got.HerdrBin != "/bin/herdr" || got.GHBin != "/bin/gh" {
+		t.Fatalf("bins herdr=%q gh=%q", got.HerdrBin, got.GHBin)
+	}
+	if got.ConcurrencyWaitOn != "managed" {
+		t.Fatalf("ConcurrencyWaitOn = %q", got.ConcurrencyWaitOn)
+	}
+	if got.GatePoll != 5*time.Millisecond || got.GateTimeout != 50*time.Millisecond {
+		t.Fatalf("gate durations poll=%s timeout=%s", got.GatePoll, got.GateTimeout)
+	}
+	if got.PromptTemplate != "from-file" {
+		t.Fatalf("PromptTemplate = %q", got.PromptTemplate)
+	}
+	if !got.IncludeDrafts {
+		t.Fatal("IncludeDrafts = false")
+	}
+	if !slices.Equal(got.WaitUntil, []string{"idle", "done"}) {
+		t.Fatalf("WaitUntil = %#v", got.WaitUntil)
+	}
+	if got.DispatchTimeout != 100*time.Millisecond {
+		t.Fatalf("DispatchTimeout = %s", got.DispatchTimeout)
+	}
+	if got.StateFile != filepath.Join(dir, "state.json") {
+		t.Fatalf("StateFile = %q", got.StateFile)
+	}
+	if got.DryRun {
+		t.Fatal("DryRun = true")
+	}
+}
+
+func TestLoadMillisAreMilliseconds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prsync.config")
+	mustWrite(t, path, "gate_poll_ms=2000\n")
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.GatePoll != 2*time.Second {
+		t.Fatalf("GatePoll = %s, want 2s (not 2000ns)", got.GatePoll)
+	}
+}
+
+func TestLoadExpandsTilde(t *testing.T) {
+	home, _ := isolateConfigEnv(t)
+	path := filepath.Join(t.TempDir(), "prsync.config")
+	mustWrite(t, path, "state_file=~/custom/state.json\ngh_bin=~/bin/gh\nherdr_bin=~/bin/herdr\n")
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.StateFile != filepath.Join(home, "custom", "state.json") {
+		t.Fatalf("StateFile = %q", got.StateFile)
+	}
+	if got.GHBin != filepath.Join(home, "bin", "gh") {
+		t.Fatalf("GHBin = %q", got.GHBin)
+	}
+	if got.HerdrBin != filepath.Join(home, "bin", "herdr") {
+		t.Fatalf("HerdrBin = %q", got.HerdrBin)
+	}
+}
+
+func TestLoadValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	overflow := "9223372036854776" // > MaxInt64 / time.Millisecond
+	tests := []struct {
+		name string
+		body string
+		key  string
+	}{
+		{name: "bad repo", body: "repos=not-a-repo\n", key: "repos"},
+		{name: "bad regex", body: "title_id_pattern=[A-Z+\n", key: "title_id_pattern"},
+		{name: "empty template", body: "tab_label_template=\n", key: "tab_label_template"},
+		{name: "empty herdr", body: "herdr_bin=\n", key: "herdr_bin"},
+		{name: "empty gh", body: "gh_bin=\n", key: "gh_bin"},
+		{name: "bad enum", body: "concurrency_wait_on=sometimes\n", key: "concurrency_wait_on"},
+		{name: "zero poll", body: "gate_poll_ms=0\n", key: "gate_poll_ms"},
+		{name: "negative timeout", body: "gate_timeout_ms=-1\n", key: "gate_timeout_ms"},
+		{name: "non integer ms", body: "dispatch_timeout_ms=2s\n", key: "dispatch_timeout_ms"},
+		{name: "overflow ms", body: "gate_poll_ms=" + overflow + "\n", key: "gate_poll_ms"},
+		{name: "bad bool", body: "dry_run=yes\n", key: "dry_run"},
+		{name: "empty wait until", body: "dispatch_wait_until=\n", key: "dispatch_wait_until"},
+		{name: "missing prompt file", body: "dispatch_prompt_template=@/no/such/prompt\n", key: "dispatch_prompt_template"},
+		{name: "empty state file", body: "state_file=\n", key: "state_file"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "prsync.config")
+			mustWrite(t, path, tc.body)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			var keyErr *KeyError
+			if !errors.As(err, &keyErr) {
+				t.Fatalf("error type %T: %v", err, err)
+			}
+			if keyErr.Key != tc.key {
+				t.Fatalf("Key = %q, want %q (err=%v)", keyErr.Key, tc.key, err)
+			}
+		})
+	}
+}
+
+func TestKeyErrorMessage(t *testing.T) {
+	t.Parallel()
+	err := &KeyError{Key: "title_id_pattern", Reason: "error parsing regexp: missing closing ]: `[A-Z+`"}
+	got := err.Error()
+	want := "key title_id_pattern: error parsing regexp: missing closing ]: `[A-Z+`"
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	t.Parallel()
+	got := Defaults()
+	if got.TitleIDPattern == nil || got.TitleIDPattern.String() != `[A-Z]+-[0-9]+` {
+		t.Fatalf("TitleIDPattern = %v", got.TitleIDPattern)
+	}
+	if got.TabLabelTemplate != "{id}" {
+		t.Fatalf("TabLabelTemplate = %q", got.TabLabelTemplate)
+	}
+	if got.HerdrBin != "herdr" || got.GHBin != "gh" {
+		t.Fatalf("bins herdr=%q gh=%q", got.HerdrBin, got.GHBin)
+	}
+	if got.ConcurrencyWaitOn != "any" {
+		t.Fatalf("ConcurrencyWaitOn = %q", got.ConcurrencyWaitOn)
+	}
+	if got.GatePoll != 2000*time.Millisecond {
+		t.Fatalf("GatePoll = %s", got.GatePoll)
+	}
+	if got.GateTimeout != 1800000*time.Millisecond {
+		t.Fatalf("GateTimeout = %s", got.GateTimeout)
+	}
+	if got.DispatchTimeout != 1800000*time.Millisecond {
+		t.Fatalf("DispatchTimeout = %s", got.DispatchTimeout)
+	}
+	if !slices.Equal(got.WaitUntil, []string{"idle", "done"}) {
+		t.Fatalf("WaitUntil = %#v", got.WaitUntil)
+	}
+	if !got.DryRun {
+		t.Fatal("DryRun default is not true")
+	}
+	if got.IncludeDrafts {
+		t.Fatal("IncludeDrafts default is not false")
+	}
+	if got.StateFile != "~/.config/prsync/state.json" {
+		t.Fatalf("StateFile = %q", got.StateFile)
+	}
+	if !regexp.MustCompile(`Address the unresolved review comments`).MatchString(got.PromptTemplate) {
+		t.Fatalf("PromptTemplate missing built-in text: %q", got.PromptTemplate)
+	}
+	if got.SourcePath != "" {
+		t.Fatalf("SourcePath = %q", got.SourcePath)
+	}
+}
+
+func isolateConfigEnv(t *testing.T) (home, cwd string) {
+	t.Helper()
+	home = t.TempDir()
+	cwd = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BUILD_WORKING_DIRECTORY", "")
+	t.Chdir(cwd)
+	return home, cwd
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/devtools/prsync/internal/config/parse.go
+++ b/devtools/prsync/internal/config/parse.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+var keyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// Parse reads a shell-sourceable KEY=VALUE file.
+func Parse(r io.Reader) (map[string]string, error) {
+	out := make(map[string]string)
+	sc := bufio.NewScanner(r)
+	line := 0
+	for sc.Scan() {
+		line++
+		raw := sc.Text()
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(raw, "=")
+		if !ok {
+			return nil, &KeyError{Line: line, Reason: "missing '='"}
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, &KeyError{Line: line, Reason: "empty key"}
+		}
+		if !keyPattern.MatchString(key) {
+			return nil, &KeyError{Key: key, Line: line, Reason: "invalid key"}
+		}
+		out[key] = unquote(strings.TrimSpace(val))
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	return out, nil
+}
+
+func unquote(v string) string {
+	if len(v) < 2 {
+		return v
+	}
+	if v[0] == '"' && v[len(v)-1] == '"' {
+		return unescapeDouble(v[1 : len(v)-1])
+	}
+	if v[0] == '\'' && v[len(v)-1] == '\'' {
+		return v[1 : len(v)-1]
+	}
+	return v
+}
+
+func unescapeDouble(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && (s[i+1] == '"' || s[i+1] == '\\') {
+			b.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/devtools/prsync/internal/version/BUILD.bazel
+++ b/devtools/prsync/internal/version/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["version.go"],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/version",
+    visibility = ["//devtools/prsync:__subpackages__"],
+)

--- a/devtools/prsync/internal/version/version.go
+++ b/devtools/prsync/internal/version/version.go
@@ -1,0 +1,6 @@
+// Package version holds the prsync version string.
+package version
+
+// Version is the prsync version. Overridable at link time with
+// -X github.com/jaeyeom/experimental/devtools/prsync/internal/version.Version.
+var Version = "0.1.0"

--- a/devtools/prsync/prsync.config.example
+++ b/devtools/prsync/prsync.config.example
@@ -1,0 +1,38 @@
+# prsync example configuration (KEY=VALUE).
+# Copy to ./prsync.config or ~/.config/prsync/prsync.config.
+# Unknown keys are ignored. Inline comments are not supported.
+
+# Space-separated owner/repo list. Empty = auto-discover from open PRs.
+# repos=
+
+# GitHub login. Empty = `gh api user --jq .login`.
+# author=
+
+# First match in the PR title is the identifier used to match a herdr tab.
+# title_id_pattern=[A-Z]+-[0-9]+
+
+# Herdr tab label after substituting {id}. Compared exactly, case-sensitive.
+# tab_label_template={id}
+
+# herdr_bin=herdr
+# gh_bin=gh
+
+# Gate busy-set: any | managed
+# concurrency_wait_on=any
+
+# Milliseconds. Parsed as n * time.Millisecond (2000 = 2s, not 2µs).
+# gate_poll_ms=2000
+# gate_timeout_ms=1800000
+# dispatch_timeout_ms=1800000
+
+# Inline prompt, or @/path/to/file (tilde is expanded).
+# dispatch_prompt_template=
+
+# true / false / 1 / 0
+# dispatch_include_drafts=false
+# dry_run=true
+
+# Whitespace-separated herdr --until tokens (each becomes its own flag).
+# dispatch_wait_until=idle done
+
+# state_file=~/.config/prsync/state.json


### PR DESCRIPTION
## Summary
- Add the `devtools/prsync` cobra skeleton: `prsync version` prints `{"version":"0.1.0"}`, and unknown commands exit 2.
- Implement KEY=VALUE config search order (`--config` path → `./prsync.config` / `BUILD_WORKING_DIRECTORY` → `~/.config/prsync/prsync.config`), parser, and validation. `KeyError` maps to exit 2.
- Parse `*_ms` keys as `n * time.Millisecond`; `dispatch_wait_until` is a `[]string` (default `idle done`).
- Wire `signal.NotifyContext` in `main`. Stub `README.org` so `org_lint_tests` / `bazel test //...` pass. No `gh` or `herdr` calls yet.

## Why
PR 1 of the #211 prsync plan. Later PRs add adapters, `scan`, `gate`, and `dispatch` on top of this CLI and config layer.

## Test plan
- [x] Table tests for the parser and search order (temp dirs / `HOME` / `BUILD_WORKING_DIRECTORY`)
- [x] CLI tests for `version` JSON, unknown command → exit 2, and `KeyError` → exit 2
- [x] `make check`

Resolves #215