### PR TITLE
feat(prsync): add gh and herdr adapters with mock + fixture coverage

### DIFF
--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["cli_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",

--- a/devtools/prsync/internal/cli/cli_test.go
+++ b/devtools/prsync/internal/cli/cli_test.go
@@ -45,6 +45,24 @@ func TestUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestNoCommandsBeyondVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"scan", "dispatch", "gate"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var stdout, stderr bytes.Buffer
+			code := Execute(context.Background(), []string{name}, &stdout, &stderr, nil)
+			if code != ExitUsage {
+				t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "unknown command") {
+				t.Fatalf("stderr = %q", stderr.String())
+			}
+		})
+	}
+}
+
 func TestReportKeyError(t *testing.T) {
 	t.Parallel()
 

--- a/devtools/prsync/internal/cli/testdata/fixtures/gh-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/gh-fake.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+cmd=${1-}
+sub=${2-}
+
+case "${cmd} ${sub}" in
+  "auth status")
+    exit 0
+    ;;
+  "api user")
+    printf '%s\n' "alice"
+    exit 0
+    ;;
+  "search prs")
+    cat "${DIR}/gh-search-prs.json"
+    exit 0
+    ;;
+  "pr list")
+    cat "${DIR}/gh-pr-list.json"
+    exit 0
+    ;;
+  "api graphql")
+    cat "${DIR}/gh-review-threads.json"
+    exit 0
+    ;;
+  *)
+    printf '%s\n' "gh-fake: unexpected: $*" >&2
+    exit 1
+    ;;
+esac

--- a/devtools/prsync/internal/cli/testdata/fixtures/gh-pr-list.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/gh-pr-list.json
@@ -1,0 +1,39 @@
+[
+  {
+    "number": 123,
+    "title": "[PROJ-123] Fix the widget",
+    "url": "https://github.com/acme/widgets/pull/123",
+    "baseRefName": "main",
+    "headRefName": "fix-widget",
+    "mergeable": "MERGEABLE",
+    "isDraft": false,
+    "reviewDecision": "APPROVED",
+    "reviewRequests": [
+      {
+        "__typename": "User",
+        "login": "reviewer-login"
+      },
+      {
+        "__typename": "Team",
+        "name": "Platform Reviewers",
+        "slug": "platform-reviewers"
+      }
+    ],
+    "latestReviews": [
+      {
+        "author": {
+          "login": "reviewer-login"
+        },
+        "state": "APPROVED",
+        "submittedAt": "2026-01-01T09:00:00Z"
+      }
+    ],
+    "statusCheckRollup": [
+      {
+        "name": "ci",
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS"
+      }
+    ]
+  }
+]

--- a/devtools/prsync/internal/cli/testdata/fixtures/gh-review-threads.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/gh-review-threads.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": null
+          },
+          "nodes": [
+            {
+              "id": "PRRT_widget",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "PRRC_widget",
+                    "author": {
+                      "login": "reviewer-login"
+                    },
+                    "path": "src/widget.go",
+                    "line": 42,
+                    "url": "https://github.com/acme/widgets/pull/123#discussion_r1",
+                    "body": "This should handle the nil case."
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/gh-search-prs.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/gh-search-prs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "repository": {
+      "nameWithOwner": "acme/widgets"
+    }
+  },
+  {
+    "repository": {
+      "nameWithOwner": "acme/gizmos"
+    }
+  }
+]

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-list.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-list.json
@@ -1,0 +1,12 @@
+{
+  "result": {
+    "agents": [
+      {
+        "pane_id": "w2:pC",
+        "tab_id": "w2:tC",
+        "agent": "codex",
+        "agent_status": "idle"
+      }
+    ]
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-prompt.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-prompt.json
@@ -1,0 +1,10 @@
+{
+  "result": {
+    "agent": {
+      "pane_id": "w2:pC",
+      "tab_id": "w2:tC",
+      "agent": "codex",
+      "agent_status": "idle"
+    }
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-error-stalled.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-error-stalled.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "agent_prompt_stalled",
+    "message": "agent did not change state within 5s"
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-error-timeout.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-error-timeout.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "timeout",
+    "message": "wait exceeded timeout_ms"
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+
+case "${1-}" in
+  --version)
+    printf '%s\n' "herdr 0.8.1"
+    exit 0
+    ;;
+esac
+
+case "${1-} ${2-}" in
+  "tab list")
+    cat "${DIR}/herdr-tab-list.json"
+    exit 0
+    ;;
+  "agent list")
+    cat "${DIR}/herdr-agent-list.json"
+    exit 0
+    ;;
+  "pane current")
+    cat "${DIR}/herdr-pane-current.json"
+    exit 0
+    ;;
+  "agent prompt")
+    cat "${DIR}/herdr-agent-prompt.json"
+    exit 0
+    ;;
+  *)
+    printf '%s\n' "herdr-fake: unexpected: $*" >&2
+    exit 1
+    ;;
+esac

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-pane-current-nested.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-pane-current-nested.json
@@ -1,0 +1,9 @@
+{
+  "result": {
+    "pane": {
+      "pane_id": "w2:pC",
+      "tab_id": "w2:tC",
+      "workspace_id": "w2"
+    }
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-pane-current.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-pane-current.json
@@ -1,0 +1,7 @@
+{
+  "result": {
+    "pane_id": "w2:pC",
+    "tab_id": "w2:tC",
+    "workspace_id": "w2"
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-tab-list.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-tab-list.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "tabs": [
+      {
+        "tab_id": "w2:tC",
+        "workspace_id": "w2",
+        "label": "PROJ-123",
+        "agent_status": "idle",
+        "pane_count": 1
+      }
+    ]
+  }
+}

--- a/devtools/prsync/internal/gh/BUILD.bazel
+++ b/devtools/prsync/internal/gh/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "types.go",
+    ],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/gh",
+    visibility = ["//devtools/prsync:__subpackages__"],
+    deps = ["@com_github_jaeyeom_go_cmdexec//:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_jaeyeom_go_cmdexec//:go_default_library"],
+)

