### PR TITLE
feat(prsync): add gate command with any vs managed busy-set

### DIFF
--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "exit.go",
+        "gate.go",
         "root.go",
         "scan.go",
         "version.go",
@@ -12,6 +13,7 @@ go_library(
     visibility = ["//devtools/prsync:__subpackages__"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/dispatch:go_default_library",
         "//devtools/prsync/internal/gh:go_default_library",
         "//devtools/prsync/internal/herdr:go_default_library",
         "//devtools/prsync/internal/scan:go_default_library",
@@ -24,6 +26,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cli_gate_test.go",
         "cli_scan_test.go",
         "cli_test.go",
     ],
@@ -31,6 +34,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/dispatch:go_default_library",
         "//devtools/prsync/internal/scan:go_default_library",
         "//devtools/prsync/internal/version:go_default_library",
         "@com_github_jaeyeom_go_cmdexec//:go_default_library",

--- a/devtools/prsync/internal/cli/cli_gate_test.go
+++ b/devtools/prsync/internal/cli/cli_gate_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestGateSafeWhenIdle(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want 0, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if !got.Safe {
+		t.Fatalf("safe = false, want true; busy=%v", got.Busy)
+	}
+	if got.Busy == nil {
+		t.Fatal("busy = null, want []")
+	}
+}
+
+func TestGateBusyWhenWorking(t *testing.T) {
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUnsafe {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitUnsafe, stderr.String(), stdout.String())
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if got.Safe {
+		t.Fatal("safe = true, want false")
+	}
+	if len(got.Busy) != 1 || got.Busy[0].PaneID != "w2:pC" || got.Busy[0].TabID != "w2:tC" {
+		t.Fatalf("busy = %+v", got.Busy)
+	}
+}
+
+func TestGateUnsetPaneIDDoesNotCallPaneCurrent(t *testing.T) {
+	t.Setenv("HERDR_PANE_ID", "")
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	t.Setenv("HERDR_FAKE_PANE_ID", "w2:pC")
+	sentinel := filepath.Join(t.TempDir(), "pane-current")
+	t.Setenv("HERDR_FAKE_PANE_CURRENT_SENTINEL", sentinel)
+
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUnsafe {
+		t.Fatalf("exit = %d, want %d (must not exclude focused pane), stderr=%q stdout=%q", code, ExitUnsafe, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("pane current was called (sentinel %s exists), err=%v", sentinel, err)
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if got.Safe || len(got.Busy) != 1 || got.Busy[0].PaneID != "w2:pC" {
+		t.Fatalf("result = %+v, want busy w2:pC", got)
+	}
+}
+
+func TestGateSelfExcludesRunnerPane(t *testing.T) {
+	t.Setenv("HERDR_PANE_ID", "w2:pC")
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want 0, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if !got.Safe {
+		t.Fatalf("safe = false, want true after self-exclusion; busy=%v", got.Busy)
+	}
+}
+
+func TestGateManagedIgnoresUnmatchedWorking(t *testing.T) {
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	t.Setenv("HERDR_FAKE_TAB_ID", "w2:tOther")
+	t.Setenv("HERDR_FAKE_PANE_ID", "w2:pX")
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\nconcurrency_wait_on=managed\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want 0, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if !got.Safe {
+		t.Fatalf("safe = false, want true; managed must ignore unmatched; busy=%v", got.Busy)
+	}
+}
+
+func TestGateManagedBusyWhenMatchedWorking(t *testing.T) {
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\nconcurrency_wait_on=managed\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUnsafe {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitUnsafe, stderr.String(), stdout.String())
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if got.Safe {
+		t.Fatal("safe = true, want false when matched tab is working")
+	}
+}
+
+func TestGateHerdrMissing(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeScanConfig(t, "gh_bin=prsync-test-missing-gh\nherdr_bin=prsync-test-missing-herdr\nauthor=alice\nrepos=acme/widgets\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "herdr") {
+		t.Fatalf("stderr = %q, want herdr missing", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on precondition", stdout.String())
+	}
+}
+
+func TestGateHerdrUnsupported(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "old", version: "herdr 0.7.9", want: "older than 0.8"},
+		{name: "unparseable", version: "herdr bananas", want: "cannot parse herdr version"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HERDR_FAKE_VERSION", tc.version)
+			ghBin, herdrBin := fixtureBins(t)
+			cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+			var stdout, stderr bytes.Buffer
+			code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+			if code != ExitPrecondition {
+				t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestGateAnyDoesNotNeedGH(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin=prsync-test-missing-gh\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want 0 (any does not call gh), stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+}
+
+func TestGateManagedNeedsGH(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin=prsync-test-missing-gh\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\nconcurrency_wait_on=managed\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gh binary not found") {
+		t.Fatalf("stderr = %q, want gh binary not found", stderr.String())
+	}
+}
+
+func TestGateMissingConfig(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", "/no/such/prsync.config"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+}
+
+func decodeGate(t *testing.T, raw []byte) dispatch.Result {
+	t.Helper()
+	var got dispatch.Result
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, raw)
+	}
+	return got
+}

--- a/devtools/prsync/internal/cli/cli_test.go
+++ b/devtools/prsync/internal/cli/cli_test.go
@@ -45,21 +45,16 @@ func TestUnknownCommand(t *testing.T) {
 	}
 }
 
-func TestNoCommandsBeyondVersionAndScan(t *testing.T) {
+func TestNoDispatchCommand(t *testing.T) {
 	t.Parallel()
 
-	for _, name := range []string{"dispatch", "gate"} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			var stdout, stderr bytes.Buffer
-			code := Execute(context.Background(), []string{name}, &stdout, &stderr, nil)
-			if code != ExitUsage {
-				t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
-			}
-			if !strings.Contains(stderr.String(), "unknown command") {
-				t.Fatalf("stderr = %q", stderr.String())
-			}
-		})
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch"}, &stdout, &stderr, nil)
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("stderr = %q", stderr.String())
 	}
 }
 

--- a/devtools/prsync/internal/cli/gate.go
+++ b/devtools/prsync/internal/cli/gate.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+	executor "github.com/jaeyeom/go-cmdexec"
+	"github.com/spf13/cobra"
+)
+
+func newGateCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
+	var configPath string
+	cmd := &cobra.Command{
+		Use:   "gate",
+		Short: "Check whether it is safe to start another agent",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runGate(cmd.Context(), stdout, exec, configPath)
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
+	return cmd
+}
+
+func runGate(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string) error {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	res, err := evaluateGate(ctx, cfg, exec)
+	if err != nil {
+		return gateError(err, cfg)
+	}
+	if err := writeGateJSON(stdout, res); err != nil {
+		return err
+	}
+	if !res.Safe {
+		return &ExitError{Code: ExitUnsafe}
+	}
+	return nil
+}
+
+func evaluateGate(ctx context.Context, cfg config.Config, exec executor.Executor) (dispatch.Result, error) {
+	h := herdr.NewClient(exec, cfg.HerdrBin)
+	if err := h.RequireMin(ctx, "0.8.0"); err != nil {
+		return dispatch.Result{}, fmt.Errorf("herdr version: %w", err)
+	}
+	runner := h.RunnerPane(ctx)
+	matched, err := managedTabs(ctx, cfg, exec, h)
+	if err != nil {
+		return dispatch.Result{}, err
+	}
+	res, err := dispatch.Check(ctx, h, cfg.ConcurrencyWaitOn, runner, matched)
+	if err != nil {
+		return dispatch.Result{}, fmt.Errorf("gate: %w", err)
+	}
+	return res, nil
+}
+
+func managedTabs(ctx context.Context, cfg config.Config, exec executor.Executor, h *herdr.Client) (map[string]struct{}, error) {
+	if cfg.ConcurrencyWaitOn != "managed" {
+		return nil, nil
+	}
+	deps := scan.Deps{
+		GH:    gh.NewClient(exec, cfg.GHBin),
+		Herdr: h,
+	}
+	doc, err := scan.Run(ctx, deps, cfg, nil, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("scan: %w", err)
+	}
+	return dispatch.MatchedTabs(doc), nil
+}
+
+func writeGateJSON(w io.Writer, res dispatch.Result) error {
+	out, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode gate: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", out); err != nil {
+		return fmt.Errorf("write gate: %w", err)
+	}
+	return nil
+}
+
+func gateError(err error, cfg config.Config) error {
+	if errors.Is(err, herdr.ErrNotInstalled) {
+		return &ExitError{Code: ExitPrecondition, Err: fmt.Errorf("herdr binary not found (herdr_bin=%q)", cfg.HerdrBin)}
+	}
+	return scanExit(err, cfg)
+}

