### PR TITLE
feat(prsync): classify PRs, paginate review threads, and match herdr tabs

### DIFF
--- a/devtools/prsync/internal/cli/cli_scan_test.go
+++ b/devtools/prsync/internal/cli/cli_scan_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestScanBadRepo(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"scan", "--repo", "not-a-repo"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid repo") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestScanGHMissing(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeScanConfig(t, "gh_bin=prsync-test-missing-gh\nherdr_bin=herdr\nauthor=alice\nrepos=acme/widgets\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"scan", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gh binary not found") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty before work starts", stdout.String())
+	}
+}
+
+func TestScanFixtureHappyPath(t *testing.T) {
+	t.Parallel()
+
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"scan", "--config", cfgPath, "--json"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+
+	var doc scan.Document
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if doc.Author != "alice" {
+		t.Fatalf("author = %q, want alice", doc.Author)
+	}
+	if len(doc.PRs) != 1 || doc.PRs[0].Number != 123 {
+		t.Fatalf("prs = %+v", doc.PRs)
+	}
+	if doc.PRs[0].Bucket != "needs_you" {
+		t.Fatalf("bucket = %q, want needs_you", doc.PRs[0].Bucket)
+	}
+	if doc.PRs[0].Tab == nil || doc.PRs[0].Tab.TabID != "w2:tC" {
+		t.Fatalf("tab = %+v, want w2:tC", doc.PRs[0].Tab)
+	}
+	if doc.PRs[0].Tab.PaneID == nil || *doc.PRs[0].Tab.PaneID != "w2:pC" {
+		t.Fatalf("pane_id = %v, want w2:pC", doc.PRs[0].Tab.PaneID)
+	}
+}
+
+func TestScanHerdrMissingDegrades(t *testing.T) {
+	t.Parallel()
+
+	ghBin, _ := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin=prsync-test-missing-herdr\nauthor=alice\nrepos=acme/widgets\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"scan", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want 0, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var doc scan.Document
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if len(doc.PRs) != 1 || doc.PRs[0].Tab != nil {
+		t.Fatalf("tab = %+v, want nil", doc.PRs[0].Tab)
+	}
+	if len(doc.Warnings) == 0 || !strings.Contains(doc.Warnings[0], "herdr unreachable") {
+		t.Fatalf("warnings = %v", doc.Warnings)
+	}
+}
+
+func writeScanConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prsync.config")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func fixtureBins(t *testing.T) (ghBin, herdrBin string) {
+	t.Helper()
+	ghBin, err := filepath.Abs(filepath.Join("testdata", "fixtures", "gh-fake.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	herdrBin, err = filepath.Abs(filepath.Join("testdata", "fixtures", "herdr-fake.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ghBin, herdrBin
+}

--- a/devtools/prsync/internal/cli/cli_test.go
+++ b/devtools/prsync/internal/cli/cli_test.go
@@ -45,10 +45,10 @@ func TestUnknownCommand(t *testing.T) {
 	}
 }
 
-func TestNoCommandsBeyondVersion(t *testing.T) {
+func TestNoCommandsBeyondVersionAndScan(t *testing.T) {
 	t.Parallel()
 
-	for _, name := range []string{"scan", "dispatch", "gate"} {
+	for _, name := range []string{"dispatch", "gate"} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var stdout, stderr bytes.Buffer

--- a/devtools/prsync/internal/cli/root.go
+++ b/devtools/prsync/internal/cli/root.go
@@ -11,15 +11,14 @@ import (
 
 // Execute runs the prsync CLI with injected IO and returns an exit code.
 func Execute(ctx context.Context, args []string, stdout, stderr io.Writer, exec executor.Executor) int {
-	_ = exec
-	root := newRoot(stdout)
+	root := newRoot(stdout, exec)
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
 	return report(stderr, root.ExecuteContext(ctx))
 }
 
-func newRoot(stdout io.Writer) *cobra.Command {
+func newRoot(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	root := &cobra.Command{
 		Use:           "prsync",
 		Short:         "Survey open GitHub PRs and match them to herdr agent tabs",
@@ -29,5 +28,6 @@ func newRoot(stdout io.Writer) *cobra.Command {
 		},
 	}
 	root.AddCommand(newVersionCmd(stdout))
+	root.AddCommand(newScanCmd(stdout, exec))
 	return root
 }

--- a/devtools/prsync/internal/cli/scan.go
+++ b/devtools/prsync/internal/cli/scan.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+	executor "github.com/jaeyeom/go-cmdexec"
+	"github.com/spf13/cobra"
+)
+
+var repoFlagPattern = regexp.MustCompile(`^[^/\s]+/[^/\s]+$`)
+
+func newScanCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
+	var (
+		configPath string
+		repos      []string
+		jsonFlag   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "scan",
+		Short: "Survey open GitHub PRs and match them to herdr tabs",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_ = jsonFlag
+			if err := validateRepoFlags(repos); err != nil {
+				return &ExitError{Code: ExitUsage, Err: err}
+			}
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			deps := scan.Deps{
+				GH:    gh.NewClient(exec, cfg.GHBin),
+				Herdr: herdr.NewClient(exec, cfg.HerdrBin),
+			}
+			doc, err := scan.Run(cmd.Context(), deps, cfg, repos, time.Now())
+			if scan.Started(doc) {
+				if werr := writeJSON(stdout, doc); werr != nil {
+					return werr
+				}
+			}
+			if err != nil {
+				return scanExit(err, cfg)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
+	cmd.Flags().StringArrayVar(&repos, "repo", nil, "replace repos list (repeatable owner/repo)")
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "accepted, no-op (stdout is always JSON)")
+	return cmd
+}
+
+func validateRepoFlags(repos []string) error {
+	for _, repo := range repos {
+		if !repoFlagPattern.MatchString(repo) {
+			return fmt.Errorf("invalid repo %q", repo)
+		}
+	}
+	return nil
+}
+
+func writeJSON(w io.Writer, doc scan.Document) error {
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode scan: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", out); err != nil {
+		return fmt.Errorf("write scan: %w", err)
+	}
+	return nil
+}
+
+func scanExit(err error, cfg config.Config) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &ExitError{Code: ExitPrecondition, Err: errors.New("interrupted")}
+	}
+	var notFound *executor.ExecutableNotFoundError
+	if errors.As(err, &notFound) {
+		return &ExitError{Code: ExitPrecondition, Err: fmt.Errorf("gh binary not found (gh_bin=%q)", cfg.GHBin)}
+	}
+	if errors.Is(err, gh.ErrUnauthenticated) {
+		return &ExitError{Code: ExitPrecondition, Err: errors.New("gh is not authenticated; run: gh auth login")}
+	}
+	if errors.Is(err, herdr.ErrUnsupported) {
+		return &ExitError{Code: ExitPrecondition, Err: herdrUnsupportedMessage(err, cfg.HerdrBin)}
+	}
+	return &ExitError{Code: ExitPrecondition, Err: err}
+}
+
+func herdrUnsupportedMessage(err error, bin string) error {
+	msg := err.Error()
+	const older = " is older than "
+	if i := strings.Index(msg, "herdr "); i >= 0 {
+		rest := msg[i+len("herdr "):]
+		if j := strings.Index(rest, older); j >= 0 {
+			return fmt.Errorf("herdr %s is older than 0.8 (herdr_bin=%q)", rest[:j], bin)
+		}
+	}
+	const prefix = "cannot parse herdr version from "
+	if i := strings.Index(msg, prefix); i >= 0 {
+		raw := strings.Trim(msg[i+len(prefix):], `"`)
+		return fmt.Errorf("cannot parse herdr version from %q", raw)
+	}
+	return err
+}

--- a/devtools/prsync/internal/scan/BUILD.bazel
+++ b/devtools/prsync/internal/scan/BUILD.bazel
@@ -3,36 +3,37 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "exit.go",
-        "root.go",
+        "bucket.go",
+        "ci.go",
+        "identifier.go",
+        "match.go",
         "scan.go",
-        "version.go",
+        "types.go",
     ],