--- a/devtools/prsync/internal/gh/client.go
+++ b/devtools/prsync/internal/gh/client.go
@@ -1,0 +1,258 @@
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+const (
+	defaultCallTimeout   = 60 * time.Second
+	maxReviewThreadPages = 50
+	prListJSONFields     = "number,title,url,baseRefName,headRefName,mergeable,isDraft,reviewDecision,reviewRequests,latestReviews,statusCheckRollup"
+	reviewThreadsQuery   = `query($owner:String!,$repo:String!,$num:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(last:1){nodes{id author{login} path line url body}}}}}}}`
+)
+
+// Client shells out to gh_bin through an injected executor.
+type Client struct {
+	exec executor.Executor
+	bin  string
+}
+
+// NewClient returns a gh adapter that invokes bin via exec.
+func NewClient(exec executor.Executor, bin string) *Client {
+	return &Client{exec: exec, bin: bin}
+}
+
+// AuthStatus runs `gh auth status`. A missing binary is an ExecutableNotFoundError.
+func (c *Client) AuthStatus(ctx context.Context) error {
+	result, err := c.execute(ctx, defaultCallTimeout, "auth", "status")
+	if err != nil {
+		return err
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("%w: %s", ErrUnauthenticated, strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+// UserLogin runs `gh api user --jq .login`.
+func (c *Client) UserLogin(ctx context.Context) (string, error) {
+	result, err := c.requireOK(ctx, defaultCallTimeout, "api", "user", "--jq", ".login")
+	if err != nil {
+		return "", err
+	}
+	login := strings.TrimSpace(result.Output)
+	if login == "" {
+		return "", fmt.Errorf("gh api user: empty login")
+	}
+	return login, nil
+}
+
+// SearchOpenPRRepos returns unique repository.nameWithOwner values.
+// capped is true when gh returned exactly 1000 search hits.
+func (c *Client) SearchOpenPRRepos(ctx context.Context, author string) (repos []string, capped bool, err error) {
+	result, err := c.requireOK(ctx, defaultCallTimeout,
+		"search", "prs", "--author", author, "--state", "open", "--limit", "1000", "--json", "repository")
+	if err != nil {
+		return nil, false, err
+	}
+	var items []struct {
+		Repository struct {
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"repository"`
+	}
+	if err := json.Unmarshal([]byte(result.Output), &items); err != nil {
+		return nil, false, fmt.Errorf("decode search prs: %w", err)
+	}
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		name := item.Repository.NameWithOwner
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		repos = append(repos, name)
+	}
+	return repos, len(items) == 1000, nil
+}
+
+// ListOpenPRs runs `gh pr list` for one repo. 404/archived become ErrInaccessible.
+func (c *Client) ListOpenPRs(ctx context.Context, repo, author string) ([]PRListItem, error) {
+	result, err := c.execute(ctx, defaultCallTimeout,
+		"pr", "list", "--repo", repo, "--author", author, "--state", "open",
+		"--limit", "1000", "--json", prListJSONFields)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		if isInaccessible(result.Stderr) {
+			return nil, fmt.Errorf("%w: %s", ErrInaccessible, strings.TrimSpace(result.Stderr))
+		}
+		return nil, &ProcError{ExitCode: result.ExitCode, Stdout: result.Output, Stderr: result.Stderr}
+	}
+	var prs []PRListItem
+	if err := json.Unmarshal([]byte(result.Output), &prs); err != nil {
+		return nil, fmt.Errorf("decode pr list: %w", err)
+	}
+	if prs == nil {
+		prs = []PRListItem{}
+	}
+	return prs, nil
+}
+
+// ReviewThreads paginates GraphQL review threads. Hitting 50 pages is an error.
+func (c *Client) ReviewThreads(ctx context.Context, owner, repo string, number int) ([]Thread, error) {
+	var threads []Thread
+	cursor := ""
+	for page := 0; page < maxReviewThreadPages; page++ {
+		nodes, next, err := c.reviewThreadsPage(ctx, owner, repo, number, cursor)
+		if err != nil {
+			return nil, err
+		}
+		threads = append(threads, nodes...)
+		if next == "" {
+			if threads == nil {
+				threads = []Thread{}
+			}
+			return threads, nil
+		}
+		cursor = next
+	}
+	return nil, fmt.Errorf("review threads page cap exceeded for %s/%s#%d", owner, repo, number)
+}
+
+func (c *Client) reviewThreadsPage(ctx context.Context, owner, repo string, number int, cursor string) ([]Thread, string, error) {
+	args := []string{
+		"api", "graphql",
+		"-f", "query=" + reviewThreadsQuery,
+		"-F", "owner=" + owner,
+		"-F", "repo=" + repo,
+		"-F", "num=" + strconv.Itoa(number),
+	}
+	if cursor != "" {
+		args = append(args, "-F", "cursor="+cursor)
+	}
+	result, err := c.requireOK(ctx, defaultCallTimeout, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	var payload graphqlReviewThreads
+	if err := json.Unmarshal([]byte(result.Output), &payload); err != nil {
+		return nil, "", fmt.Errorf("decode review threads: %w", err)
+	}
+	if len(payload.Errors) > 0 {
+		return nil, "", fmt.Errorf("review threads graphql: %s", payload.Errors[0].Message)
+	}
+	if payload.Data.Repository.PullRequest == nil {
+		return nil, "", fmt.Errorf("review threads: pull request %s/%s#%d not found", owner, repo, number)
+	}
+	conn := payload.Data.Repository.PullRequest.ReviewThreads
+	threads := make([]Thread, 0, len(conn.Nodes))
+	for _, node := range conn.Nodes {
+		threads = append(threads, node.toThread())
+	}
+	next := ""
+	if conn.PageInfo.HasNextPage {
+		next = conn.PageInfo.EndCursor
+	}
+	return threads, next, nil
+}
+
+func (c *Client) requireOK(ctx context.Context, timeout time.Duration, args ...string) (*executor.ExecutionResult, error) {
+	result, err := c.execute(ctx, timeout, args...)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, &ProcError{ExitCode: result.ExitCode, Stdout: result.Output, Stderr: result.Stderr}
+	}
+	return result, nil
+}
+
+func (c *Client) execute(ctx context.Context, timeout time.Duration, args ...string) (*executor.ExecutionResult, error) {
+	result, err := c.exec.Execute(ctx, executor.ToolConfig{
+		Command: c.bin,
+		Args:    args,
+		Timeout: timeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("run %s: %w", c.bin, err)
+	}
+	return result, nil
+}
+
+func isInaccessible(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "http 404") ||
+		strings.Contains(s, "could not resolve to a repository") ||
+		strings.Contains(s, "not found") ||
+		strings.Contains(s, "archived")
+}
+
+type graphqlReviewThreads struct {
+	Data struct {
+		Repository struct {
+			PullRequest *struct {
+				ReviewThreads graphqlThreadConn `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type graphqlThreadConn struct {
+	PageInfo struct {
+		HasNextPage bool   `json:"hasNextPage"`
+		EndCursor   string `json:"endCursor"`
+	} `json:"pageInfo"`
+	Nodes []graphqlThread `json:"nodes"`
+}
+
+type graphqlThread struct {
+	ID         string `json:"id"`
+	IsResolved bool   `json:"isResolved"`
+	Comments   struct {
+		Nodes []graphqlComment `json:"nodes"`
+	} `json:"comments"`
+}
+
+type graphqlComment struct {
+	ID     string `json:"id"`
+	Author *struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	Path string `json:"path"`
+	Line *int   `json:"line"`
+	URL  string `json:"url"`
+	Body string `json:"body"`
+}
+
+func (n graphqlThread) toThread() Thread {
+	comments := make([]ThreadComment, 0, len(n.Comments.Nodes))
+	for _, node := range n.Comments.Nodes {
+		var author *ThreadAuthor
+		if node.Author != nil {
+			author = &ThreadAuthor{Login: node.Author.Login}
+		}
+		comments = append(comments, ThreadComment{
+			ID:     node.ID,
+			Author: author,
+			Path:   node.Path,
+			Line:   node.Line,
+			URL:    node.URL,
+			Body:   node.Body,
+		})
+	}
+	return Thread{ID: n.ID, IsResolved: n.IsResolved, Comments: comments}
+}

--- a/devtools/prsync/internal/gh/client_test.go
+++ b/devtools/prsync/internal/gh/client_test.go
@@ -1,0 +1,340 @@
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+const testGHBin = "/tmp/prsync-gh-fake"
+
+func TestAuthStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "auth", "status").WillSucceed("", 0).Build()
+		if err := NewClient(mock, testGHBin).AuthStatus(context.Background()); err != nil {
+			t.Fatalf("AuthStatus() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		t.Parallel()
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "auth", "status").
+			WillFail("You are not logged into any GitHub hosts", 1).Build()
+		err := NewClient(mock, testGHBin).AuthStatus(context.Background())
+		if !errors.Is(err, ErrUnauthenticated) {
+			t.Fatalf("AuthStatus() error = %v, want ErrUnauthenticated", err)
+		}
+	})
+
+	t.Run("missing binary", func(t *testing.T) {
+		t.Parallel()
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "auth", "status").
+			WillError(&executor.ExecutableNotFoundError{Command: testGHBin}).Build()
+		err := NewClient(mock, testGHBin).AuthStatus(context.Background())
+		var notFound *executor.ExecutableNotFoundError
+		if !errors.As(err, &notFound) {
+			t.Fatalf("AuthStatus() error = %v, want ExecutableNotFoundError", err)
+		}
+	})
+}
+
+func TestUserLogin(t *testing.T) {
+	t.Parallel()
+
+	mock := newGHMock()
+	mock.ExpectCommandWithArgs(testGHBin, "api", "user", "--jq", ".login").
+		WillSucceed("alice\n", 0).Build()
+	got, err := NewClient(mock, testGHBin).UserLogin(context.Background())
+	if err != nil {
+		t.Fatalf("UserLogin() unexpected error: %v", err)
+	}
+	if got != "alice" {
+		t.Fatalf("UserLogin() = %q, want %q", got, "alice")
+	}
+}
+
+func TestSearchOpenPRRepos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unique preserves first-seen order", func(t *testing.T) {
+		t.Parallel()
+		body, err := json.Marshal([]map[string]any{
+			{"repository": map[string]string{"nameWithOwner": "acme/widgets"}},
+			{"repository": map[string]string{"nameWithOwner": "acme/gizmos"}},
+			{"repository": map[string]string{"nameWithOwner": "acme/widgets"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "search", "prs",
+			"--author", "alice", "--state", "open", "--limit", "1000", "--json", "repository").
+			WillSucceed(string(body), 0).Build()
+		repos, capped, err := NewClient(mock, testGHBin).SearchOpenPRRepos(context.Background(), "alice")
+		if err != nil {
+			t.Fatalf("SearchOpenPRRepos() unexpected error: %v", err)
+		}
+		if capped {
+			t.Fatal("capped = true, want false")
+		}
+		want := []string{"acme/widgets", "acme/gizmos"}
+		if !equalStrings(repos, want) {
+			t.Fatalf("repos = %v, want %v", repos, want)
+		}
+	})
+
+	t.Run("capped when result length is 1000", func(t *testing.T) {
+		t.Parallel()
+		items := make([]map[string]any, 1000)
+		for i := range items {
+			items[i] = map[string]any{
+				"repository": map[string]string{"nameWithOwner": "acme/r" + strconv.Itoa(i)},
+			}
+		}
+		body, err := json.Marshal(items)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "search", "prs",
+			"--author", "alice", "--state", "open", "--limit", "1000", "--json", "repository").
+			WillSucceed(string(body), 0).Build()
+		repos, capped, err := NewClient(mock, testGHBin).SearchOpenPRRepos(context.Background(), "alice")
+		if err != nil {
+			t.Fatalf("SearchOpenPRRepos() unexpected error: %v", err)
+		}
+		if !capped {
+			t.Fatal("capped = false, want true")
+		}
+		if len(repos) != 1000 {
+			t.Fatalf("len(repos) = %d, want 1000", len(repos))
+		}
+	})
+}
+
+func TestListOpenPRs(t *testing.T) {
+	t.Parallel()
+
+	const jsonFields = "number,title,url,baseRefName,headRefName,mergeable,isDraft,reviewDecision,reviewRequests,latestReviews,statusCheckRollup"
+
+	t.Run("parses list", func(t *testing.T) {
+		t.Parallel()
+		body := `[{
+			"number":123,
+			"title":"[PROJ-123] Fix the widget",
+			"url":"https://github.com/acme/widgets/pull/123",
+			"baseRefName":"main",
+			"headRefName":"fix-widget",
+			"mergeable":"MERGEABLE",
+			"isDraft":false,
+			"reviewDecision":"APPROVED",
+			"reviewRequests":[{"__typename":"User","login":"reviewer"}],
+			"latestReviews":[{"author":{"login":"reviewer"},"state":"APPROVED","submittedAt":"2026-01-01T00:00:00Z"}],
+			"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}]
+		}]`
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "pr", "list",
+			"--repo", "acme/widgets", "--author", "alice", "--state", "open",
+			"--limit", "1000", "--json", jsonFields).
+			WillSucceed(body, 0).Build()
+		got, err := NewClient(mock, testGHBin).ListOpenPRs(context.Background(), "acme/widgets", "alice")
+		if err != nil {
+			t.Fatalf("ListOpenPRs() unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].Number != 123 || got[0].Title == "" || got[0].IsDraft {
+			t.Fatalf("ListOpenPRs() = %+v", got)
+		}
+		if got[0].ReviewDecision != "APPROVED" || len(got[0].ReviewRequests) != 1 {
+			t.Fatalf("reviews = %+v", got[0])
+		}
+	})
+
+	t.Run("inaccessible stderr", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name   string
+			stderr string
+		}{
+			{name: "http 404", stderr: "gh: HTTP 404: Not Found"},
+			{name: "could not resolve", stderr: "Could not resolve to a Repository"},
+			{name: "not found", stderr: "GraphQL: Not Found"},
+			{name: "archived", stderr: "Repository has been archived"},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				mock := newGHMock()
+				mock.ExpectCommandWithArgs(testGHBin, "pr", "list",
+					"--repo", "acme/gone", "--author", "alice", "--state", "open",
+					"--limit", "1000", "--json", jsonFields).
+					WillFail(tc.stderr, 1).Build()
+				_, err := NewClient(mock, testGHBin).ListOpenPRs(context.Background(), "acme/gone", "alice")
+				if !errors.Is(err, ErrInaccessible) {
+					t.Fatalf("ListOpenPRs() error = %v, want ErrInaccessible", err)
+				}
+			})
+		}
+	})
+
+	t.Run("http 403 rate limit is fatal", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name   string
+			stderr string
+		}{
+			{name: "api rate limit", stderr: "HTTP 403: API rate limit exceeded"},
+			{name: "secondary", stderr: "HTTP 403: secondary rate limit"},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				mock := newGHMock()
+				mock.ExpectCommandWithArgs(testGHBin, "pr", "list",
+					"--repo", "acme/widgets", "--author", "alice", "--state", "open",
+					"--limit", "1000", "--json", jsonFields).
+					WillFail(tc.stderr, 1).Build()
+				_, err := NewClient(mock, testGHBin).ListOpenPRs(context.Background(), "acme/widgets", "alice")
+				if err == nil {
+					t.Fatal("ListOpenPRs() error = nil, want fatal")
+				}
+				if errors.Is(err, ErrInaccessible) {
+					t.Fatalf("ListOpenPRs() treated 403 as inaccessible: %v", err)
+				}
+			})
+		}
+	})
+}
+
+func TestReviewThreads(t *testing.T) {
+	t.Parallel()
+
+	t.Run("paginates and omits cursor on first page", func(t *testing.T) {
+		t.Parallel()
+		page1 := `{
+			"data":{"repository":{"pullRequest":{"reviewThreads":{
+				"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR1"},
+				"nodes":[{
+					"id":"PRRT_a",
+					"isResolved":false,
+					"comments":{"nodes":[{"id":"PRRC_a","author":{"login":"rev"},"path":"a.go","line":1,"url":"https://ex/a","body":"fix"}]}
+				}]
+			}}}}
+		}`
+		page2 := `{
+			"data":{"repository":{"pullRequest":{"reviewThreads":{
+				"pageInfo":{"hasNextPage":false,"endCursor":"CURSOR2"},
+				"nodes":[{
+					"id":"PRRT_b",
+					"isResolved":true,
+					"comments":{"nodes":[{"id":"PRRC_b","author":null,"path":"b.go","line":null,"url":"https://ex/b","body":"ok"}]}
+				}]
+			}}}}
+		}`
+		mock := newGHMock()
+		mock.ExpectCustom(func(_ context.Context, cfg executor.ToolConfig) bool {
+			return cfg.Command == testGHBin && isGraphQL(cfg.Args) && !hasCursor(cfg.Args)
+		}).WillSucceed(page1, 0).Once().Build()
+		mock.ExpectCustom(func(_ context.Context, cfg executor.ToolConfig) bool {
+			return cfg.Command == testGHBin && isGraphQL(cfg.Args) && hasCursorValue(cfg.Args, "CURSOR1")
+		}).WillSucceed(page2, 0).Once().Build()
+
+		got, err := NewClient(mock, testGHBin).ReviewThreads(context.Background(), "acme", "widgets", 123)
+		if err != nil {
+			t.Fatalf("ReviewThreads() unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("len(threads) = %d, want 2", len(got))
+		}
+		if got[0].ID != "PRRT_a" || got[0].IsResolved || len(got[0].Comments) != 1 {
+			t.Fatalf("thread0 = %+v", got[0])
+		}
+		if got[0].Comments[0].Author == nil || got[0].Comments[0].Author.Login != "rev" {
+			t.Fatalf("thread0 author = %+v", got[0].Comments[0].Author)
+		}
+		if got[1].ID != "PRRT_b" || !got[1].IsResolved {
+			t.Fatalf("thread1 = %+v", got[1])
+		}
+		if got[1].Comments[0].Author != nil {
+			t.Fatalf("deleted author should be nil, got %+v", got[1].Comments[0].Author)
+		}
+		if got[1].Comments[0].Line != nil {
+			t.Fatalf("null line should be nil, got %v", got[1].Comments[0].Line)
+		}
+		if err := mock.AssertExpectationsMet(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("page cap fails", func(t *testing.T) {
+		t.Parallel()
+		page := `{
+			"data":{"repository":{"pullRequest":{"reviewThreads":{
+				"pageInfo":{"hasNextPage":true,"endCursor":"NEXT"},
+				"nodes":[{"id":"PRRT_x","isResolved":false,"comments":{"nodes":[]}}]
+			}}}}
+		}`
+		mock := newGHMock()
+		mock.ExpectCustom(func(_ context.Context, cfg executor.ToolConfig) bool {
+			return cfg.Command == testGHBin && isGraphQL(cfg.Args)
+		}).WillSucceed(page, 0).Build()
+		_, err := NewClient(mock, testGHBin).ReviewThreads(context.Background(), "acme", "widgets", 9)
+		if err == nil {
+			t.Fatal("ReviewThreads() error = nil, want page cap")
+		}
+		if !strings.Contains(err.Error(), "acme/widgets#9") {
+			t.Fatalf("error %q should name owner/repo#N", err)
+		}
+	})
+}
+
+func newGHMock() *executor.MockExecutor {
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand(testGHBin, true)
+	return mock
+}
+
+func isGraphQL(args []string) bool {
+	return len(args) >= 2 && args[0] == "api" && args[1] == "graphql"
+}
+
+func hasCursor(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "cursor=") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCursorValue(args []string, cursor string) bool {
+	want := "cursor=" + cursor
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/devtools/prsync/internal/gh/types.go
+++ b/devtools/prsync/internal/gh/types.go
@@ -1,0 +1,97 @@
+// Package gh talks to GitHub through the gh CLI.
+package gh
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnauthenticated is returned when `gh auth status` exits non-zero.
+var ErrUnauthenticated = errors.New("gh is not authenticated")
+
+// ErrInaccessible is returned only for 404 / not-found / archived repositories.
+var ErrInaccessible = errors.New("repository inaccessible")
+
+// ProcError is a non-zero process exit from gh.
+type ProcError struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+func (e *ProcError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Stderr != "" {
+		return e.Stderr
+	}
+	if e.Stdout != "" {
+		return e.Stdout
+	}
+	return fmt.Sprintf("exit %d", e.ExitCode)
+}
+
+// PRListItem is one row from `gh pr list --json`.
+type PRListItem struct {
+	Number            int            `json:"number"`
+	Title             string         `json:"title"`
+	URL               string         `json:"url"`
+	BaseRefName       string         `json:"baseRefName"`
+	HeadRefName       string         `json:"headRefName"`
+	Mergeable         string         `json:"mergeable"`
+	IsDraft           bool           `json:"isDraft"`
+	ReviewDecision    string         `json:"reviewDecision"`
+	ReviewRequests    []ReviewReq    `json:"reviewRequests"`
+	LatestReviews     []LatestReview `json:"latestReviews"`
+	StatusCheckRollup []StatusCheck  `json:"statusCheckRollup"`
+}
+
+// ReviewReq is a requested reviewer (user or team) from gh JSON.
+type ReviewReq struct {
+	Type  string `json:"__typename"` //nolint:tagliatelle // gh JSON
+	Login string `json:"login,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Slug  string `json:"slug,omitempty"`
+}
+
+// LatestReview is an unused-by-v1 bucket field kept so we do not refetch.
+type LatestReview struct {
+	Author      ReviewAuthor `json:"author"`
+	State       string       `json:"state"`
+	SubmittedAt string       `json:"submittedAt"`
+}
+
+// ReviewAuthor is the author of a latest review.
+type ReviewAuthor struct {
+	Login string `json:"login"`
+}
+
+// StatusCheck is one statusCheckRollup entry.
+type StatusCheck struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// Thread is one review thread after pagination flattening.
+type Thread struct {
+	ID         string
+	IsResolved bool
+	Comments   []ThreadComment
+}
+
+// ThreadComment is the last comment on a review thread.
+type ThreadComment struct {
+	ID     string
+	Author *ThreadAuthor
+	Path   string
+	Line   *int
+	URL    string
+	Body   string
+}
+
+// ThreadAuthor is a GitHub user on a review comment. Nil author means deleted.
+type ThreadAuthor struct {
+	Login string
+}

--- a/devtools/prsync/internal/herdr/BUILD.bazel
+++ b/devtools/prsync/internal/herdr/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "types.go",
+    ],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/herdr",
+    visibility = ["//devtools/prsync:__subpackages__"],
+    deps = ["@com_github_jaeyeom_go_cmdexec//:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_jaeyeom_go_cmdexec//:go_default_library"],
+)

--- a/devtools/prsync/internal/herdr/client.go
+++ b/devtools/prsync/internal/herdr/client.go
@@ -1,0 +1,313 @@
+package herdr
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+const (
+	defaultCallTimeout = 60 * time.Second
+	promptTimeoutGrace = 5 * time.Second
+)
+
+// Same regex as devtools/setup-dev/ansible/packages_data.go for herdr --version.
+var herdrVersionRe = regexp.MustCompile(`herdr ([0-9.]+)`)
+
+// Client shells out to herdr_bin through an injected executor.
+type Client struct {
+	exec executor.Executor
+	bin  string
+}
+
+// NewClient returns a herdr adapter that invokes bin via exec.
+func NewClient(exec executor.Executor, bin string) *Client {
+	return &Client{exec: exec, bin: bin}
+}
+
+// RequireMin runs `--version` and checks it is at least minimum (e.g. "0.8.0").
+func (c *Client) RequireMin(ctx context.Context, minimum string) error {
+	result, err := c.execute(ctx, defaultCallTimeout, "--version")
+	if err != nil {
+		var notFound *executor.ExecutableNotFoundError
+		if errors.As(err, &notFound) {
+			return fmt.Errorf("%w: %w", ErrNotInstalled, err)
+		}
+		return fmt.Errorf("%w: %w", ErrUnsupported, err)
+	}
+	text := result.Output
+	if !herdrVersionRe.MatchString(text) {
+		text = result.Stderr
+	}
+	got, ok := parseHerdrVersion(text)
+	if !ok {
+		raw := strings.TrimSpace(result.Output + "\n" + result.Stderr)
+		return fmt.Errorf("%w: cannot parse herdr version from %q", ErrUnsupported, raw)
+	}
+	cmp, ok := compareVersions(got, minimum)
+	if !ok {
+		return fmt.Errorf("%w: cannot parse herdr version from %q", ErrUnsupported, got)
+	}
+	if cmp < 0 {
+		return fmt.Errorf("%w: herdr %s is older than %s", ErrUnsupported, got, minimum)
+	}
+	return nil
+}
+
+// TabList runs `herdr tab list` and returns .result.tabs.
+func (c *Client) TabList(ctx context.Context) ([]Tab, error) {
+	raw, err := c.output(ctx, defaultCallTimeout, "tab", "list")
+	if err != nil {
+		return nil, err
+	}
+	var env struct {
+		Result struct {
+			Tabs *[]Tab `json:"tabs"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("decode tab list: %w", err)
+	}
+	if env.Result.Tabs == nil {
+		return nil, fmt.Errorf("%w: tab list missing tabs", ErrDegraded)
+	}
+	return *env.Result.Tabs, nil
+}
+
+// AgentList runs `herdr agent list` and returns .result.agents.
+func (c *Client) AgentList(ctx context.Context) ([]Agent, error) {
+	raw, err := c.output(ctx, defaultCallTimeout, "agent", "list")
+	if err != nil {
+		return nil, err
+	}
+	var env struct {
+		Result struct {
+			Agents *[]Agent `json:"agents"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("decode agent list: %w", err)
+	}
+	if env.Result.Agents == nil {
+		return nil, fmt.Errorf("%w: agent list missing agents", ErrDegraded)
+	}
+	return *env.Result.Agents, nil
+}
+
+// PaneCurrent runs `herdr pane current --pane <paneID>`.
+func (c *Client) PaneCurrent(ctx context.Context, paneID string) (Pane, error) {
+	raw, err := c.output(ctx, defaultCallTimeout, "pane", "current", "--pane", paneID)
+	if err != nil {
+		return Pane{}, err
+	}
+	var env struct {
+		Result struct {
+			PaneID      string `json:"pane_id"`      //nolint:tagliatelle // herdr/brief wire format
+			TabID       string `json:"tab_id"`       //nolint:tagliatelle // herdr/brief wire format
+			WorkspaceID string `json:"workspace_id"` //nolint:tagliatelle // herdr/brief wire format
+			Pane        *Pane  `json:"pane"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return Pane{}, fmt.Errorf("decode pane current: %w", err)
+	}
+	if env.Result.PaneID != "" {
+		return Pane{
+			PaneID:      env.Result.PaneID,
+			TabID:       env.Result.TabID,
+			WorkspaceID: env.Result.WorkspaceID,
+		}, nil
+	}
+	if env.Result.Pane != nil && env.Result.Pane.PaneID != "" {
+		return *env.Result.Pane, nil
+	}
+	return Pane{}, fmt.Errorf("%w: pane current missing pane", ErrDegraded)
+}
+
+// RunnerPane returns HERDR_PANE_ID. An unset value must not call pane current.
+func (c *Client) RunnerPane(ctx context.Context) string {
+	paneID := os.Getenv("HERDR_PANE_ID")
+	if paneID == "" {
+		return ""
+	}
+	_, _ = c.PaneCurrent(ctx, paneID)
+	return paneID
+}
+
+// Prompt runs `herdr agent prompt` and maps the process result to a PromptOutcome.
+func (c *Client) Prompt(ctx context.Context, paneID, text string, until []string, timeout time.Duration) PromptOutcome {
+	args := []string{"agent", "prompt", paneID, text, "--wait"}
+	for _, tok := range until {
+		args = append(args, "--until", tok)
+	}
+	args = append(args, "--timeout", strconv.FormatInt(timeout.Milliseconds(), 10))
+
+	result, err := c.execute(ctx, timeout+promptTimeoutGrace, args...)
+	if err != nil {
+		return PromptOutcome{Status: PromptError, Err: err}
+	}
+	if result.ExitCode == 0 {
+		if agent, ok := parsePromptAgent(result.Output); ok {
+			return PromptOutcome{Status: PromptMatched, Agent: agent}
+		}
+	}
+	if code := promptErrorCode(result.Stderr, result.Output); code != "" {
+		switch code {
+		case "agent_prompt_stalled":
+			return PromptOutcome{Status: PromptStalled}
+		case "timeout":
+			return PromptOutcome{Status: PromptTimeout}
+		default:
+			return PromptOutcome{Status: PromptError, Err: fmt.Errorf("herdr prompt: %s", code)}
+		}
+	}
+	if ctx.Err() != nil {
+		return PromptOutcome{Status: PromptError, Err: ctx.Err()}
+	}
+	return PromptOutcome{Status: PromptError, Err: fmt.Errorf("herdr prompt: unparseable result")}
+}
+
+func (c *Client) output(ctx context.Context, timeout time.Duration, args ...string) ([]byte, error) {
+	result, err := c.execute(ctx, timeout, args...)
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		return nil, &ProcError{ExitCode: result.ExitCode, Stdout: result.Output, Stderr: result.Stderr}
+	}
+	return []byte(result.Output), nil
+}
+
+func (c *Client) execute(ctx context.Context, timeout time.Duration, args ...string) (*executor.ExecutionResult, error) {
+	result, err := c.exec.Execute(ctx, executor.ToolConfig{
+		Command: c.bin,
+		Args:    args,
+		Timeout: timeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("run %s: %w", c.bin, err)
+	}
+	return result, nil
+}
+
+func parseHerdrVersion(text string) (string, bool) {
+	m := herdrVersionRe.FindStringSubmatch(text)
+	if m == nil {
+		return "", false
+	}
+	if _, ok := parseDotVersion(m[1]); !ok {
+		return "", false
+	}
+	return m[1], true
+}
+
+func compareVersions(a, b string) (int, bool) {
+	as, ok := parseDotVersion(a)
+	if !ok {
+		return 0, false
+	}
+	bs, ok := parseDotVersion(b)
+	if !ok {
+		return 0, false
+	}
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(as) {
+			av = as[i]
+		}
+		if i < len(bs) {
+			bv = bs[i]
+		}
+		if av < bv {
+			return -1, true
+		}
+		if av > bv {
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+func parseDotVersion(s string) ([]int, bool) {
+	if s == "" {
+		return nil, false
+	}
+	parts := strings.Split(s, ".")
+	out := make([]int, len(parts))
+	for i, p := range parts {
+		if p == "" {
+			return nil, false
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, false
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
+func parsePromptAgent(raw string) (Agent, bool) {
+	var env struct {
+		Result *struct {
+			Agent *Agent `json:"agent"`
+		} `json:"result"`
+	}
+	if json.Unmarshal([]byte(raw), &env) != nil || env.Result == nil || env.Result.Agent == nil {
+		return Agent{}, false
+	}
+	if env.Result.Agent.PaneID == "" {
+		return Agent{}, false
+	}
+	return *env.Result.Agent, true
+}
+
+func promptErrorCode(blobs ...string) string {
+	for _, raw := range blobs {
+		if code, ok := jsonErrorCode(raw); ok {
+			return code
+		}
+	}
+	return ""
+}
+
+func jsonErrorCode(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	var env struct {
+		Error *struct {
+			Code string `json:"code"`
+			Type string `json:"type"`
+		} `json:"error"`
+		Code string `json:"code"`
+	}
+	if json.Unmarshal([]byte(raw), &env) != nil {
+		return "", false
+	}
+	if env.Error != nil {
+		if env.Error.Code != "" {
+			return env.Error.Code, true
+		}
+		if env.Error.Type != "" {
+			return env.Error.Type, true
+		}
+	}
+	if env.Code != "" {
+		return env.Code, true
+	}
+	return "", false
+}

--- a/devtools/prsync/internal/herdr/client_test.go
+++ b/devtools/prsync/internal/herdr/client_test.go
@@ -1,0 +1,401 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+const testHerdrBin = "/tmp/prsync-herdr-fake"
+
+const tabListJSON = `{
+  "result": {
+    "tabs": [
+      {
+        "tab_id": "w2:tC",
+        "workspace_id": "w2",
+        "label": "PROJ-123",
+        "agent_status": "idle",
+        "pane_count": 1
+      }
+    ]
+  }
+}`
+
+const agentListJSON = `{
+  "result": {
+    "agents": [
+      {
+        "pane_id": "w2:pC",
+        "tab_id": "w2:tC",
+        "agent": "codex",
+        "agent_status": "idle"
+      }
+    ]
+  }
+}`
+
+const paneCurrentJSON = `{
+  "result": {
+    "pane_id": "w2:pC",
+    "tab_id": "w2:tC",
+    "workspace_id": "w2"
+  }
+}`
+
+const paneCurrentNestedJSON = `{
+  "result": {
+    "pane": {
+      "pane_id": "w2:pC",
+      "tab_id": "w2:tC",
+      "workspace_id": "w2"
+    }
+  }
+}`
+
+const promptSuccessJSON = `{
+  "result": {
+    "agent": {
+      "pane_id": "w2:pC",
+      "tab_id": "w2:tC",
+      "agent": "codex",
+      "agent_status": "idle"
+    }
+  }
+}`
+
+func TestRequireMin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+		wantErr error
+	}{
+		{name: "0.8.1", output: "herdr 0.8.1\n"},
+		{name: "0.8", output: "herdr 0.8\n"},
+		{name: "0.7.9", output: "herdr 0.7.9\n", wantErr: ErrUnsupported},
+		{name: "garbage", output: "herdr bananas\n", wantErr: ErrUnsupported},
+		{
+			name:    "missing binary",
+			execErr: &executor.ExecutableNotFoundError{Command: testHerdrBin},
+			wantErr: ErrNotInstalled,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := newHerdrMock()
+			exp := mock.ExpectCommandWithArgs(testHerdrBin, "--version")
+			if tc.execErr != nil {
+				exp.WillError(tc.execErr).Build()
+			} else {
+				exp.WillSucceed(tc.output, 0).Build()
+			}
+			err := NewClient(mock, testHerdrBin).RequireMin(context.Background(), "0.8.0")
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("RequireMin() unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("RequireMin() error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestTabList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses envelope", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "tab", "list").WillSucceed(tabListJSON, 0).Build()
+		got, err := NewClient(mock, testHerdrBin).TabList(context.Background())
+		if err != nil {
+			t.Fatalf("TabList() unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].TabID != "w2:tC" || got[0].Label != "PROJ-123" {
+			t.Fatalf("TabList() = %+v", got)
+		}
+	})
+
+	t.Run("missing tabs is degraded", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "tab", "list").
+			WillSucceed(`{"result":{}}`, 0).Build()
+		_, err := NewClient(mock, testHerdrBin).TabList(context.Background())
+		if !errors.Is(err, ErrDegraded) {
+			t.Fatalf("TabList() error = %v, want ErrDegraded", err)
+		}
+	})
+
+	t.Run("empty tabs is ok", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "tab", "list").
+			WillSucceed(`{"result":{"tabs":[]}}`, 0).Build()
+		got, err := NewClient(mock, testHerdrBin).TabList(context.Background())
+		if err != nil {
+			t.Fatalf("TabList() unexpected error: %v", err)
+		}
+		if got == nil || len(got) != 0 {
+			t.Fatalf("TabList() = %#v, want empty slice", got)
+		}
+	})
+}
+
+func TestAgentList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses envelope", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "agent", "list").WillSucceed(agentListJSON, 0).Build()
+		got, err := NewClient(mock, testHerdrBin).AgentList(context.Background())
+		if err != nil {
+			t.Fatalf("AgentList() unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].PaneID != "w2:pC" || got[0].Agent != "codex" {
+			t.Fatalf("AgentList() = %+v", got)
+		}
+	})
+
+	t.Run("missing agents is degraded", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "agent", "list").
+			WillSucceed(`{"result":{}}`, 0).Build()
+		_, err := NewClient(mock, testHerdrBin).AgentList(context.Background())
+		if !errors.Is(err, ErrDegraded) {
+			t.Fatalf("AgentList() error = %v, want ErrDegraded", err)
+		}
+	})
+}
+
+func TestPaneCurrent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flat result", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "pane", "current", "--pane", "w2:pC").
+			WillSucceed(paneCurrentJSON, 0).Build()
+		got, err := NewClient(mock, testHerdrBin).PaneCurrent(context.Background(), "w2:pC")
+		if err != nil {
+			t.Fatalf("PaneCurrent() unexpected error: %v", err)
+		}
+		if got.PaneID != "w2:pC" || got.TabID != "w2:tC" || got.WorkspaceID != "w2" {
+			t.Fatalf("PaneCurrent() = %+v", got)
+		}
+	})
+
+	t.Run("nested pane", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "pane", "current", "--pane", "w2:pC").
+			WillSucceed(paneCurrentNestedJSON, 0).Build()
+		got, err := NewClient(mock, testHerdrBin).PaneCurrent(context.Background(), "w2:pC")
+		if err != nil {
+			t.Fatalf("PaneCurrent() unexpected error: %v", err)
+		}
+		if got.PaneID != "w2:pC" {
+			t.Fatalf("PaneCurrent() = %+v", got)
+		}
+	})
+}
+
+func TestRunnerPaneUnsetDoesNotCallPaneCurrent(t *testing.T) {
+	t.Setenv("HERDR_PANE_ID", "")
+	mock := newHerdrMock()
+	mock.ExpectCommandWithArgs(testHerdrBin, "pane", "current", "--pane", "w2:pFocus").
+		WillSucceed(`{"result":{"pane_id":"w2:pFocus","tab_id":"w2:tFocus","workspace_id":"w2"}}`, 0).Build()
+
+	got := NewClient(mock, testHerdrBin).RunnerPane(context.Background())
+	if got != "" {
+		t.Fatalf("RunnerPane() = %q, want empty", got)
+	}
+	for _, call := range mock.GetCallHistory() {
+		if looksLikePaneCurrent(call.Config.Args) {
+			t.Fatalf("pane current was called: %v", call.Config.Args)
+		}
+	}
+}
+
+func TestRunnerPaneSetKeepsEnvOnVerifyError(t *testing.T) {
+	t.Setenv("HERDR_PANE_ID", "w2:pC")
+	mock := newHerdrMock()
+	mock.ExpectCommandWithArgs(testHerdrBin, "pane", "current", "--pane", "w2:pC").
+		WillError(errors.New("transport")).Build()
+
+	got := NewClient(mock, testHerdrBin).RunnerPane(context.Background())
+	if got != "w2:pC" {
+		t.Fatalf("RunnerPane() = %q, want %q", got, "w2:pC")
+	}
+}
+
+func TestPrompt(t *testing.T) {
+	t.Parallel()
+
+	until := []string{"idle", "done"}
+	timeout := 30 * time.Second
+
+	t.Run("matched", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		expectPrompt(mock).WillSucceed(promptSuccessJSON, 0).Build()
+		out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", until, timeout)
+		if out.Status != PromptMatched {
+			t.Fatalf("status = %q, want %q (err=%v)", out.Status, PromptMatched, out.Err)
+		}
+		if out.Agent.PaneID != "w2:pC" || out.Agent.AgentStatus != "idle" {
+			t.Fatalf("agent = %+v", out.Agent)
+		}
+	})
+
+	t.Run("stalled", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		expectPrompt(mock).WillReturn(&executor.ExecutionResult{
+			Stderr:   `{"error":{"code":"agent_prompt_stalled","message":"agent did not change state within 5s"}}`,
+			ExitCode: 1,
+		}, nil).Build()
+		out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", until, timeout)
+		if out.Status != PromptStalled {
+			t.Fatalf("status = %q, want %q (err=%v)", out.Status, PromptStalled, out.Err)
+		}
+	})
+
+	t.Run("herdr timeout code", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		expectPrompt(mock).WillReturn(&executor.ExecutionResult{
+			Stderr:   `{"error":{"code":"timeout","message":"wait exceeded timeout_ms"}}`,
+			ExitCode: 1,
+		}, nil).Build()
+		out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", until, timeout)
+		if out.Status != PromptTimeout {
+			t.Fatalf("status = %q, want %q (err=%v)", out.Status, PromptTimeout, out.Err)
+		}
+	})
+
+	t.Run("process kill is PromptError", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		expectPrompt(mock).WillTimeout(timeout + 5*time.Second).Build()
+		out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", until, timeout)
+		if out.Status != PromptError {
+			t.Fatalf("status = %q, want %q", out.Status, PromptError)
+		}
+		var timeoutErr *executor.TimeoutError
+		if !errors.As(out.Err, &timeoutErr) {
+			t.Fatalf("err = %v, want TimeoutError", out.Err)
+		}
+	})
+
+	t.Run("unparseable is PromptError", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		expectPrompt(mock).WillSucceed("not-json", 0).Build()
+		out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", until, timeout)
+		if out.Status != PromptError {
+			t.Fatalf("status = %q, want %q", out.Status, PromptError)
+		}
+	})
+
+	t.Run("passes until flags and timeout ms", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		var saw []string
+		mock.ExpectCustom(func(_ context.Context, cfg executor.ToolConfig) bool {
+			if cfg.Command != testHerdrBin {
+				return false
+			}
+			saw = append([]string(nil), cfg.Args...)
+			return true
+		}).WillSucceed(promptSuccessJSON, 0).Build()
+		_ = NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", until, timeout)
+		wantPrefix := []string{"agent", "prompt", "w2:pC", "hello", "--wait", "--until", "idle", "--until", "done", "--timeout", "30000"}
+		if !equalStrings(saw, wantPrefix) {
+			t.Fatalf("args = %v, want %v", saw, wantPrefix)
+		}
+	})
+}
+
+func newHerdrMock() *executor.MockExecutor {
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand(testHerdrBin, true)
+	return mock
+}
+
+func expectPrompt(mock *executor.MockExecutor) *executor.MockExpectationBuilder {
+	return mock.ExpectCustom(func(_ context.Context, cfg executor.ToolConfig) bool {
+		return cfg.Command == testHerdrBin && len(cfg.Args) >= 4 &&
+			cfg.Args[0] == "agent" && cfg.Args[1] == "prompt"
+	})
+}
+
+func looksLikePaneCurrent(args []string) bool {
+	return len(args) >= 2 && args[0] == "pane" && args[1] == "current"
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPromptErrorCodeLookupOrder(t *testing.T) {
+	t.Parallel()
+	mock := newHerdrMock()
+	expectPrompt(mock).WillReturn(&executor.ExecutionResult{
+		Output:   `{"error":{"type":"agent_prompt_stalled"},"code":"timeout"}`,
+		ExitCode: 1,
+	}, nil).Build()
+	out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", []string{"idle"}, time.Second)
+	if out.Status != PromptStalled {
+		t.Fatalf("status = %q, want stalled from error.type before top-level code (err=%v)", out.Status, out.Err)
+	}
+}
+
+func TestRequireMinUsesStderr(t *testing.T) {
+	t.Parallel()
+	mock := newHerdrMock()
+	mock.ExpectCommandWithArgs(testHerdrBin, "--version").WillReturn(&executor.ExecutionResult{
+		Stderr:   "herdr 0.8.1\n",
+		ExitCode: 0,
+	}, nil).Build()
+	if err := NewClient(mock, testHerdrBin).RequireMin(context.Background(), "0.8.0"); err != nil {
+		t.Fatalf("RequireMin() unexpected error: %v", err)
+	}
+}
+
+func TestPromptOtherCodeIsError(t *testing.T) {
+	t.Parallel()
+	mock := newHerdrMock()
+	expectPrompt(mock).WillReturn(&executor.ExecutionResult{
+		Stderr:   `{"error":{"code":"pane_not_found","message":"nope"}}`,
+		ExitCode: 1,
+	}, nil).Build()
+	out := NewClient(mock, testHerdrBin).Prompt(context.Background(), "w2:pC", "hello", []string{"idle"}, time.Second)
+	if out.Status != PromptError {
+		t.Fatalf("status = %q, want %q", out.Status, PromptError)
+	}
+	if out.Err == nil || !strings.Contains(out.Err.Error(), "pane_not_found") {
+		t.Fatalf("err = %v, want pane_not_found", out.Err)
+	}
+}

--- a/devtools/prsync/internal/herdr/types.go
+++ b/devtools/prsync/internal/herdr/types.go
@@ -1,0 +1,78 @@
+// Package herdr talks to herdr through its CLI.
+package herdr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotInstalled is returned when herdr_bin is missing from PATH.
+var ErrNotInstalled = errors.New("herdr not installed")
+
+// ErrUnsupported is returned when --version is unparseable or older than the minimum.
+var ErrUnsupported = errors.New("herdr version unsupported")
+
+// ErrDegraded is returned when a herdr success envelope is missing an expected field.
+var ErrDegraded = errors.New("herdr response missing expected fields")
+
+// ProcError is a non-zero process exit from herdr.
+type ProcError struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+func (e *ProcError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Stderr != "" {
+		return e.Stderr
+	}
+	if e.Stdout != "" {
+		return e.Stdout
+	}
+	return fmt.Sprintf("exit %d", e.ExitCode)
+}
+
+// Tab is one herdr tab from `herdr tab list`.
+type Tab struct {
+	TabID       string `json:"tab_id"`       //nolint:tagliatelle // herdr/brief wire format
+	WorkspaceID string `json:"workspace_id"` //nolint:tagliatelle // herdr/brief wire format
+	Label       string `json:"label"`
+	AgentStatus string `json:"agent_status"` //nolint:tagliatelle // herdr/brief wire format
+	PaneCount   int    `json:"pane_count"`   //nolint:tagliatelle // herdr/brief wire format
+}
+
+// Agent is one herdr agent from `herdr agent list`.
+type Agent struct {
+	PaneID      string `json:"pane_id"` //nolint:tagliatelle // herdr/brief wire format
+	TabID       string `json:"tab_id"`  //nolint:tagliatelle // herdr/brief wire format
+	Agent       string `json:"agent"`
+	AgentStatus string `json:"agent_status"` //nolint:tagliatelle // herdr/brief wire format
+}
+
+// Pane is the focused or addressed pane from `herdr pane current`.
+type Pane struct {
+	PaneID      string `json:"pane_id"`      //nolint:tagliatelle // herdr/brief wire format
+	TabID       string `json:"tab_id"`       //nolint:tagliatelle // herdr/brief wire format
+	WorkspaceID string `json:"workspace_id"` //nolint:tagliatelle // herdr/brief wire format
+}
+
+// PromptStatus is the classified outcome of `herdr agent prompt`.
+type PromptStatus string
+
+// Prompt outcome values.
+const (
+	PromptMatched PromptStatus = "matched"
+	PromptStalled PromptStatus = "stalled"
+	PromptTimeout PromptStatus = "timeout"
+	PromptError   PromptStatus = "error"
+)
+
+// PromptOutcome is the mapped result of AgentPrompt.
+type PromptOutcome struct {
+	Status PromptStatus
+	Agent  Agent
+	Err    error
+}


### PR DESCRIPTION
## Summary
- Add `internal/gh` and `internal/herdr` process adapters that shell out through `go-cmdexec` (`gh_bin` / `herdr_bin` from config).
- `gh`: `AuthStatus`, `UserLogin`, `SearchOpenPRRepos`, `ListOpenPRs`, and paginated `ReviewThreads`. Inaccessible is 404 / not-found / archived only; HTTP 403 (rate limit) is fatal.
- `herdr`: `RequireMin("0.8.0")` parsing `herdr ([0-9.]+)` (`ErrNotInstalled` vs `ErrUnsupported`); `TabList`, `AgentList`, `PaneCurrent`, and `Prompt` outcomes (`PromptMatched` / `PromptStalled` / `PromptTimeout` / `PromptError`).
- Unset `HERDR_PANE_ID` does not call `pane current`. No cobra subcommands beyond `version`.
- Commit pinned JSON fixtures and executable, shellcheck-clean `gh-fake.sh` / `herdr-fake.sh`.

## Why
PR 2 of the #211 prsync plan. Later PRs add `scan`, `gate`, and `dispatch` on top of these adapters.

## Test plan
- [x] `MockExecutor` version-parse table: `0.8.1` / `0.8` / `0.7.9` / garbage / missing binary
- [x] Inaccessible 404/archived vs fatal HTTP 403; GraphQL pagination and 50-page cap
- [x] Prompt outcome mapping and unset `HERDR_PANE_ID` does not call `pane current`
- [x] Fixture scripts executable and shellcheck-clean
- [x] `make check`

Resolves #214