--- a/devtools/prsync/internal/cli/root.go
+++ b/devtools/prsync/internal/cli/root.go
@@ -29,5 +29,6 @@ func newRoot(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	}
 	root.AddCommand(newVersionCmd(stdout))
 	root.AddCommand(newScanCmd(stdout, exec))
+	root.AddCommand(newGateCmd(stdout, exec))
 	return root
 }

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
@@ -5,7 +5,7 @@ DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
 case "${1-}" in
   --version)
-    printf '%s\n' "herdr 0.8.1"
+    printf '%s\n' "${HERDR_FAKE_VERSION:-herdr 0.8.1}"
     exit 0
     ;;
 esac
@@ -16,10 +16,23 @@ case "${1-} ${2-}" in
     exit 0
     ;;
   "agent list")
+    if [ -n "${HERDR_FAKE_STATUS_FILE-}" ] || [ -n "${HERDR_FAKE_AGENT_STATUS-}" ] || [ -n "${HERDR_FAKE_TAB_ID-}" ] || [ -n "${HERDR_FAKE_PANE_ID-}" ]; then
+      status=${HERDR_FAKE_AGENT_STATUS:-idle}
+      if [ -n "${HERDR_FAKE_STATUS_FILE-}" ] && [ -f "$HERDR_FAKE_STATUS_FILE" ]; then
+        status=$(cat "$HERDR_FAKE_STATUS_FILE")
+      fi
+      tab_id=${HERDR_FAKE_TAB_ID:-w2:tC}
+      pane_id=${HERDR_FAKE_PANE_ID:-w2:pC}
+      printf '%s\n' "{\"result\":{\"agents\":[{\"pane_id\":\"${pane_id}\",\"tab_id\":\"${tab_id}\",\"agent\":\"codex\",\"agent_status\":\"${status}\"}]}}"
+      exit 0
+    fi
     cat "${DIR}/herdr-agent-list.json"
     exit 0
     ;;
   "pane current")