-    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/cli",
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/scan",
     visibility = ["//devtools/prsync:__subpackages__"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",
         "//devtools/prsync/internal/gh:go_default_library",
         "//devtools/prsync/internal/herdr:go_default_library",
-        "//devtools/prsync/internal/scan:go_default_library",
-        "//devtools/prsync/internal/version:go_default_library",
-        "@com_github_jaeyeom_go_cmdexec//:go_default_library",
-        "@com_github_spf13_cobra//:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
-        "cli_scan_test.go",
-        "cli_test.go",
+        "bucket_test.go",
+        "ci_test.go",
+        "identifier_test.go",
+        "match_test.go",
+        "scan_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",
-        "//devtools/prsync/internal/scan:go_default_library",
-        "//devtools/prsync/internal/version:go_default_library",
+        "//devtools/prsync/internal/gh:go_default_library",
+        "//devtools/prsync/internal/herdr:go_default_library",
         "@com_github_jaeyeom_go_cmdexec//:go_default_library",
     ],
 )

--- a/devtools/prsync/internal/scan/bucket.go
+++ b/devtools/prsync/internal/scan/bucket.go
@@ -1,0 +1,32 @@
+package scan
+
+// PRFacts is the I/O-free input to readiness classification.
+type PRFacts struct {
+	Unaddressed    bool
+	CIState        string
+	ReviewDecision string
+	ReviewRequests []string
+	IsDraft        bool
+	Mergeable      string
+}
+
+// Bucket returns needs_you | draft | waiting | ready.
+func Bucket(p PRFacts) string {
+	needsYou := p.Unaddressed ||
+		p.CIState == "failing" ||
+		(p.ReviewDecision == "APPROVED" && len(p.ReviewRequests) > 0)
+	if needsYou {
+		return "needs_you"
+	}
+	if p.IsDraft {
+		return "draft"
+	}
+	if !p.IsDraft &&
+		p.ReviewDecision == "APPROVED" &&
+		len(p.ReviewRequests) == 0 &&
+		p.CIState == "green" &&
+		p.Mergeable != "CONFLICTING" {
+		return "ready"
+	}
+	return "waiting"
+}