+    if [ -n "${HERDR_FAKE_PANE_CURRENT_SENTINEL-}" ]; then
+      printf '%s\n' "called" > "$HERDR_FAKE_PANE_CURRENT_SENTINEL"
+    fi
     cat "${DIR}/herdr-pane-current.json"
     exit 0
     ;;

--- a/devtools/prsync/internal/dispatch/BUILD.bazel
+++ b/devtools/prsync/internal/dispatch/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gate.go"],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch",
+    visibility = ["//devtools/prsync:__subpackages__"],
+    deps = [
+        "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/herdr:go_default_library",
+        "//devtools/prsync/internal/scan:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gate_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/herdr:go_default_library",
+        "//devtools/prsync/internal/scan:go_default_library",
+    ],
+)

--- a/devtools/prsync/internal/dispatch/gate.go
+++ b/devtools/prsync/internal/dispatch/gate.go
@@ -1,0 +1,122 @@
+// Package dispatch implements the prsync concurrency gate.
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+const herdrMinVersion = "0.8.0"
+
+// ErrTimeout is returned when Wait expires with a non-empty busy set.
+var ErrTimeout = errors.New("gate timeout")
+
+// Clock is the injected clock for Wait.
+type Clock interface {
+	Now() time.Time
+}
+
+// Sleeper is the injected sleeper for Wait.
+type Sleeper interface {
+	Sleep(ctx context.Context, d time.Duration) error
+}
+
+// Herdr is the herdr surface the gate uses.
+type Herdr interface {
+	RequireMin(ctx context.Context, minimum string) error
+	AgentList(ctx context.Context) ([]herdr.Agent, error)
+}
+
+// Result is the outbound gate JSON document.
+type Result struct {
+	Safe bool   `json:"safe"`
+	Busy []Busy `json:"busy"`
+}
+
+// Busy is one working agent in the busy set.
+type Busy struct {
+	PaneID string `json:"pane_id"` //nolint:tagliatelle // brief outbound contract
+	TabID  string `json:"tab_id"`  //nolint:tagliatelle // brief outbound contract
+}
+
+// Check is a one-shot busy-set evaluation. It does not sleep.
+func Check(ctx context.Context, h Herdr, waitOn, runnerPane string, matchedTabs map[string]struct{}) (Result, error) {
+	if err := h.RequireMin(ctx, herdrMinVersion); err != nil {
+		return Result{}, fmt.Errorf("herdr version: %w", err)
+	}
+	return snapshot(ctx, h, waitOn, runnerPane, matchedTabs)
+}
+
+// Wait polls until the busy set is empty or cfg.GateTimeout elapses.
+func Wait(ctx context.Context, h Herdr, cfg config.Config, runnerPane string, matchedTabs map[string]struct{}, clock Clock, sleeper Sleeper) (Result, error) {
+	if err := h.RequireMin(ctx, herdrMinVersion); err != nil {
+		return Result{}, fmt.Errorf("herdr version: %w", err)
+	}
+	start := clock.Now()
+	for {
+		res, err := snapshot(ctx, h, cfg.ConcurrencyWaitOn, runnerPane, matchedTabs)
+		if err != nil {
+			return res, err
+		}
+		if res.Safe {
+			return res, nil
+		}
+		if clock.Now().Sub(start) >= cfg.GateTimeout {
+			return res, ErrTimeout
+		}
+		if err := sleeper.Sleep(ctx, cfg.GatePoll); err != nil {
+			return res, fmt.Errorf("gate sleep: %w", err)
+		}
+	}
+}
+
+// MatchedTabs collects tab IDs from a scan document, including tabs with a nil pane_id.
+func MatchedTabs(doc scan.Document) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, pr := range doc.PRs {
+		if pr.Tab != nil && pr.Tab.TabID != "" {
+			out[pr.Tab.TabID] = struct{}{}
+		}
+	}
+	return out
+}
+
+func snapshot(ctx context.Context, h Herdr, waitOn, runnerPane string, matchedTabs map[string]struct{}) (Result, error) {
+	agents, err := h.AgentList(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("agent list: %w", err)
+	}
+	busy := busySet(agents, waitOn, runnerPane, matchedTabs)
+	return Result{Safe: len(busy) == 0, Busy: busy}, nil
+}
+
+func busySet(agents []herdr.Agent, waitOn, runnerPane string, matchedTabs map[string]struct{}) []Busy {
+	out := make([]Busy, 0)
+	for _, agent := range agents {
+		if !isBusy(agent, waitOn, runnerPane, matchedTabs) {
+			continue
+		}
+		out = append(out, Busy{PaneID: agent.PaneID, TabID: agent.TabID})
+	}
+	return out
+}
+
+func isBusy(agent herdr.Agent, waitOn, runnerPane string, matchedTabs map[string]struct{}) bool {
+	if agent.AgentStatus != "working" {
+		return false
+	}
+	if runnerPane != "" && agent.PaneID == runnerPane {
+		return false
+	}
+	if waitOn == "managed" {
+		_, ok := matchedTabs[agent.TabID]
+		return ok
+	}
+	return true
+}

--- a/devtools/prsync/internal/dispatch/gate_test.go
+++ b/devtools/prsync/internal/dispatch/gate_test.go
@@ -1,0 +1,300 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+func TestCheckWorkingIsBusy(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pC", "w2:tC")}}}
+	got, err := Check(context.Background(), h, "any", "", nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got.Safe {
+		t.Fatal("safe = true, want false while an agent is working")
+	}
+	if len(got.Busy) != 1 || got.Busy[0].PaneID != "w2:pC" || got.Busy[0].TabID != "w2:tC" {
+		t.Fatalf("busy = %+v, want [{w2:pC w2:tC}]", got.Busy)
+	}
+}
+
+func TestCheckIdleIsSafe(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+	got, err := Check(context.Background(), h, "any", "", nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !got.Safe {
+		t.Fatalf("safe = false, want true; busy=%+v", got.Busy)
+	}
+	if got.Busy == nil {
+		t.Fatal("busy = nil, want empty slice")
+	}
+	if len(got.Busy) != 0 {
+		t.Fatalf("busy = %+v, want empty", got.Busy)
+	}
+}
+
+func TestCheckSelfExclusion(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pC", "w2:tC")}}}
+	got, err := Check(context.Background(), h, "any", "w2:pC", nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !got.Safe {
+		t.Fatalf("safe = false, want true after excluding runner pane; busy=%+v", got.Busy)
+	}
+}
+
+func TestCheckUnsetRunnerDoesNotExclude(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pFocus", "w2:tFocus")}}}
+	got, err := Check(context.Background(), h, "any", "", nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got.Safe {
+		t.Fatal("safe = true, want false when runner pane is unset")
+	}
+	if len(got.Busy) != 1 || got.Busy[0].PaneID != "w2:pFocus" {
+		t.Fatalf("busy = %+v, want focused pane included", got.Busy)
+	}
+}
+
+func TestCheckManagedIgnoresUnmatched(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pX", "w2:tOther")}}}
+	matched := map[string]struct{}{"w2:tC": {}}
+	got, err := Check(context.Background(), h, "managed", "", matched)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !got.Safe {
+		t.Fatalf("safe = false, want true; managed must ignore unmatched working agents; busy=%+v", got.Busy)
+	}
+}
+
+func TestCheckManagedBusyWhenMatched(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pC", "w2:tC")}}}
+	matched := map[string]struct{}{"w2:tC": {}}
+	got, err := Check(context.Background(), h, "managed", "", matched)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got.Safe {
+		t.Fatal("safe = true, want false when a matched tab is working")
+	}
+}
+
+func TestCheckNonWorkingStatusesAreSafe(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{"idle", "done", "blocked", "unknown", "none"} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			h := &scriptHerdr{lists: [][]herdr.Agent{{{
+				PaneID: "w2:pC", TabID: "w2:tC", Agent: "codex", AgentStatus: status,
+			}}}}
+			got, err := Check(context.Background(), h, "any", "", nil)
+			if err != nil {
+				t.Fatalf("Check() unexpected error: %v", err)
+			}
+			if !got.Safe {
+				t.Fatalf("status %s: safe = false, want true; busy=%+v", status, got.Busy)
+			}
+		})
+	}
+}
+
+func TestCheckRequireMinErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "not installed", err: herdr.ErrNotInstalled},
+		{name: "unsupported", err: herdr.ErrUnsupported},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := &scriptHerdr{minErr: tc.err}
+			_, err := Check(context.Background(), h, "any", "", nil)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("Check() error = %v, want %v", err, tc.err)
+			}
+		})
+	}
+}
+
+func TestCheckAgentListError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("agent list boom")
+	h := &scriptHerdr{lists: [][]herdr.Agent{{}}, listErrs: []error{want}}
+	_, err := Check(context.Background(), h, "any", "", nil)
+	if !errors.Is(err, want) {
+		t.Fatalf("Check() error = %v, want %v", err, want)
+	}
+}
+
+func TestMatchedTabsIncludesNilPane(t *testing.T) {
+	t.Parallel()
+
+	doc := scan.Document{PRs: []scan.PR{
+		{Tab: &scan.Tab{TabID: "w2:tC"}},
+		{Tab: nil},
+		{Tab: &scan.Tab{TabID: "w2:tD", PaneID: strPtr("w2:pD")}},
+	}}
+	got := MatchedTabs(doc)
+	if _, ok := got["w2:tC"]; !ok {
+		t.Fatalf("matched = %v, want w2:tC (nil pane_id still counts)", got)
+	}
+	if _, ok := got["w2:tD"]; !ok {
+		t.Fatalf("matched = %v, want w2:tD", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("matched = %v, want 2 tabs", got)
+	}
+}
+
+func TestWaitFlipsWorkingToIdle(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{
+		{workingAgent("w2:pC", "w2:tC")},
+		{idleAgent("w2:pC", "w2:tC")},
+	}}
+	clock := &fakeClock{now: time.Unix(0, 0).UTC()}
+	sleeper := &fakeSleeper{clock: clock}
+	cfg := config.Defaults()
+	cfg.GatePoll = time.Millisecond
+	cfg.GateTimeout = 50 * time.Millisecond
+
+	got, err := Wait(context.Background(), h, cfg, "", nil, clock, sleeper)
+	if err != nil {
+		t.Fatalf("Wait() unexpected error: %v", err)
+	}
+	if !got.Safe {
+		t.Fatalf("safe = false after flip, busy=%+v", got.Busy)
+	}
+	if h.n != 2 {
+		t.Fatalf("AgentList calls = %d, want 2 (busy then idle)", h.n)
+	}
+	if sleeper.n != 1 {
+		t.Fatalf("Sleep calls = %d, want 1", sleeper.n)
+	}
+}
+
+func TestWaitTimeoutStaysBusy(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pC", "w2:tC")}}}
+	clock := &fakeClock{now: time.Unix(0, 0).UTC()}
+	sleeper := &fakeSleeper{clock: clock}
+	cfg := config.Defaults()
+	cfg.GatePoll = time.Millisecond
+	cfg.GateTimeout = 3 * time.Millisecond
+
+	got, err := Wait(context.Background(), h, cfg, "", nil, clock, sleeper)
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Wait() error = %v, want ErrTimeout", err)
+	}
+	if got.Safe {
+		t.Fatal("safe = true on timeout, want false")
+	}
+}
+
+func TestWaitHonorsContextCancelDuringSleep(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pC", "w2:tC")}}}
+	clock := &fakeClock{now: time.Unix(0, 0).UTC()}
+	ctx, cancel := context.WithCancel(context.Background())
+	sleeper := &fakeSleeper{clock: clock, before: cancel}
+	cfg := config.Defaults()
+	cfg.GatePoll = time.Millisecond
+	cfg.GateTimeout = 50 * time.Millisecond
+
+	_, err := Wait(ctx, h, cfg, "", nil, clock, sleeper)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait() error = %v, want context.Canceled", err)
+	}
+}
+
+type scriptHerdr struct {
+	minErr   error
+	lists    [][]herdr.Agent
+	listErrs []error
+	n        int
+}
+
+func (s *scriptHerdr) RequireMin(context.Context, string) error { return s.minErr }
+
+func (s *scriptHerdr) AgentList(context.Context) ([]herdr.Agent, error) {
+	i := s.n
+	s.n++
+	if i < len(s.listErrs) && s.listErrs[i] != nil {
+		return nil, s.listErrs[i]
+	}
+	if len(s.lists) == 0 {
+		return nil, errors.New("no agent lists configured")
+	}
+	if i >= len(s.lists) {
+		i = len(s.lists) - 1
+	}
+	return s.lists[i], nil
+}
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+type fakeSleeper struct {
+	clock  *fakeClock
+	n      int
+	before func()
+}
+
+func (s *fakeSleeper) Sleep(ctx context.Context, d time.Duration) error {
+	s.n++
+	if s.before != nil {
+		s.before()
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("sleep: %w", err)
+	}
+	s.clock.now = s.clock.now.Add(d)
+	return nil
+}
+
+func workingAgent(paneID, tabID string) herdr.Agent {
+	return herdr.Agent{PaneID: paneID, TabID: tabID, Agent: "codex", AgentStatus: "working"}
+}
+
+func idleAgent(paneID, tabID string) herdr.Agent {
+	return herdr.Agent{PaneID: paneID, TabID: tabID, Agent: "codex", AgentStatus: "idle"}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary
- Add `internal/dispatch` (`Check`, `Wait`) and the one-shot `prsync gate` command.
- Busy set is all `working` agents (`concurrency_wait_on=any`) or only those whose `tab_id` is in this run's matched tab set (`managed`). Standalone `gate` + `managed` runs a scan.
- `runner_pane` comes from `HERDR_PANE_ID` only. Unset env + a successful `pane current` fixture does **not** exclude that pane and does **not** call `pane current`.
- Exit 0 if safe, 1 if the busy set is non-empty, 2 for usage/config, 3 if herdr is missing, unparseable, or `< 0.8`. Exit 1 remains "unsafe but herdr is up."

## Why
PR 4 of the #211 prsync plan. Operators can ask whether it is safe to start another agent before dispatch.

## Test plan
- [x] Fake clock/sleeper: busy while a fixture agent is `working`, `safe` when it flips
- [x] `managed` ignores unmatched working agents; nil-`pane_id` matched tabs still count
- [x] Integration via `cli.Execute` + `herdr-fake.sh` (idle/working, self-exclusion, herdr missing/old/unparseable, `any` does not need `gh`)
- [x] `make check`

Resolves #212