--- a/devtools/prsync/internal/scan/bucket_test.go
+++ b/devtools/prsync/internal/scan/bucket_test.go
@@ -1,0 +1,120 @@
+package scan
+
+import (
+	"testing"
+)
+
+func TestBucket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		facts PRFacts
+		want  string
+	}{
+		{
+			name:  "draft plus failing CI is needs_you",
+			facts: PRFacts{IsDraft: true, CIState: "failing"},
+			want:  "needs_you",
+		},
+		{
+			name:  "draft plus unaddressed is needs_you",
+			facts: PRFacts{IsDraft: true, Unaddressed: true, CIState: "green"},
+			want:  "needs_you",
+		},
+		{
+			name:  "draft otherwise is draft",
+			facts: PRFacts{IsDraft: true, CIState: "green", ReviewDecision: "APPROVED"},
+			want:  "draft",
+		},
+		{
+			name: "approved with outstanding requests is needs_you",
+			facts: PRFacts{
+				ReviewDecision: "APPROVED",
+				ReviewRequests: []string{"User:reviewer"},
+				CIState:        "green",
+				Mergeable:      "MERGEABLE",
+			},
+			want: "needs_you",
+		},
+		{
+			name: "approved green mergeable is ready",
+			facts: PRFacts{
+				ReviewDecision: "APPROVED",
+				CIState:        "green",
+				Mergeable:      "MERGEABLE",
+			},
+			want: "ready",
+		},
+		{
+			name: "approved green unknown mergeable is still ready",
+			facts: PRFacts{
+				ReviewDecision: "APPROVED",
+				CIState:        "green",
+				Mergeable:      "UNKNOWN",
+			},
+			want: "ready",
+		},
+		{
+			name: "approved green conflicting is waiting",
+			facts: PRFacts{
+				ReviewDecision: "APPROVED",
+				CIState:        "green",
+				Mergeable:      "CONFLICTING",
+			},
+			want: "waiting",
+		},
+		{
+			name: "changes requested is waiting",
+			facts: PRFacts{
+				ReviewDecision: "CHANGES_REQUESTED",
+				CIState:        "green",
+				Mergeable:      "MERGEABLE",
+			},
+			want: "waiting",
+		},
+		{
+			name: "review required is waiting",
+			facts: PRFacts{
+				ReviewDecision: "REVIEW_REQUIRED",
+				CIState:        "green",
+				Mergeable:      "MERGEABLE",
+			},
+			want: "waiting",
+		},
+		{
+			name:  "empty decision is waiting",
+			facts: PRFacts{CIState: "green", Mergeable: "MERGEABLE"},
+			want:  "waiting",
+		},
+		{
+			name: "pending CI is waiting",
+			facts: PRFacts{
+				ReviewDecision: "APPROVED",
+				CIState:        "pending",
+				Mergeable:      "MERGEABLE",
+			},
+			want: "waiting",
+		},
+		{
+			name:  "failing CI is needs_you",
+			facts: PRFacts{CIState: "failing"},
+			want:  "needs_you",
+		},
+		{
+			name:  "unaddressed comments are needs_you",
+			facts: PRFacts{Unaddressed: true, CIState: "green", ReviewDecision: "APPROVED"},
+			want:  "needs_you",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Bucket(tc.facts)
+			if got != tc.want {
+				t.Fatalf("Bucket() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/devtools/prsync/internal/scan/ci.go
+++ b/devtools/prsync/internal/scan/ci.go
@@ -1,0 +1,24 @@
+package scan
+
+import "github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+
+// CIState classifies statusCheckRollup into green | failing | pending | none.
+func CIState(checks []gh.StatusCheck) string {
+	if len(checks) == 0 {
+		return "none"
+	}
+	hasPending := false
+	for _, check := range checks {
+		switch check.Conclusion {
+		case "FAILURE", "CANCELLED", "ACTION_REQUIRED", "TIMED_OUT":
+			return "failing"
+		}
+		if check.Status != "COMPLETED" {
+			hasPending = true
+		}
+	}
+	if hasPending {
+		return "pending"
+	}
+	return "green"
+}

--- a/devtools/prsync/internal/scan/ci_test.go
+++ b/devtools/prsync/internal/scan/ci_test.go
@@ -1,0 +1,116 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+)
+
+func TestCIState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		checks []gh.StatusCheck
+		want   string
+	}{
+		{
+			name:   "no checks configured",
+			checks: nil,
+			want:   "none",
+		},
+		{
+			name:   "empty rollup",
+			checks: []gh.StatusCheck{},
+			want:   "none",
+		},
+		{
+			name: "all checks passing",
+			checks: []gh.StatusCheck{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "lint", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want: "green",
+		},
+		{
+			name: "one check failed",
+			checks: []gh.StatusCheck{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			want: "failing",
+		},
+		{
+			name: "one check cancelled",
+			checks: []gh.StatusCheck{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "deploy", Status: "COMPLETED", Conclusion: "CANCELLED"},
+			},
+			want: "failing",
+		},
+		{
+			name: "action required treated as failure",
+			checks: []gh.StatusCheck{
+				{Name: "review", Status: "COMPLETED", Conclusion: "ACTION_REQUIRED"},
+			},
+			want: "failing",
+		},
+		{
+			name: "timed out treated as failure",
+			checks: []gh.StatusCheck{
+				{Name: "e2e", Status: "COMPLETED", Conclusion: "TIMED_OUT"},
+			},
+			want: "failing",
+		},
+		{
+			name: "one check pending",
+			checks: []gh.StatusCheck{
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "test", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			want: "pending",
+		},
+		{
+			name: "queued check treated as pending",
+			checks: []gh.StatusCheck{
+				{Name: "build", Status: "QUEUED", Conclusion: ""},
+			},
+			want: "pending",
+		},
+		{
+			name: "failure takes priority over pending",
+			checks: []gh.StatusCheck{
+				{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "test", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			want: "failing",
+		},
+		{
+			name: "neutral treated as passing",
+			checks: []gh.StatusCheck{
+				{Name: "info", Status: "COMPLETED", Conclusion: "NEUTRAL"},
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want: "green",
+		},
+		{
+			name: "skipped treated as passing",
+			checks: []gh.StatusCheck{
+				{Name: "optional", Status: "COMPLETED", Conclusion: "SKIPPED"},
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want: "green",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := CIState(tc.checks)
+			if got != tc.want {
+				t.Fatalf("CIState() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/devtools/prsync/internal/scan/identifier.go
+++ b/devtools/prsync/internal/scan/identifier.go
@@ -1,0 +1,16 @@
+package scan
+
+import "regexp"
+
+// ExtractID returns the first title_id_pattern match, or nil if none.
+func ExtractID(title string, re *regexp.Regexp) *string {
+	if re == nil {
+		return nil
+	}
+	loc := re.FindStringIndex(title)
+	if loc == nil {
+		return nil
+	}
+	s := title[loc[0]:loc[1]]
+	return &s
+}

--- a/devtools/prsync/internal/scan/identifier_test.go
+++ b/devtools/prsync/internal/scan/identifier_test.go
@@ -1,0 +1,76 @@
+package scan
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestExtractID(t *testing.T) {
+	t.Parallel()
+
+	defaultRe := regexp.MustCompile(`[A-Z]+-[0-9]+`)
+
+	tests := []struct {
+		name  string
+		title string
+		re    *regexp.Regexp
+		want  *string
+	}{
+		{
+			name:  "bracketed jira key",
+			title: "[PROJ-123] foo",
+			re:    defaultRe,
+			want:  strPtr("PROJ-123"),
+		},
+		{
+			name:  "first of two keys",
+			title: "PROJ-1 and PROJ-2",
+			re:    defaultRe,
+			want:  strPtr("PROJ-1"),
+		},
+		{
+			name:  "no match",
+			title: "no key here",
+			re:    defaultRe,
+			want:  nil,
+		},
+		{
+			name:  "custom regex",
+			title: "ticket:42 extra",
+			re:    regexp.MustCompile(`ticket:\d+`),
+			want:  strPtr("ticket:42"),
+		},
+		{
+			name:  "lowercase title with case-insensitive regex",
+			title: "fix proj-9 now",
+			re:    regexp.MustCompile(`(?i)proj-[0-9]+`),
+			want:  strPtr("proj-9"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExtractID(tc.title, tc.re)
+			if !sameStringPtr(got, tc.want) {
+				t.Fatalf("ExtractID(%q) = %s, want %s", tc.title, formatPtr(got), formatPtr(tc.want))
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+func formatPtr(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}
+
+func sameStringPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/devtools/prsync/internal/scan/match.go
+++ b/devtools/prsync/internal/scan/match.go
@@ -1,0 +1,60 @@
+package scan
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+)
+
+// Match finds a unique herdr tab for the identifier. Never guesses on 0 or N.
+func Match(id *string, repo string, number int, template string, tabs []herdr.Tab, agents []herdr.Agent) (*Tab, string) {
+	if id == nil {
+		return nil, fmt.Sprintf("%s#%d: no identifier matched title_id_pattern", repo, number)
+	}
+	label := strings.ReplaceAll(template, "{id}", *id)
+	var hits []herdr.Tab
+	for _, tab := range tabs {
+		if tab.Label == label {
+			hits = append(hits, tab)
+		}
+	}
+	switch len(hits) {
+	case 0:
+		return nil, fmt.Sprintf("%s: identifier matched but no herdr tab labeled '%s'", *id, label)
+	case 1:
+		return attachAgent(*id, hits[0], agents)
+	default:
+		ids := make([]string, len(hits))
+		for i, tab := range hits {
+			ids[i] = tab.TabID
+		}
+		return nil, fmt.Sprintf("%s: ambiguous herdr tab label '%s' matches %s", *id, label, strings.Join(ids, ", "))
+	}
+}
+
+func attachAgent(id string, hit herdr.Tab, agents []herdr.Agent) (*Tab, string) {
+	var matched []herdr.Agent
+	for _, agent := range agents {
+		if agent.TabID == hit.TabID {
+			matched = append(matched, agent)
+		}
+	}
+	out := &Tab{
+		TabID:       hit.TabID,
+		WorkspaceID: hit.WorkspaceID,
+		Label:       hit.Label,
+		AgentStatus: "none",
+	}
+	switch len(matched) {
+	case 1:
+		pane := matched[0].PaneID
+		out.PaneID = &pane
+		out.AgentStatus = matched[0].AgentStatus
+		return out, ""
+	case 0:
+		return out, ""
+	default:
+		return out, fmt.Sprintf("%s: tab %s has %d agents; refusing to guess", id, hit.TabID, len(matched))
+	}
+}

--- a/devtools/prsync/internal/scan/match_test.go
+++ b/devtools/prsync/internal/scan/match_test.go
@@ -1,0 +1,133 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+)
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+
+	id := "PROJ-123"
+	tab := herdr.Tab{TabID: "w2:tC", WorkspaceID: "w2", Label: "PROJ-123", AgentStatus: "idle"}
+	wipTab := herdr.Tab{TabID: "w2:tW", WorkspaceID: "w2", Label: "wip/PROJ-123"}
+	agent := herdr.Agent{PaneID: "w2:pC", TabID: "w2:tC", Agent: "codex", AgentStatus: "idle"}
+
+	tests := []struct {
+		name       string
+		id         *string
+		repo       string
+		number     int
+		template   string
+		tabs       []herdr.Tab
+		agents     []herdr.Agent
+		wantNil    bool
+		wantTabID  string
+		wantPane   *string
+		wantStatus string
+		wantWarn   string
+	}{
+		{
+			name:     "zero tabs",
+			id:       &id,
+			template: "{id}",
+			wantNil:  true,
+			wantWarn: "PROJ-123: identifier matched but no herdr tab labeled 'PROJ-123'",
+		},
+		{
+			name:       "one tab one agent",
+			id:         &id,
+			template:   "{id}",
+			tabs:       []herdr.Tab{tab},
+			agents:     []herdr.Agent{agent},
+			wantTabID:  "w2:tC",
+			wantPane:   strPtr("w2:pC"),
+			wantStatus: "idle",
+		},
+		{
+			name:       "one tab zero agents",
+			id:         &id,
+			template:   "{id}",
+			tabs:       []herdr.Tab{tab},
+			wantTabID:  "w2:tC",
+			wantPane:   nil,
+			wantStatus: "none",
+		},
+		{
+			name:       "one tab two agents",
+			id:         &id,
+			template:   "{id}",
+			tabs:       []herdr.Tab{tab},
+			agents:     []herdr.Agent{agent, {PaneID: "w2:pD", TabID: "w2:tC", AgentStatus: "idle"}},
+			wantTabID:  "w2:tC",
+			wantPane:   nil,
+			wantStatus: "none",
+			wantWarn:   "PROJ-123: tab w2:tC has 2 agents; refusing to guess",
+		},
+		{
+			name:     "two tabs never guess",
+			id:       &id,
+			template: "{id}",
+			tabs:     []herdr.Tab{tab, {TabID: "w3:tC", WorkspaceID: "w3", Label: "PROJ-123"}},
+			wantNil:  true,
+			wantWarn: "PROJ-123: ambiguous herdr tab label 'PROJ-123' matches w2:tC, w3:tC",
+		},
+		{
+			name:       "wip template",
+			id:         &id,
+			template:   "wip/{id}",
+			tabs:       []herdr.Tab{wipTab},
+			agents:     []herdr.Agent{{PaneID: "w2:pW", TabID: "w2:tW", AgentStatus: "idle"}},
+			wantTabID:  "w2:tW",
+			wantPane:   strPtr("w2:pW"),
+			wantStatus: "idle",
+		},
+		{
+			name:     "case-sensitive miss",
+			id:       &id,
+			template: "{id}",
+			tabs:     []herdr.Tab{{TabID: "w2:tC", Label: "proj-123"}},
+			wantNil:  true,
+			wantWarn: "PROJ-123: identifier matched but no herdr tab labeled 'PROJ-123'",
+		},
+		{
+			name:     "no identifier",
+			id:       nil,
+			repo:     "acme/widgets",
+			number:   9,
+			template: "{id}",
+			tabs:     []herdr.Tab{tab},
+			wantNil:  true,
+			wantWarn: "acme/widgets#9: no identifier matched title_id_pattern",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, warn := Match(tc.id, tc.repo, tc.number, tc.template, tc.tabs, tc.agents)
+			if warn != tc.wantWarn {
+				t.Fatalf("warning = %q, want %q", warn, tc.wantWarn)
+			}
+			if got == nil {
+				if !tc.wantNil {
+					t.Fatal("tab is nil, want object")
+				}
+				return
+			}
+			if tc.wantNil {
+				t.Fatalf("tab = %+v, want nil", got)
+			}
+			if got.TabID != tc.wantTabID {
+				t.Errorf("tab_id = %q, want %q", got.TabID, tc.wantTabID)
+			}
+			if !sameStringPtr(got.PaneID, tc.wantPane) {
+				t.Errorf("pane_id = %s, want %s", formatPtr(got.PaneID), formatPtr(tc.wantPane))
+			}
+			if got.AgentStatus != tc.wantStatus {
+				t.Errorf("agent_status = %q, want %q", got.AgentStatus, tc.wantStatus)
+			}
+		})
+	}
+}

--- a/devtools/prsync/internal/scan/scan.go
+++ b/devtools/prsync/internal/scan/scan.go
@@ -1,0 +1,288 @@
+// Package scan classifies open PRs and matches them to herdr tabs.
+package scan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+)
+
+const herdrMinVersion = "0.8.0"
+
+// Deps is the injected GitHub and herdr adapters.
+type Deps struct {
+	GH    GH
+	Herdr Herdr
+}
+
+// GH is the GitHub surface scan uses.
+type GH interface {
+	AuthStatus(ctx context.Context) error
+	UserLogin(ctx context.Context) (string, error)
+	SearchOpenPRRepos(ctx context.Context, author string) (repos []string, capped bool, err error)
+	ListOpenPRs(ctx context.Context, repo, author string) ([]gh.PRListItem, error)
+	ReviewThreads(ctx context.Context, owner, repo string, number int) ([]gh.Thread, error)
+}
+
+// Herdr is the herdr surface scan uses.
+type Herdr interface {
+	RequireMin(ctx context.Context, minimum string) error
+	TabList(ctx context.Context) ([]herdr.Tab, error)
+	AgentList(ctx context.Context) ([]herdr.Agent, error)
+}
+
+// Started reports whether work began and a document should be emitted.
+func Started(doc Document) bool {
+	return doc.Author != "" || len(doc.Repos) > 0 || len(doc.PRs) > 0
+}
+
+// Run surveys open PRs. The returned document is the work so far; a non-nil
+// error is fatal (exit 3) after the caller writes that document when Started.
+func Run(ctx context.Context, deps Deps, cfg config.Config, repos []string, now time.Time) (Document, error) {
+	doc := emptyDocument(now)
+	if err := deps.GH.AuthStatus(ctx); err != nil {
+		return doc, fmt.Errorf("gh auth: %w", err)
+	}
+	author, err := resolveAuthor(ctx, deps.GH, cfg.Author)
+	if err != nil {
+		return doc, err
+	}
+	doc.Author = author
+	cfg.Author = author
+
+	resolved, err := resolveRepos(ctx, deps.GH, cfg, repos, &doc)
+	if err != nil {
+		return doc, err
+	}
+	doc.Repos = resolved
+
+	if err := classifyRepos(ctx, deps.GH, cfg, resolved, &doc); err != nil {
+		return doc, err
+	}
+	if err := matchTabs(ctx, deps.Herdr, cfg, &doc); err != nil {
+		return doc, err
+	}
+	return doc, nil
+}
+
+func emptyDocument(now time.Time) Document {
+	return Document{
+		GeneratedAt:       now.UTC().Format(time.RFC3339),
+		Repos:             []string{},
+		PRs:               []PR{},
+		InaccessibleRepos: []string{},
+		Warnings:          []string{},
+	}
+}
+
+func resolveAuthor(ctx context.Context, client GH, configured string) (string, error) {
+	if configured != "" {
+		return configured, nil
+	}
+	login, err := client.UserLogin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve author: %w", err)
+	}
+	return login, nil
+}
+
+func resolveRepos(ctx context.Context, client GH, cfg config.Config, override []string, doc *Document) ([]string, error) {
+	list := override
+	if len(list) == 0 {
+		list = cfg.Repos
+	}
+	if len(list) > 0 {
+		return dedupe(list), nil
+	}
+	found, capped, err := client.SearchOpenPRRepos(ctx, cfg.Author)
+	if err != nil {
+		return nil, fmt.Errorf("search prs: %w", err)
+	}
+	if capped {
+		warn(doc, "search result hit --limit 1000; some repos may be missing")
+	}
+	if found == nil {
+		found = []string{}
+	}
+	return found, nil
+}
+
+func classifyRepos(ctx context.Context, client GH, cfg config.Config, repos []string, doc *Document) error {
+	for _, repo := range repos {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("scan: %w", err)
+		}
+		prs, err := client.ListOpenPRs(ctx, repo, cfg.Author)
+		if err != nil {
+			if errors.Is(err, gh.ErrInaccessible) {
+				doc.InaccessibleRepos = append(doc.InaccessibleRepos, repo)
+				continue
+			}
+			return fmt.Errorf("list prs %s: %w", repo, err)
+		}
+		owner, name, err := splitRepo(repo)
+		if err != nil {
+			return err
+		}
+		for _, item := range prs {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("scan: %w", err)
+			}
+			classified, err := classifyPR(ctx, client, cfg, owner, name, repo, item)
+			if err != nil {
+				return err
+			}
+			doc.PRs = append(doc.PRs, classified)
+		}
+	}
+	return nil
+}
+
+func classifyPR(ctx context.Context, client GH, cfg config.Config, owner, name, repo string, item gh.PRListItem) (PR, error) {
+	threads, err := client.ReviewThreads(ctx, owner, name, item.Number)
+	if err != nil {
+		return PR{}, fmt.Errorf("%s#%d: %w", repo, item.Number, err)
+	}
+	comments := blockingComments(threads, cfg.Author)
+	id := ExtractID(item.Title, cfg.TitleIDPattern)
+	ci := CIState(item.StatusCheckRollup)
+	reqs := formatReviewRequests(item.ReviewRequests)
+	out := PR{
+		Repo:             repo,
+		Number:           item.Number,
+		Title:            item.Title,
+		URL:              item.URL,
+		Identifier:       id,
+		Base:             item.BaseRefName,
+		Head:             item.HeadRefName,
+		IsDraft:          item.IsDraft,
+		ReviewDecision:   item.ReviewDecision,
+		ReviewRequests:   reqs,
+		CIState:          ci,
+		Unaddressed:      len(comments) > 0,
+		BlockingComments: comments,
+	}
+	out.Bucket = Bucket(PRFacts{
+		Unaddressed:    out.Unaddressed,
+		CIState:        ci,
+		ReviewDecision: item.ReviewDecision,
+		ReviewRequests: reqs,
+		IsDraft:        item.IsDraft,
+		Mergeable:      item.Mergeable,
+	})
+	return out, nil
+}
+
+func blockingComments(threads []gh.Thread, author string) []Comment {
+	out := make([]Comment, 0)
+	for _, thread := range threads {
+		if thread.IsResolved || len(thread.Comments) == 0 {
+			continue
+		}
+		last := thread.Comments[len(thread.Comments)-1]
+		if last.Author != nil && strings.EqualFold(last.Author.Login, author) {
+			continue
+		}
+		login := ""
+		if last.Author != nil {
+			login = last.Author.Login
+		}
+		out = append(out, Comment{
+			ThreadID:  thread.ID,
+			CommentID: last.ID,
+			Author:    login,
+			Path:      last.Path,
+			Line:      last.Line,
+			URL:       last.URL,
+			Body:      last.Body,
+		})
+	}
+	return out
+}
+
+func formatReviewRequests(reqs []gh.ReviewReq) []string {
+	out := make([]string, 0, len(reqs))
+	for _, req := range reqs {
+		switch req.Type {
+		case "Team":
+			slug := req.Slug
+			if slug == "" {
+				slug = req.Name
+			}
+			out = append(out, "Team:"+slug)
+		default:
+			out = append(out, "User:"+req.Login)
+		}
+	}
+	return out
+}
+
+func matchTabs(ctx context.Context, client Herdr, cfg config.Config, doc *Document) error {
+	if err := client.RequireMin(ctx, herdrMinVersion); err != nil {
+		if errors.Is(err, herdr.ErrNotInstalled) {
+			nullTabs(doc)
+			warn(doc, "herdr unreachable: "+err.Error())
+			return nil
+		}
+		return fmt.Errorf("herdr version: %w", err)
+	}
+	tabs, err := client.TabList(ctx)
+	if err != nil {
+		nullTabs(doc)
+		warn(doc, "herdr unreachable: "+err.Error())
+		return nil
+	}
+	agents, err := client.AgentList(ctx)
+	if err != nil {
+		nullTabs(doc)
+		warn(doc, "herdr unreachable: "+err.Error())
+		return nil
+	}
+	for i := range doc.PRs {
+		tab, warning := Match(doc.PRs[i].Identifier, doc.PRs[i].Repo, doc.PRs[i].Number, cfg.TabLabelTemplate, tabs, agents)
+		doc.PRs[i].Tab = tab
+		if warning != "" {
+			warn(doc, warning)
+		}
+	}
+	return nil
+}
+
+func nullTabs(doc *Document) {
+	for i := range doc.PRs {
+		doc.PRs[i].Tab = nil
+	}
+}
+
+func warn(doc *Document, msg string) {
+	slog.Warn(msg)
+	doc.Warnings = append(doc.Warnings, msg)
+}
+
+func dedupe(repos []string) []string {
+	seen := make(map[string]struct{}, len(repos))
+	out := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		if _, ok := seen[repo]; ok {
+			continue
+		}
+		seen[repo] = struct{}{}
+		out = append(out, repo)
+	}
+	return out
+}
+
+func splitRepo(repo string) (string, string, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", fmt.Errorf("invalid repo %q", repo)
+	}
+	return owner, name, nil
+}

--- a/devtools/prsync/internal/scan/scan_test.go
+++ b/devtools/prsync/internal/scan/scan_test.go
@@ -1,0 +1,463 @@
+package scan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+var fixtureNow = time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+
+func TestRunGolden(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	cfg.Repos = []string{"acme/widgets"}
+	cfg.GHBin = "gh"
+	cfg.HerdrBin = "herdr"
+
+	deps := Deps{GH: fixtureGH{}, Herdr: fixtureHerdr{}}
+	doc, err := Run(context.Background(), deps, cfg, nil, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	got, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = append(got, '\n')
+
+	path := filepath.Join("testdata", "golden", "scan.json")
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, got, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // testdata path
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRunHerdrMissingDegrades(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	cfg.Repos = []string{"acme/widgets"}
+
+	deps := Deps{
+		GH:    fixtureGH{},
+		Herdr: stubHerdr{minErr: herdr.ErrNotInstalled},
+	}
+	doc, err := Run(context.Background(), deps, cfg, nil, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(doc.PRs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1", len(doc.PRs))
+	}
+	if doc.PRs[0].Tab != nil {
+		t.Fatalf("tab = %+v, want nil", doc.PRs[0].Tab)
+	}
+	if len(doc.Warnings) != 1 || !bytes.Contains([]byte(doc.Warnings[0]), []byte("herdr unreachable")) {
+		t.Fatalf("warnings = %v, want herdr unreachable", doc.Warnings)
+	}
+}
+
+func TestRunHerdrUnsupported(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	cfg.Repos = []string{"acme/widgets"}
+
+	deps := Deps{
+		GH:    fixtureGH{},
+		Herdr: stubHerdr{minErr: herdr.ErrUnsupported},
+	}
+	doc, err := Run(context.Background(), deps, cfg, nil, fixtureNow)
+	if err == nil {
+		t.Fatal("Run() error = nil, want unsupported")
+	}
+	if !errors.Is(err, herdr.ErrUnsupported) {
+		t.Fatalf("Run() error = %v, want ErrUnsupported", err)
+	}
+	if len(doc.PRs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1 (partial document)", len(doc.PRs))
+	}
+	if doc.PRs[0].Tab != nil {
+		t.Fatalf("tab = %+v, want nil", doc.PRs[0].Tab)
+	}
+}
+
+func TestRunInaccessibleRepo(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+
+	g := &scriptGH{
+		list: map[string]listResult{
+			"acme/widgets":  {prs: fixturePRs()},
+			"acme/archived": {err: gh.ErrInaccessible},
+		},
+		threads: map[int][]gh.Thread{123: fixtureThreads()},
+	}
+	deps := Deps{GH: g, Herdr: fixtureHerdr{}}
+	doc, err := Run(context.Background(), deps, cfg, []string{"acme/widgets", "acme/archived"}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(doc.PRs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1", len(doc.PRs))
+	}
+	if len(doc.InaccessibleRepos) != 1 || doc.InaccessibleRepos[0] != "acme/archived" {
+		t.Fatalf("inaccessible = %v, want [acme/archived]", doc.InaccessibleRepos)
+	}
+}
+
+func TestRunMidScanRateLimitEmitsPartial(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+
+	g := &scriptGH{
+		list: map[string]listResult{
+			"acme/widgets": {prs: fixturePRs()},
+			"acme/gizmos":  {err: &gh.ProcError{ExitCode: 1, Stderr: "API rate limit exceeded"}},
+		},
+		threads: map[int][]gh.Thread{123: fixtureThreads()},
+	}
+	deps := Deps{GH: g, Herdr: fixtureHerdr{}}
+	doc, err := Run(context.Background(), deps, cfg, []string{"acme/widgets", "acme/gizmos"}, fixtureNow)
+	if err == nil {
+		t.Fatal("Run() error = nil, want rate-limit")
+	}
+	if len(doc.PRs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1 classified before failure", len(doc.PRs))
+	}
+	if doc.Author != "alice" {
+		t.Fatalf("author = %q, want alice", doc.Author)
+	}
+}
+
+func TestRunUnauthenticatedNoDocument(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	g := &scriptGH{authErr: gh.ErrUnauthenticated}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, nil, fixtureNow)
+	if err == nil {
+		t.Fatal("Run() error = nil, want unauthenticated")
+	}
+	if errors.Is(err, gh.ErrUnauthenticated) == false {
+		t.Fatalf("Run() error = %v, want ErrUnauthenticated", err)
+	}
+	if doc.Author != "" || len(doc.PRs) != 0 {
+		t.Fatalf("document started: author=%q prs=%d", doc.Author, len(doc.PRs))
+	}
+}
+
+func TestRunGHMissing(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.GHBin = "/missing/gh"
+	g := &scriptGH{authErr: &executor.ExecutableNotFoundError{Command: cfg.GHBin}}
+	_, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, nil, fixtureNow)
+	if err == nil {
+		t.Fatal("Run() error = nil, want missing binary")
+	}
+	var notFound *executor.ExecutableNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Run() error = %v, want ExecutableNotFoundError", err)
+	}
+}
+
+func TestRunSearchCapWarning(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	g := &scriptGH{
+		search:       []string{"acme/widgets"},
+		searchCapped: true,
+		list:         map[string]listResult{"acme/widgets": {prs: fixturePRs()}},
+		threads:      map[int][]gh.Thread{123: fixtureThreads()},
+	}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, nil, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	found := false
+	for _, w := range doc.Warnings {
+		if w == "search result hit --limit 1000; some repos may be missing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %v, missing search cap warning", doc.Warnings)
+	}
+}
+
+func TestRunRepoOverrideReplacesConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	cfg.Repos = []string{"acme/ignored"}
+	g := &scriptGH{
+		list:    map[string]listResult{"acme/widgets": {prs: fixturePRs()}},
+		threads: map[int][]gh.Thread{123: fixtureThreads()},
+	}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, []string{"acme/widgets"}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(doc.Repos) != 1 || doc.Repos[0] != "acme/widgets" {
+		t.Fatalf("repos = %v, want [acme/widgets]", doc.Repos)
+	}
+}
+
+func TestStarted(t *testing.T) {
+	t.Parallel()
+	if Started(Document{}) {
+		t.Fatal("empty document should not be started")
+	}
+	if !Started(Document{Author: "alice"}) {
+		t.Fatal("author set should be started")
+	}
+}
+
+func TestExtractIDNilRegexp(t *testing.T) {
+	t.Parallel()
+	if got := ExtractID("PROJ-1", nil); got != nil {
+		t.Fatalf("ExtractID(nil re) = %v, want nil", got)
+	}
+}
+
+func TestRunAuthorLastCommentNotBlocking(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	line := 1
+	g := &scriptGH{
+		list: map[string]listResult{"acme/widgets": {prs: fixturePRs()}},
+		threads: map[int][]gh.Thread{123: {{
+			ID: "PRRT_own", IsResolved: false,
+			Comments: []gh.ThreadComment{{
+				ID: "PRRC_own", Author: &gh.ThreadAuthor{Login: "Alice"},
+				Path: "a.go", Line: &line, URL: "u", Body: "done",
+			}},
+		}}},
+	}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, []string{"acme/widgets"}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if doc.PRs[0].Unaddressed {
+		t.Fatal("unaddressed = true, want false when last comment is author")
+	}
+	if len(doc.PRs[0].BlockingComments) != 0 {
+		t.Fatalf("blocking = %+v, want empty", doc.PRs[0].BlockingComments)
+	}
+}
+
+func TestRunDeletedAuthorIsBlocking(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	g := &scriptGH{
+		list: map[string]listResult{"acme/widgets": {prs: fixturePRs()}},
+		threads: map[int][]gh.Thread{123: {{
+			ID: "PRRT_gone", IsResolved: false,
+			Comments: []gh.ThreadComment{{
+				ID: "PRRC_gone", Author: nil, Path: "a.go", URL: "u", Body: "?",
+			}},
+		}}},
+	}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, []string{"acme/widgets"}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if !doc.PRs[0].Unaddressed {
+		t.Fatal("unaddressed = false, want true when author is deleted")
+	}
+	if doc.PRs[0].BlockingComments[0].Author != "" {
+		t.Fatalf("author = %q, want empty", doc.PRs[0].BlockingComments[0].Author)
+	}
+}
+
+type fixtureGH struct{}
+
+func (fixtureGH) AuthStatus(context.Context) error { return nil }
+
+func (fixtureGH) UserLogin(context.Context) (string, error) { return "alice", nil }
+
+func (fixtureGH) SearchOpenPRRepos(context.Context, string) ([]string, bool, error) {
+	return []string{"acme/widgets"}, false, nil
+}
+
+func (fixtureGH) ListOpenPRs(_ context.Context, repo, _ string) ([]gh.PRListItem, error) {
+	if repo != "acme/widgets" {
+		return nil, gh.ErrInaccessible
+	}
+	return fixturePRs(), nil
+}
+
+func (fixtureGH) ReviewThreads(context.Context, string, string, int) ([]gh.Thread, error) {
+	return fixtureThreads(), nil
+}
+
+type fixtureHerdr struct{}
+
+func (fixtureHerdr) RequireMin(context.Context, string) error { return nil }
+
+func (fixtureHerdr) TabList(context.Context) ([]herdr.Tab, error) {
+	return []herdr.Tab{{
+		TabID: "w2:tC", WorkspaceID: "w2", Label: "PROJ-123", AgentStatus: "idle", PaneCount: 1,
+	}}, nil
+}
+
+func (fixtureHerdr) AgentList(context.Context) ([]herdr.Agent, error) {
+	return []herdr.Agent{{
+		PaneID: "w2:pC", TabID: "w2:tC", Agent: "codex", AgentStatus: "idle",
+	}}, nil
+}
+
+type stubHerdr struct {
+	minErr  error
+	tabs    []herdr.Tab
+	agents  []herdr.Agent
+	listErr error
+}
+
+func (s stubHerdr) RequireMin(context.Context, string) error { return s.minErr }
+
+func (s stubHerdr) TabList(context.Context) ([]herdr.Tab, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.tabs, nil
+}
+
+func (s stubHerdr) AgentList(context.Context) ([]herdr.Agent, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.agents, nil
+}
+
+type listResult struct {
+	prs []gh.PRListItem
+	err error
+}
+
+type scriptGH struct {
+	authErr      error
+	login        string
+	loginErr     error
+	search       []string
+	searchCapped bool
+	searchErr    error
+	list         map[string]listResult
+	threads      map[int][]gh.Thread
+	threadErr    error
+}
+
+func (g *scriptGH) AuthStatus(context.Context) error { return g.authErr }
+
+func (g *scriptGH) UserLogin(context.Context) (string, error) {
+	if g.loginErr != nil {
+		return "", g.loginErr
+	}
+	if g.login != "" {
+		return g.login, nil
+	}
+	return "alice", nil
+}
+
+func (g *scriptGH) SearchOpenPRRepos(context.Context, string) ([]string, bool, error) {
+	return g.search, g.searchCapped, g.searchErr
+}
+
+func (g *scriptGH) ListOpenPRs(_ context.Context, repo, _ string) ([]gh.PRListItem, error) {
+	res, ok := g.list[repo]
+	if !ok {
+		return nil, gh.ErrInaccessible
+	}
+	return res.prs, res.err
+}
+
+func (g *scriptGH) ReviewThreads(_ context.Context, _, _ string, number int) ([]gh.Thread, error) {
+	if g.threadErr != nil {
+		return nil, g.threadErr
+	}
+	return g.threads[number], nil
+}
+
+func depsWith(g GH, h Herdr) Deps { return Deps{GH: g, Herdr: h} }
+
+func fixturePRs() []gh.PRListItem {
+	return []gh.PRListItem{{
+		Number:         123,
+		Title:          "[PROJ-123] Fix the widget",
+		URL:            "https://github.com/acme/widgets/pull/123",
+		BaseRefName:    "main",
+		HeadRefName:    "fix-widget",
+		Mergeable:      "MERGEABLE",
+		IsDraft:        false,
+		ReviewDecision: "APPROVED",
+		ReviewRequests: []gh.ReviewReq{
+			{Type: "User", Login: "reviewer-login"},
+			{Type: "Team", Name: "Platform Reviewers", Slug: "platform-reviewers"},
+		},
+		LatestReviews: []gh.LatestReview{
+			{Author: gh.ReviewAuthor{Login: "reviewer-login"}, State: "APPROVED", SubmittedAt: "2026-01-01T09:00:00Z"},
+		},
+		StatusCheckRollup: []gh.StatusCheck{
+			{Name: "ci", Status: "COMPLETED", Conclusion: "SUCCESS"},
+		},
+	}}
+}
+
+func fixtureThreads() []gh.Thread {
+	line := 42
+	return []gh.Thread{{
+		ID:         "PRRT_widget",
+		IsResolved: false,
+		Comments: []gh.ThreadComment{{
+			ID:     "PRRC_widget",
+			Author: &gh.ThreadAuthor{Login: "reviewer-login"},
+			Path:   "src/widget.go",
+			Line:   &line,
+			URL:    "https://github.com/acme/widgets/pull/123#discussion_r1",
+			Body:   "This should handle the nil case.",
+		}},
+	}}
+}

--- a/devtools/prsync/internal/scan/testdata/golden/scan.json
+++ b/devtools/prsync/internal/scan/testdata/golden/scan.json
@@ -1,0 +1,47 @@
+{
+  "generated_at": "2026-01-01T09:00:00Z",
+  "author": "alice",
+  "repos": [
+    "acme/widgets"
+  ],
+  "prs": [
+    {
+      "repo": "acme/widgets",
+      "number": 123,
+      "title": "[PROJ-123] Fix the widget",
+      "url": "https://github.com/acme/widgets/pull/123",
+      "identifier": "PROJ-123",
+      "base": "main",
+      "head": "fix-widget",
+      "is_draft": false,
+      "review_decision": "APPROVED",
+      "review_requests": [
+        "User:reviewer-login",
+        "Team:platform-reviewers"
+      ],
+      "ci_state": "green",
+      "bucket": "needs_you",
+      "unaddressed": true,
+      "blocking_comments": [
+        {
+          "thread_id": "PRRT_widget",
+          "comment_id": "PRRC_widget",
+          "author": "reviewer-login",
+          "path": "src/widget.go",
+          "line": 42,
+          "url": "https://github.com/acme/widgets/pull/123#discussion_r1",
+          "body": "This should handle the nil case."
+        }
+      ],
+      "tab": {
+        "tab_id": "w2:tC",
+        "pane_id": "w2:pC",
+        "workspace_id": "w2",
+        "label": "PROJ-123",
+        "agent_status": "idle"
+      }
+    }
+  ],
+  "inaccessible_repos": [],
+  "warnings": []
+}

--- a/devtools/prsync/internal/scan/types.go
+++ b/devtools/prsync/internal/scan/types.go
@@ -1,0 +1,50 @@
+package scan
+
+// Document is the outbound scan JSON document.
+type Document struct {
+	GeneratedAt       string   `json:"generated_at"` //nolint:tagliatelle // brief outbound contract
+	Author            string   `json:"author"`
+	Repos             []string `json:"repos"`
+	PRs               []PR     `json:"prs"`                //nolint:tagliatelle // brief outbound contract
+	InaccessibleRepos []string `json:"inaccessible_repos"` //nolint:tagliatelle // brief outbound contract
+	Warnings          []string `json:"warnings"`
+}
+
+// PR is one classified pull request in a scan document.
+type PR struct {
+	Repo             string    `json:"repo"`
+	Number           int       `json:"number"`
+	Title            string    `json:"title"`
+	URL              string    `json:"url"`
+	Identifier       *string   `json:"identifier"`
+	Base             string    `json:"base"`
+	Head             string    `json:"head"`
+	IsDraft          bool      `json:"is_draft"`        //nolint:tagliatelle // brief outbound contract
+	ReviewDecision   string    `json:"review_decision"` //nolint:tagliatelle // brief outbound contract
+	ReviewRequests   []string  `json:"review_requests"` //nolint:tagliatelle // brief outbound contract
+	CIState          string    `json:"ci_state"`        //nolint:tagliatelle // brief outbound contract
+	Bucket           string    `json:"bucket"`
+	Unaddressed      bool      `json:"unaddressed"`
+	BlockingComments []Comment `json:"blocking_comments"` //nolint:tagliatelle // brief outbound contract
+	Tab              *Tab      `json:"tab"`
+}
+
+// Comment is one unresolved review thread whose last author is not the PR author.
+type Comment struct {
+	ThreadID  string `json:"thread_id"`  //nolint:tagliatelle // brief outbound contract
+	CommentID string `json:"comment_id"` //nolint:tagliatelle // brief outbound contract
+	Author    string `json:"author"`
+	Path      string `json:"path"`
+	Line      *int   `json:"line"`
+	URL       string `json:"url"`
+	Body      string `json:"body"`
+}
+
+// Tab is a uniquely matched herdr tab. Nil on the PR means no unique tab.
+type Tab struct {
+	TabID       string  `json:"tab_id"`       //nolint:tagliatelle // brief outbound contract
+	PaneID      *string `json:"pane_id"`      //nolint:tagliatelle // brief outbound contract
+	WorkspaceID string  `json:"workspace_id"` //nolint:tagliatelle // brief outbound contract
+	Label       string  `json:"label"`
+	AgentStatus string  `json:"agent_status"` //nolint:tagliatelle // brief outbound contract
+}


### PR DESCRIPTION
## Summary
- Add `internal/scan.Run(ctx, deps, cfg, repos, now)` and the `prsync scan` cobra command.
- Classify each open PR: identifier extraction, CI state (gh-nudge table plus `TIMED_OUT` → `failing`), blocking review threads, and readiness bucket (`needs_you` > `draft` > `waiting` > `ready`).
- Call paginated `ReviewThreads` (do not silently cap at 100). Inaccessible repos are 404/archived only; mid-scan GraphQL / rate-limit failures emit partial JSON then exit 3.
- Match herdr tabs 0/1/N and never guess. herdr **missing** → `tab: null` + warning, exit 0. herdr **present but < 0.8** → exit 3.

## Why
PR 3 of the #211 prsync plan. Operators can run `prsync scan` as a read-only survey.

## Test plan
- [x] Unit tables for identifier / bucket / CI (including `TIMED_OUT`) / match
- [x] Golden JSON over the fixture PR set (`internal/scan/testdata/golden/scan.json`, `-update` to regenerate)
- [x] herdr missing degrades; gh missing / bad `--repo` / mid-scan rate-limit mapped to exit 0/2/3
- [x] `make check`

Resolves #216