### PR TITLE
feat(prsync): add dry-run dispatch eligibility and prompt rendering

### DIFF
--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "dispatch.go",
         "exit.go",
         "gate.go",
         "root.go",
@@ -26,6 +27,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cli_dispatch_test.go",
         "cli_gate_test.go",
         "cli_scan_test.go",
         "cli_test.go",

--- a/devtools/prsync/internal/cli/cli_dispatch_test.go
+++ b/devtools/prsync/internal/cli/cli_dispatch_test.go
@@ -1,0 +1,364 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestPeekScanJSONLeadingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(scan.Document{
+		GeneratedAt:       "2026-01-01T09:00:00Z",
+		Author:            "alice",
+		Repos:             []string{"acme/widgets"},
+		PRs:               []scan.PR{{Repo: "acme/widgets", Number: 123, Unaddressed: true}},
+		InaccessibleRepos: []string{},
+		Warnings:          []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, isJSON, err := peekScanJSON(strings.NewReader("  \n" + string(raw)))
+	if err != nil {
+		t.Fatalf("peekScanJSON() error = %v", err)
+	}
+	if !isJSON {
+		t.Fatal("isJSON = false, want true")
+	}
+	if doc.Author != "alice" || len(doc.PRs) != 1 || doc.PRs[0].Number != 123 {
+		t.Fatalf("doc = %+v", doc)
+	}
+}
+
+func TestPeekScanJSONDecodeError(t *testing.T) {
+	t.Parallel()
+
+	_, isJSON, err := peekScanJSON(strings.NewReader("  \n{not-json"))
+	if err == nil {
+		t.Fatal("error = nil, want decode error")
+	}
+	if !isJSON {
+		t.Fatal("isJSON = false, want true so CLI fails loud")
+	}
+}
+
+func TestPeekScanJSONNonJSONFallsBack(t *testing.T) {
+	t.Parallel()
+
+	_, isJSON, err := peekScanJSON(strings.NewReader("not json"))
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if isJSON {
+		t.Fatal("isJSON = true, want false (internal scan)")
+	}
+}
+
+func TestPeekScanJSONEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, isJSON, err := peekScanJSON(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if isJSON {
+		t.Fatal("empty stdin should fall back to internal scan")
+	}
+}
+
+func TestStdinIsTTY(t *testing.T) {
+	t.Parallel()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		r.Close()
+		w.Close()
+	})
+	if stdinIsTTY(r) {
+		t.Fatal("pipe must not be a TTY")
+	}
+	if !stdinIsTTY(nil) {
+		t.Fatal("nil stdin treated as TTY (internal scan)")
+	}
+}
+
+func TestDispatchBadPR(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--pr", "not-a-pr"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid --pr") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestDispatchPRAndAll(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--pr", "acme/widgets#1", "--all"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot combine --pr and --all") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestDispatchStdinJSONDryRun(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	sentinel := filepath.Join(t.TempDir(), "prompt")
+	t.Setenv("HERDR_FAKE_PROMPT_SENTINEL", sentinel)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + statePath,
+	}, "\n")+"\n")
+
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, "  \n"+string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if !got.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %+v", got.Results)
+	}
+	if got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("action = %q, want would_dispatch", got.Results[0].Action)
+	}
+	if got.Results[0].RenderedPrompt == "" {
+		t.Fatal("rendered_prompt empty")
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("agent prompt was invoked")
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state_file was written on dry-run")
+	}
+}
+
+func TestDispatchStdinDecodeError(t *testing.T) {
+	restore := swapStdin(t, "  \n{not json")
+	defer restore()
+	cfgPath := writeScanConfig(t, "author=alice\nrepos=acme/widgets\nstate_file="+filepath.Join(t.TempDir(), "s.json")+"\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "stdin scan JSON") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestDispatchNotFoundPR(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{
+		"dispatch", "--config", cfgPath,
+		"--pr", "acme/widgets#123",
+		"--pr", "acme/missing#9",
+	}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2 (never drop)", len(got.Results))
+	}
+	actions := map[string]string{}
+	for _, r := range got.Results {
+		actions[r.Repo] = r.Action
+	}
+	if actions["acme/missing"] != dispatch.ActionSkippedNotFound {
+		t.Fatalf("actions = %v", actions)
+	}
+	if actions["acme/widgets"] != dispatch.ActionWouldDispatch {
+		t.Fatalf("actions = %v", actions)
+	}
+}
+
+func TestDispatchDoesNotInvokePromptOnInternalScan(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	sentinel := filepath.Join(t.TempDir(), "prompt")
+	t.Setenv("HERDR_FAKE_PROMPT_SENTINEL", sentinel)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("results = %+v", got.Results)
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("agent prompt was invoked")
+	}
+}
+
+func TestDispatchHerdrMissing(t *testing.T) {
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=prsync-test-missing-gh",
+		"herdr_bin=prsync-test-missing-herdr",
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "herdr") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestDispatchCorruptState(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(statePath, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"state_file=" + statePath,
+	}, "\n")+"\n")
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitUsage, stderr.String(), stdout.String())
+	}
+}
+
+func stdinEligibleDoc() scan.Document {
+	line := 42
+	id := "PROJ-123"
+	pane := "w2:pC"
+	return scan.Document{
+		GeneratedAt: "2026-01-01T09:00:00Z",
+		Author:      "alice",
+		Repos:       []string{"acme/widgets"},
+		PRs: []scan.PR{{
+			Repo:        "acme/widgets",
+			Number:      123,
+			Title:       "[PROJ-123] Fix the widget",
+			URL:         "https://github.com/acme/widgets/pull/123",
+			Identifier:  &id,
+			Unaddressed: true,
+			BlockingComments: []scan.Comment{{
+				ThreadID:  "PRRT_widget",
+				CommentID: "PRRC_widget",
+				Author:    "reviewer-login",
+				Path:      "src/widget.go",
+				Line:      &line,
+				URL:       "https://github.com/acme/widgets/pull/123#discussion_r1",
+				Body:      "This should handle the nil case.",
+			}},
+			Tab: &scan.Tab{
+				TabID: "w2:tC", PaneID: &pane, WorkspaceID: "w2",
+				Label: "PROJ-123", AgentStatus: "idle",
+			},
+		}},
+		InaccessibleRepos: []string{},
+		Warnings:          []string{},
+	}
+}
+
+func mustScanJSON(t *testing.T, doc scan.Document) []byte {
+	t.Helper()
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func decodeDispatch(t *testing.T, raw []byte) dispatch.Document {
+	t.Helper()
+	var got dispatch.Document
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, raw)
+	}
+	return got
+}
+
+func swapStdin(t *testing.T, body string) (restore func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdin
+	os.Stdin = r
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.WriteString(w, body)
+		_ = w.Close()
+		close(done)
+	}()
+	return func() {
+		<-done
+		os.Stdin = old
+		_ = r.Close()
+	}
+}

--- a/devtools/prsync/internal/cli/cli_test.go
+++ b/devtools/prsync/internal/cli/cli_test.go
@@ -45,19 +45,6 @@ func TestUnknownCommand(t *testing.T) {
 	}
 }
 
-func TestNoDispatchCommand(t *testing.T) {
-	t.Parallel()
-
-	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch"}, &stdout, &stderr, nil)
-	if code != ExitUsage {
-		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "unknown command") {
-		t.Fatalf("stderr = %q", stderr.String())
-	}
-}
-
 func TestReportKeyError(t *testing.T) {
 	t.Parallel()
 

--- a/devtools/prsync/internal/cli/dispatch.go
+++ b/devtools/prsync/internal/cli/dispatch.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+	"unicode"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+	executor "github.com/jaeyeom/go-cmdexec"
+	"github.com/spf13/cobra"
+)
+
+func newDispatchCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
+	var (
+		configPath string
+		prs        []string
+		all        bool
+	)
+	cmd := &cobra.Command{
+		Use:   "dispatch",
+		Short: "Send unmatched review comments to the matched herdr agent",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDispatch(cmd.Context(), stdout, exec, configPath, prs, all)
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
+	cmd.Flags().StringArrayVar(&prs, "pr", nil, "limit to owner/repo#N (repeatable)")
+	cmd.Flags().BoolVar(&all, "all", false, "dispatch every PR in the scan document")
+	cmd.Flags().Bool("go", false, "send prompts (default is dry-run)")
+	return cmd
+}
+
+func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, prs []string, all bool) error {
+	if all && len(prs) > 0 {
+		return &ExitError{Code: ExitUsage, Err: errors.New("cannot combine --pr and --all")}
+	}
+	for _, p := range prs {
+		if _, _, err := dispatch.ParsePR(p); err != nil {
+			return &ExitError{Code: ExitUsage, Err: err}
+		}
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	doc, err := loadScanDoc(ctx, cfg, exec)
+	if err != nil {
+		return err
+	}
+	h := herdr.NewClient(exec, cfg.HerdrBin)
+	out, err := dispatch.Run(ctx, h, dispatch.FileStore{Path: cfg.StateFile}, cfg, dispatch.Request{
+		Doc:        doc,
+		PRs:        prs,
+		RunnerPane: h.RunnerPane(ctx),
+	}, time.Now())
+	if writeErr := writeDispatchJSON(stdout, out); writeErr != nil {
+		return writeErr
+	}
+	if err != nil {
+		return dispatchExit(err, cfg)
+	}
+	return nil
+}
+
+func loadScanDoc(ctx context.Context, cfg config.Config, exec executor.Executor) (scan.Document, error) {
+	doc, fromStdin, err := readStdinScan(os.Stdin)
+	if err != nil {
+		return scan.Document{}, &ExitError{Code: ExitUsage, Err: fmt.Errorf("stdin scan JSON: %w", err)}
+	}
+	if fromStdin {
+		return doc, nil
+	}
+	deps := scan.Deps{
+		GH:    gh.NewClient(exec, cfg.GHBin),
+		Herdr: herdr.NewClient(exec, cfg.HerdrBin),
+	}
+	doc, err = scan.Run(ctx, deps, cfg, nil, time.Now())
+	if err != nil {
+		if scan.Started(doc) {
+			return doc, scanExit(err, cfg)
+		}
+		return scan.Document{}, scanExit(err, cfg)
+	}
+	return doc, nil
+}
+
+func readStdinScan(f *os.File) (scan.Document, bool, error) {
+	if stdinIsTTY(f) {
+		return scan.Document{}, false, nil
+	}
+	return peekScanJSON(f)
+}
+
+func stdinIsTTY(f *os.File) bool {
+	if f == nil {
+		return true
+	}
+	fi, err := f.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+func peekScanJSON(r io.Reader) (scan.Document, bool, error) {
+	br := bufio.NewReader(r)
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return scan.Document{}, false, nil
+			}
+			return scan.Document{}, false, fmt.Errorf("read stdin: %w", err)
+		}
+		if !unicode.IsSpace(rune(b)) {
+			if err := br.UnreadByte(); err != nil {
+				return scan.Document{}, false, fmt.Errorf("unread stdin: %w", err)
+			}
+			break
+		}
+	}
+	p, err := br.Peek(1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return scan.Document{}, false, fmt.Errorf("peek stdin: %w", err)
+	}
+	if len(p) != 1 || p[0] != '{' {
+		return scan.Document{}, false, nil
+	}
+	var doc scan.Document
+	if err := json.NewDecoder(br).Decode(&doc); err != nil {
+		return scan.Document{}, true, fmt.Errorf("decode scan JSON: %w", err)
+	}
+	return doc, true, nil
+}
+
+func writeDispatchJSON(w io.Writer, doc dispatch.Document) error {
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode dispatch: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", out); err != nil {
+		return fmt.Errorf("write dispatch: %w", err)
+	}
+	return nil
+}
+
+func dispatchExit(err error, cfg config.Config) error {
+	if errors.Is(err, dispatch.ErrCorruptState) {
+		return &ExitError{Code: ExitUsage, Err: err}
+	}
+	if errors.Is(err, herdr.ErrNotInstalled) {
+		return &ExitError{Code: ExitPrecondition, Err: fmt.Errorf("herdr binary not found (herdr_bin=%q)", cfg.HerdrBin)}
+	}
+	return scanExit(err, cfg)
+}

--- a/devtools/prsync/internal/cli/root.go
+++ b/devtools/prsync/internal/cli/root.go
@@ -29,6 +29,7 @@ func newRoot(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	}
 	root.AddCommand(newVersionCmd(stdout))
 	root.AddCommand(newScanCmd(stdout, exec))
+	root.AddCommand(newDispatchCmd(stdout, exec))
 	root.AddCommand(newGateCmd(stdout, exec))
 	return root
 }

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
@@ -37,6 +37,9 @@ case "${1-} ${2-}" in
     exit 0
     ;;
   "agent prompt")
+    if [ -n "${HERDR_FAKE_PROMPT_SENTINEL-}" ]; then
+      printf '%s\n' "called" > "$HERDR_FAKE_PROMPT_SENTINEL"
+    fi
     cat "${DIR}/herdr-agent-prompt.json"
     exit 0
     ;;

--- a/devtools/prsync/internal/dispatch/BUILD.bazel
+++ b/devtools/prsync/internal/dispatch/BUILD.bazel
@@ -2,19 +2,33 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["gate.go"],
+    srcs = [
+        "dispatch.go",
+        "gate.go",
+        "prompt.go",
+        "state.go",
+        "types.go",
+    ],
     importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch",
     visibility = ["//devtools/prsync:__subpackages__"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",
         "//devtools/prsync/internal/herdr:go_default_library",
         "//devtools/prsync/internal/scan:go_default_library",
+        "@com_github_google_renameio_v2//:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["gate_test.go"],
+    srcs = [
+        "dispatch_test.go",
+        "eligible_test.go",
+        "gate_test.go",
+        "prompt_test.go",
+        "state_test.go",
+    ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
         "//devtools/prsync/internal/config:go_default_library",

--- a/devtools/prsync/internal/dispatch/dispatch.go
+++ b/devtools/prsync/internal/dispatch/dispatch.go
@@ -1,0 +1,195 @@
+package dispatch
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+var prFlagPattern = regexp.MustCompile(`^([^/#]+/[^/#]+)#(\d+)$`)
+
+// StateStore loads dedupe state. Dry-run loads but never writes.
+type StateStore interface {
+	Load() (State, error)
+}
+
+// Request is the candidate-set input to Run.
+type Request struct {
+	Doc        scan.Document
+	PRs        []string
+	RunnerPane string
+}
+
+// Candidate is one PR considered for dispatch.
+type Candidate struct {
+	Repo   string
+	Number int
+	PR     *scan.PR
+}
+
+// ParsePR parses an owner/repo#N flag value.
+func ParsePR(s string) (string, int, error) {
+	m := prFlagPattern.FindStringSubmatch(s)
+	if m == nil {
+		return "", 0, fmt.Errorf("invalid --pr %q", s)
+	}
+	n, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid --pr %q: %w", s, err)
+	}
+	return m[1], n, nil
+}
+
+// Candidates builds the sorted candidate set from a scan document and --pr flags.
+// An empty PRs list means every PR in the document. A --pr absent from the
+// document is still returned (PR == nil) so it is never silently dropped.
+func Candidates(doc scan.Document, prs []string) ([]Candidate, error) {
+	byKey := make(map[string]scan.PR, len(doc.PRs))
+	for _, pr := range doc.PRs {
+		byKey[prKey(pr.Repo, pr.Number)] = pr
+	}
+	var out []Candidate
+	if len(prs) == 0 {
+		out = make([]Candidate, 0, len(doc.PRs))
+		for i := range doc.PRs {
+			pr := doc.PRs[i]
+			out = append(out, Candidate{Repo: pr.Repo, Number: pr.Number, PR: &pr})
+		}
+	} else {
+		out = make([]Candidate, 0, len(prs))
+		for _, raw := range prs {
+			repo, n, err := ParsePR(raw)
+			if err != nil {
+				return nil, err
+			}
+			c := Candidate{Repo: repo, Number: n}
+			if pr, ok := byKey[prKey(repo, n)]; ok {
+				p := pr
+				c.PR = &p
+			}
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Number < out[j].Number
+	})
+	return out, nil
+}
+
+// Evaluate returns the skip action for a candidate, or a zero Action if eligible.
+func Evaluate(c Candidate, cfg config.Config, st State) Item {
+	r := Item{Repo: c.Repo, Number: c.Number}
+	if c.PR == nil {
+		r.Action = ActionSkippedNotFound
+		return r
+	}
+	pr := *c.PR
+	switch {
+	case !pr.Unaddressed:
+		r.Action = ActionSkippedAddressed
+	case pr.IsDraft && !cfg.IncludeDrafts:
+		r.Action = ActionSkippedDraft
+	case pr.Tab == nil:
+		r.Action = ActionSkippedNoTab
+	case pr.Tab.PaneID == nil:
+		r.Action = ActionSkippedNoAgent
+	case !readyStatus(pr.Tab.AgentStatus):
+		r.Action = ActionSkippedBusy
+	case st.Deduped(prKey(c.Repo, c.Number), commentIDs(pr)):
+		r.Action = ActionSkippedDeduped
+	}
+	return r
+}
+
+// Run evaluates the candidate set. The dry-run path does a one-shot gate.Check,
+// never polls, never emits queued, and never writes state.
+func Run(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, now time.Time) (Document, error) {
+	doc := Document{
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		DryRun:      true,
+		Results:     []Item{},
+	}
+	cands, err := Candidates(req.Doc, req.PRs)
+	if err != nil {
+		return doc, err
+	}
+	st, err := loadState(store)
+	if err != nil {
+		return doc, err
+	}
+	for _, c := range cands {
+		doc.Results = append(doc.Results, evaluateDry(c, cfg, st))
+	}
+	if err := annotateGate(ctx, h, cfg, req, &doc); err != nil {
+		return doc, err
+	}
+	return doc, nil
+}
+
+func evaluateDry(c Candidate, cfg config.Config, st State) Item {
+	r := Evaluate(c, cfg, st)
+	if r.Action != "" {
+		return r
+	}
+	pr := *c.PR
+	r.Action = ActionWouldDispatch
+	r.PaneID = *pr.Tab.PaneID
+	r.RenderedPrompt = Render(cfg.PromptTemplate, pr)
+	return r
+}
+
+func annotateGate(ctx context.Context, h Herdr, cfg config.Config, req Request, doc *Document) error {
+	res, err := Check(ctx, h, cfg.ConcurrencyWaitOn, req.RunnerPane, MatchedTabs(req.Doc))
+	if err != nil {
+		return fmt.Errorf("gate: %w", err)
+	}
+	if res.Safe || len(res.Busy) == 0 {
+		return nil
+	}
+	detail := fmt.Sprintf("gate currently busy: pane %s working", res.Busy[0].PaneID)
+	for i := range doc.Results {
+		if doc.Results[i].Action == ActionWouldDispatch {
+			doc.Results[i].Detail = detail
+		}
+	}
+	return nil
+}
+
+func loadState(store StateStore) (State, error) {
+	if store == nil {
+		return State{}, nil
+	}
+	st, err := store.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load state: %w", err)
+	}
+	if st == nil {
+		st = State{}
+	}
+	return st, nil
+}
+
+func readyStatus(status string) bool {
+	return status == "idle" || status == "done"
+}
+
+func commentIDs(pr scan.PR) []string {
+	ids := make([]string, 0, len(pr.BlockingComments))
+	for _, c := range pr.BlockingComments {
+		ids = append(ids, c.CommentID)
+	}
+	return ids
+}
+
+func prKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}

--- a/devtools/prsync/internal/dispatch/dispatch_test.go
+++ b/devtools/prsync/internal/dispatch/dispatch_test.go
@@ -1,0 +1,226 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+var fixtureNow = time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+
+func TestRunDryRunGolden(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	doc := goldenScanDoc()
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	pre := State{}
+	pre.Record("acme/widgets#204", []string{"PRRC_old"}, fixtureNow)
+	if err := SaveFile(store.Path, pre); err != nil {
+		t.Fatal(err)
+	}
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+
+	gotDoc, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: doc,
+		PRs: []string{
+			"acme/gizmos#50",
+			"acme/missing#9",
+			"acme/widgets#123",
+			"acme/widgets#200",
+			"acme/widgets#201",
+			"acme/widgets#202",
+			"acme/widgets#203",
+			"acme/widgets#204",
+		},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if !gotDoc.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if len(gotDoc.Results) != 8 {
+		t.Fatalf("len(results) = %d, want 8 (never silently drop)", len(gotDoc.Results))
+	}
+
+	got, err := json.MarshalIndent(gotDoc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = append(got, '\n')
+	path := filepath.Join("testdata", "golden", "dispatch-dry-run.json")
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, got, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // testdata path
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRunDryRunDoesNotWriteState(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := FileStore{Path: path}
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+	cfg := config.Defaults()
+	_, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("state file written on dry-run: %v", err)
+	}
+}
+
+func TestRunDryRunDoesNotPoll(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pX", "w2:tX")}}}
+	cfg := config.Defaults()
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if h.n != 1 {
+		t.Fatalf("AgentList calls = %d, want 1 (one-shot Check, never poll)", h.n)
+	}
+	if got.Results[0].Action != ActionWouldDispatch {
+		t.Fatalf("action = %q, want would_dispatch (never queued)", got.Results[0].Action)
+	}
+	if got.Results[0].Detail != "gate currently busy: pane w2:pX working" {
+		t.Fatalf("detail = %q", got.Results[0].Detail)
+	}
+}
+
+func TestRunDryRunNeverQueued(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{
+		{workingAgent("w2:pX", "w2:tX")},
+		{idleAgent("w2:pX", "w2:tX")},
+	}}
+	cfg := config.Defaults()
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	for _, r := range got.Results {
+		if r.Action == ActionQueued {
+			t.Fatalf("dry-run emitted queued: %+v", r)
+		}
+	}
+	if h.n != 1 {
+		t.Fatalf("AgentList calls = %d, want 1", h.n)
+	}
+}
+
+func TestRunDryRunHerdrRequired(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{minErr: herdr.ErrNotInstalled}
+	cfg := config.Defaults()
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	_, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if !errors.Is(err, herdr.ErrNotInstalled) {
+		t.Fatalf("error = %v, want ErrNotInstalled", err)
+	}
+}
+
+func TestRunRecordsEveryInputPR(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+	cfg := config.Defaults()
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+		PRs: []string{"acme/widgets#123", "acme/missing#1"},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	actions := map[string]string{}
+	for _, r := range got.Results {
+		actions[r.Repo+"#"+itoa(r.Number)] = r.Action
+	}
+	if actions["acme/widgets#123"] != ActionWouldDispatch {
+		t.Fatalf("actions = %v", actions)
+	}
+	if actions["acme/missing#1"] != ActionSkippedNotFound {
+		t.Fatalf("actions = %v", actions)
+	}
+}
+
+func goldenScanDoc() scan.Document {
+	addr := fixtureEligiblePR()
+	addr.Repo = "acme/gizmos"
+	addr.Number = 50
+	addr.Unaddressed = false
+	addr.BlockingComments = nil
+
+	draft := fixtureEligiblePR()
+	draft.Number = 200
+	draft.IsDraft = true
+
+	noTab := fixtureEligiblePR()
+	noTab.Number = 201
+	noTab.Tab = nil
+
+	noPane := fixtureEligiblePR()
+	noPane.Number = 202
+	noPane.Tab.PaneID = nil
+
+	busy := fixtureEligiblePR()
+	busy.Number = 203
+	busy.Tab.AgentStatus = "working"
+
+	deduped := fixtureEligiblePR()
+	deduped.Number = 204
+	deduped.BlockingComments[0].CommentID = "PRRC_old"
+
+	return scan.Document{PRs: []scan.PR{
+		addr, fixtureEligiblePR(), draft, noTab, noPane, busy, deduped,
+	}}
+}
+
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}

--- a/devtools/prsync/internal/dispatch/eligible_test.go
+++ b/devtools/prsync/internal/dispatch/eligible_test.go
@@ -1,0 +1,215 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+func TestEligibleSkipReasons(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	tests := []struct {
+		name string
+		c    Candidate
+		cfg  config.Config
+		st   State
+		want string
+	}{
+		{
+			name: "not found",
+			c:    Candidate{Repo: "acme/missing", Number: 9},
+			cfg:  cfg,
+			want: ActionSkippedNotFound,
+		},
+		{
+			name: "addressed",
+			c:    Candidate{Repo: "acme/widgets", Number: 1, PR: prWith(func(p *scan.PR) { p.Unaddressed = false; p.BlockingComments = nil })},
+			cfg:  cfg,
+			want: ActionSkippedAddressed,
+		},
+		{
+			name: "draft",
+			c:    Candidate{Repo: "acme/widgets", Number: 1, PR: prWith(func(p *scan.PR) { p.IsDraft = true })},
+			cfg:  cfg,
+			want: ActionSkippedDraft,
+		},
+		{
+			name: "no tab",
+			c:    Candidate{Repo: "acme/widgets", Number: 1, PR: prWith(func(p *scan.PR) { p.Tab = nil })},
+			cfg:  cfg,
+			want: ActionSkippedNoTab,
+		},
+		{
+			name: "no agent",
+			c:    Candidate{Repo: "acme/widgets", Number: 1, PR: prWith(func(p *scan.PR) { p.Tab.PaneID = nil })},
+			cfg:  cfg,
+			want: ActionSkippedNoAgent,
+		},
+		{
+			name: "busy working",
+			c:    Candidate{Repo: "acme/widgets", Number: 1, PR: prWith(func(p *scan.PR) { p.Tab.AgentStatus = "working" })},
+			cfg:  cfg,
+			want: ActionSkippedBusy,
+		},
+		{
+			name: "busy blocked",
+			c:    Candidate{Repo: "acme/widgets", Number: 1, PR: prWith(func(p *scan.PR) { p.Tab.AgentStatus = "blocked" })},
+			cfg:  cfg,
+			want: ActionSkippedBusy,
+		},
+		{
+			name: "deduped",
+			c:    Candidate{Repo: "acme/widgets", Number: 123, PR: prWith(nil)},
+			cfg:  cfg,
+			st:   State{"acme/widgets#123": {DispatchedCommentIDs: []string{"PRRC_widget"}}},
+			want: ActionSkippedDeduped,
+		},
+		{
+			name: "eligible idle",
+			c:    Candidate{Repo: "acme/widgets", Number: 123, PR: prWith(nil)},
+			cfg:  cfg,
+			want: "",
+		},
+		{
+			name: "eligible done",
+			c:    Candidate{Repo: "acme/widgets", Number: 123, PR: prWith(func(p *scan.PR) { p.Tab.AgentStatus = "done" })},
+			cfg:  cfg,
+			want: "",
+		},
+		{
+			name: "include drafts",
+			c:    Candidate{Repo: "acme/widgets", Number: 123, PR: prWith(func(p *scan.PR) { p.IsDraft = true })},
+			cfg:  func() config.Config { c := config.Defaults(); c.IncludeDrafts = true; return c }(),
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Evaluate(tc.c, tc.cfg, tc.st)
+			if got.Action != tc.want {
+				t.Fatalf("action = %q, want %q", got.Action, tc.want)
+			}
+			if got.Repo != tc.c.Repo || got.Number != tc.c.Number {
+				t.Fatalf("result = %+v, want repo/number from candidate", got)
+			}
+		})
+	}
+}
+
+func TestParsePR(t *testing.T) {
+	t.Parallel()
+
+	repo, n, err := ParsePR("acme/widgets#123")
+	if err != nil {
+		t.Fatalf("ParsePR() error = %v", err)
+	}
+	if repo != "acme/widgets" || n != 123 {
+		t.Fatalf("ParsePR() = %s #%d", repo, n)
+	}
+}
+
+func TestParsePRInvalid(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"widgets#123", "acme/widgets", "acme/widgets#", "acme/widgets#x", "#123", "acme/#1"} {
+		if _, _, err := ParsePR(in); err == nil {
+			t.Fatalf("ParsePR(%q) error = nil, want error", in)
+		}
+	}
+}
+
+func TestCandidatesFromDocument(t *testing.T) {
+	t.Parallel()
+
+	doc := scan.Document{PRs: []scan.PR{
+		{Repo: "acme/widgets", Number: 200},
+		{Repo: "acme/gizmos", Number: 50},
+		{Repo: "acme/widgets", Number: 123},
+	}}
+	got, err := Candidates(doc, nil)
+	if err != nil {
+		t.Fatalf("Candidates() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].Repo != "acme/gizmos" || got[0].Number != 50 {
+		t.Fatalf("first = %s#%d, want acme/gizmos#50", got[0].Repo, got[0].Number)
+	}
+	if got[1].Repo != "acme/widgets" || got[1].Number != 123 {
+		t.Fatalf("second = %s#%d, want acme/widgets#123", got[1].Repo, got[1].Number)
+	}
+	if got[2].Repo != "acme/widgets" || got[2].Number != 200 {
+		t.Fatalf("third = %s#%d, want acme/widgets#200", got[2].Repo, got[2].Number)
+	}
+}
+
+func TestCandidatesFromFlagsIncludesMissing(t *testing.T) {
+	t.Parallel()
+
+	doc := scan.Document{PRs: []scan.PR{{Repo: "acme/widgets", Number: 123}}}
+	got, err := Candidates(doc, []string{"acme/missing#9", "acme/widgets#123"})
+	if err != nil {
+		t.Fatalf("Candidates() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (never drop --pr)", len(got))
+	}
+	if got[0].Repo != "acme/missing" || got[0].PR != nil {
+		t.Fatalf("first = %+v, want missing not found", got[0])
+	}
+	if got[1].PR == nil || got[1].Number != 123 {
+		t.Fatalf("second = %+v, want widgets#123", got[1])
+	}
+}
+
+func TestCandidatesBadFlag(t *testing.T) {
+	t.Parallel()
+
+	_, err := Candidates(scan.Document{}, []string{"nope"})
+	if err == nil {
+		t.Fatal("Candidates(bad --pr) error = nil, want error")
+	}
+}
+
+func fixtureEligiblePR() scan.PR {
+	line := 42
+	id := "PROJ-123"
+	pane := "w2:pC"
+	return scan.PR{
+		Repo:        "acme/widgets",
+		Number:      123,
+		Title:       "[PROJ-123] Fix the widget",
+		URL:         "https://github.com/acme/widgets/pull/123",
+		Identifier:  &id,
+		Unaddressed: true,
+		BlockingComments: []scan.Comment{{
+			ThreadID:  "PRRT_widget",
+			CommentID: "PRRC_widget",
+			Author:    "reviewer-login",
+			Path:      "src/widget.go",
+			Line:      &line,
+			URL:       "https://github.com/acme/widgets/pull/123#discussion_r1",
+			Body:      "This should handle the nil case.",
+		}},
+		Tab: &scan.Tab{
+			TabID:       "w2:tC",
+			PaneID:      &pane,
+			WorkspaceID: "w2",
+			Label:       "PROJ-123",
+			AgentStatus: "idle",
+		},
+	}
+}
+
+func prWith(edit func(*scan.PR)) *scan.PR {
+	p := fixtureEligiblePR()
+	if edit != nil {
+		edit(&p)
+	}
+	return &p
+}

--- a/devtools/prsync/internal/dispatch/gate.go
+++ b/devtools/prsync/internal/dispatch/gate.go
@@ -1,4 +1,4 @@
-// Package dispatch implements the prsync concurrency gate.
+// Package dispatch implements eligibility, dry-run dispatch, and the concurrency gate.
 package dispatch
 
 import (

--- a/devtools/prsync/internal/dispatch/prompt.go
+++ b/devtools/prsync/internal/dispatch/prompt.go
@@ -1,0 +1,56 @@
+package dispatch
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+// Render substitutes prompt template variables with PR fields.
+// Replacement is literal strings.ReplaceAll, longest key first.
+func Render(tmpl string, pr scan.PR) string {
+	id := ""
+	if pr.Identifier != nil {
+		id = *pr.Identifier
+	}
+	vars := []struct {
+		key string
+		val string
+	}{
+		{"{identifier}", id},
+		{"{comments}", formatComments(pr.BlockingComments)},
+		{"{number}", strconv.Itoa(pr.Number)},
+		{"{title}", pr.Title},
+		{"{repo}", pr.Repo},
+		{"{url}", pr.URL},
+	}
+	sort.Slice(vars, func(i, j int) bool {
+		return len(vars[i].key) > len(vars[j].key)
+	})
+	out := tmpl
+	for _, v := range vars {
+		out = strings.ReplaceAll(out, v.key, v.val)
+	}
+	return out
+}
+
+func formatComments(comments []scan.Comment) string {
+	lines := make([]string, 0, len(comments))
+	for _, c := range comments {
+		lines = append(lines, formatComment(c))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatComment(c scan.Comment) string {
+	if c.Path == "" {
+		return fmt.Sprintf("- (no path) — %s: %s (%s)", c.Author, c.Body, c.URL)
+	}
+	if c.Line == nil {
+		return fmt.Sprintf("- %s — %s: %s (%s)", c.Path, c.Author, c.Body, c.URL)
+	}
+	return fmt.Sprintf("- %s:%d — %s: %s (%s)", c.Path, *c.Line, c.Author, c.Body, c.URL)
+}

--- a/devtools/prsync/internal/dispatch/prompt_test.go
+++ b/devtools/prsync/internal/dispatch/prompt_test.go
@@ -1,0 +1,113 @@
+package dispatch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+func TestRenderAllVariables(t *testing.T) {
+	t.Parallel()
+
+	line := 42
+	id := "PROJ-123"
+	pr := scan.PR{
+		Repo:       "acme/widgets",
+		Number:     123,
+		Title:      "[PROJ-123] Fix the widget",
+		URL:        "https://github.com/acme/widgets/pull/123",
+		Identifier: &id,
+		BlockingComments: []scan.Comment{{
+			Author: "reviewer-login",
+			Path:   "src/widget.go",
+			Line:   &line,
+			URL:    "https://github.com/acme/widgets/pull/123#discussion_r1",
+			Body:   "This should handle the nil case.",
+		}},
+	}
+	tmpl := "{repo} {number} {url} {identifier} {title}\n{comments}"
+	got := Render(tmpl, pr)
+	want := "acme/widgets 123 https://github.com/acme/widgets/pull/123 PROJ-123 [PROJ-123] Fix the widget\n" +
+		"- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)"
+	if got != want {
+		t.Fatalf("Render() = %q\nwant %q", got, want)
+	}
+}
+
+func TestRenderNullLine(t *testing.T) {
+	t.Parallel()
+
+	pr := scan.PR{
+		BlockingComments: []scan.Comment{{
+			Author: "r",
+			Path:   "src/widget.go",
+			URL:    "u",
+			Body:   "nits",
+		}},
+	}
+	got := Render("{comments}", pr)
+	want := "- src/widget.go — r: nits (u)"
+	if got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	line := 7
+	pr := scan.PR{
+		BlockingComments: []scan.Comment{{
+			Author: "r",
+			Path:   "",
+			Line:   &line,
+			URL:    "u",
+			Body:   "overall",
+		}},
+	}
+	got := Render("{comments}", pr)
+	want := "- (no path) — r: overall (u)"
+	if got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDefaultTemplate(t *testing.T) {
+	t.Parallel()
+
+	line := 42
+	pr := fixtureEligiblePR()
+	pr.BlockingComments[0].Line = &line
+	got := Render(config.Defaults().PromptTemplate, pr)
+	if !strings.Contains(got, "PR #123 (https://github.com/acme/widgets/pull/123)") {
+		t.Fatalf("missing number/url: %q", got)
+	}
+	if !strings.Contains(got, "- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)") {
+		t.Fatalf("missing comments: %q", got)
+	}
+	if strings.Contains(got, "{") {
+		t.Fatalf("unreplaced placeholder: %q", got)
+	}
+}
+
+func TestRenderLongestKeyFirst(t *testing.T) {
+	t.Parallel()
+
+	id := "PROJ-123"
+	pr := scan.PR{Identifier: &id, Number: 9}
+	got := Render("{identifier} {number}", pr)
+	if got != "PROJ-123 9" {
+		t.Fatalf("Render() = %q, want %q", got, "PROJ-123 9")
+	}
+}
+
+func TestRenderNilIdentifier(t *testing.T) {
+	t.Parallel()
+
+	got := Render("id={identifier}.", scan.PR{})
+	if got != "id=." {
+		t.Fatalf("Render() = %q, want %q", got, "id=.")
+	}
+}

--- a/devtools/prsync/internal/dispatch/state.go
+++ b/devtools/prsync/internal/dispatch/state.go
@@ -1,0 +1,100 @@
+package dispatch
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/renameio/v2"
+)
+
+// ErrCorruptState is returned when state_file exists but is not valid JSON.
+var ErrCorruptState = errors.New("corrupt state file")
+
+// State is the on-disk dedupe map keyed by owner/repo#N.
+type State map[string]Entry
+
+// Entry is one PR's last successful dispatch.
+type Entry struct {
+	DispatchedCommentIDs []string `json:"dispatched_comment_ids"` //nolint:tagliatelle // brief outbound contract
+	DispatchedAt         string   `json:"dispatched_at"`          //nolint:tagliatelle // brief outbound contract
+}
+
+// FileStore loads dispatch state from a JSON file.
+type FileStore struct {
+	Path string
+}
+
+// Load implements StateStore.
+func (s FileStore) Load() (State, error) {
+	return LoadFile(s.Path)
+}
+
+// Deduped reports whether current comment IDs are a subset of the stored set.
+func (s State) Deduped(key string, commentIDs []string) bool {
+	if s == nil {
+		return false
+	}
+	entry, ok := s[key]
+	if !ok {
+		return false
+	}
+	stored := make(map[string]struct{}, len(entry.DispatchedCommentIDs))
+	for _, id := range entry.DispatchedCommentIDs {
+		stored[id] = struct{}{}
+	}
+	for _, id := range commentIDs {
+		if _, ok := stored[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Record replaces the stored comment-id set for key. It does not union.
+func (s State) Record(key string, commentIDs []string, at time.Time) {
+	ids := append([]string(nil), commentIDs...)
+	s[key] = Entry{
+		DispatchedCommentIDs: ids,
+		DispatchedAt:         at.UTC().Format(time.RFC3339),
+	}
+}
+
+// LoadFile reads state from path. A missing file is empty state.
+func LoadFile(path string) (State, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is the configured state_file
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return State{}, nil
+		}
+		return nil, fmt.Errorf("read state file: %w", err)
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCorruptState, err)
+	}
+	if st == nil {
+		st = State{}
+	}
+	return st, nil
+}
+
+// SaveFile writes state atomically. Parent dirs are created with 0700.
+func SaveFile(path string, st State) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := renameio.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write state file: %w", err)
+	}
+	return nil
+}

--- a/devtools/prsync/internal/dispatch/state_test.go
+++ b/devtools/prsync/internal/dispatch/state_test.go
@@ -1,0 +1,127 @@
+package dispatch
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDedupeEmptyState(t *testing.T) {
+	t.Parallel()
+
+	st := State{}
+	if st.Deduped("acme/widgets#123", []string{"PRRC_a"}) {
+		t.Fatal("empty state must not be deduped")
+	}
+}
+
+func TestDedupeSubset(t *testing.T) {
+	t.Parallel()
+
+	st := State{"acme/widgets#123": {DispatchedCommentIDs: []string{"PRRC_a", "PRRC_b"}}}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_a"}) {
+		t.Fatal("subset of stored ids must be deduped")
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_a", "PRRC_b"}) {
+		t.Fatal("equal set must be deduped")
+	}
+}
+
+func TestDedupeNewID(t *testing.T) {
+	t.Parallel()
+
+	st := State{"acme/widgets#123": {DispatchedCommentIDs: []string{"PRRC_a"}}}
+	if st.Deduped("acme/widgets#123", []string{"PRRC_a", "PRRC_b"}) {
+		t.Fatal("new comment id must not be deduped")
+	}
+}
+
+func TestDedupeReplaceNotUnion(t *testing.T) {
+	t.Parallel()
+
+	st := State{}
+	at := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	st.Record("acme/widgets#123", []string{"PRRC_a", "PRRC_b"}, at)
+	st.Record("acme/widgets#123", []string{"PRRC_c"}, at)
+	got := st["acme/widgets#123"].DispatchedCommentIDs
+	want := []string{"PRRC_c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ids = %v, want %v (replace, not union)", got, want)
+	}
+	if st["acme/widgets#123"].DispatchedAt != "2026-01-01T09:00:00Z" {
+		t.Fatalf("dispatched_at = %q", st["acme/widgets#123"].DispatchedAt)
+	}
+}
+
+func TestLoadFileMissingIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	st, err := LoadFile(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("LoadFile(missing) error = %v", err)
+	}
+	if len(st) != 0 {
+		t.Fatalf("state = %#v, want empty", st)
+	}
+}
+
+func TestLoadFileCorrupt(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadFile(path)
+	if err == nil {
+		t.Fatal("LoadFile(corrupt) error = nil, want error")
+	}
+	if !errors.Is(err, ErrCorruptState) {
+		t.Fatalf("error = %v, want ErrCorruptState", err)
+	}
+}
+
+func TestSaveFileRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "state.json")
+	st := State{}
+	st.Record("acme/widgets#123", []string{"PRRC_a"}, time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	if err := SaveFile(path, st); err != nil {
+		t.Fatalf("SaveFile() error = %v", err)
+	}
+	got, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !reflect.DeepEqual(got["acme/widgets#123"].DispatchedCommentIDs, []string{"PRRC_a"}) {
+		t.Fatalf("round-trip = %#v", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("perm = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestFileStoreLoad(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state.json")
+	st := State{"acme/widgets#1": {DispatchedCommentIDs: []string{"x"}}}
+	if err := SaveFile(path, st); err != nil {
+		t.Fatal(err)
+	}
+	got, err := FileStore{Path: path}.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !got.Deduped("acme/widgets#1", []string{"x"}) {
+		t.Fatalf("loaded state = %#v", got)
+	}
+}

--- a/devtools/prsync/internal/dispatch/testdata/golden/dispatch-dry-run.json
+++ b/devtools/prsync/internal/dispatch/testdata/golden/dispatch-dry-run.json
@@ -1,0 +1,48 @@
+{
+  "generated_at": "2026-01-01T09:00:00Z",
+  "dry_run": true,
+  "results": [
+    {
+      "repo": "acme/gizmos",
+      "number": 50,
+      "action": "skipped_addressed"
+    },
+    {
+      "repo": "acme/missing",
+      "number": 9,
+      "action": "skipped_not_found"
+    },
+    {
+      "repo": "acme/widgets",
+      "number": 123,
+      "action": "would_dispatch",
+      "pane_id": "w2:pC",
+      "rendered_prompt": "Address the unresolved review comments on PR #123 (https://github.com/acme/widgets/pull/123).\n\nUnaddressed threads:\n- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)\n\nFor each thread: understand the reviewer's ask, make the change (or reply if you\ndisagree, with reasoning), resolve the thread, and push. Do not touch other PRs."
+    },
+    {
+      "repo": "acme/widgets",
+      "number": 200,
+      "action": "skipped_draft"
+    },
+    {
+      "repo": "acme/widgets",
+      "number": 201,
+      "action": "skipped_no_tab"
+    },
+    {
+      "repo": "acme/widgets",
+      "number": 202,
+      "action": "skipped_no_agent"
+    },
+    {
+      "repo": "acme/widgets",
+      "number": 203,
+      "action": "skipped_busy"
+    },
+    {
+      "repo": "acme/widgets",
+      "number": 204,
+      "action": "skipped_deduped"
+    }
+  ]
+}

--- a/devtools/prsync/internal/dispatch/types.go
+++ b/devtools/prsync/internal/dispatch/types.go
@@ -1,0 +1,35 @@
+package dispatch
+
+// Action values in a dispatch result.
+const (
+	ActionWouldDispatch     = "would_dispatch"
+	ActionDispatched        = "dispatched"
+	ActionDispatchedTimeout = "dispatched_timeout"
+	ActionSkippedNoTab      = "skipped_no_tab"
+	ActionSkippedNoAgent    = "skipped_no_agent"
+	ActionSkippedBusy       = "skipped_busy"
+	ActionSkippedDeduped    = "skipped_deduped"
+	ActionSkippedDraft      = "skipped_draft"
+	ActionSkippedStalled    = "skipped_stalled"
+	ActionSkippedAddressed  = "skipped_addressed"
+	ActionSkippedNotFound   = "skipped_not_found"
+	ActionQueued            = "queued"
+	ActionFailed            = "failed"
+)
+
+// Document is the outbound dispatch JSON document.
+type Document struct {
+	GeneratedAt string `json:"generated_at"` //nolint:tagliatelle // brief outbound contract
+	DryRun      bool   `json:"dry_run"`      //nolint:tagliatelle // brief outbound contract
+	Results     []Item `json:"results"`
+}
+
+// Item is one PR's dispatch outcome.
+type Item struct {
+	Repo           string `json:"repo"`
+	Number         int    `json:"number"`
+	Action         string `json:"action"`
+	PaneID         string `json:"pane_id,omitempty"`         //nolint:tagliatelle // brief outbound contract
+	RenderedPrompt string `json:"rendered_prompt,omitempty"` //nolint:tagliatelle // brief outbound contract
+	Detail         string `json:"detail,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Add dry-run `prsync dispatch`: candidate set, skip reasons (`skipped_addressed`, `skipped_not_found`, and the rest), and a rendered prompt on `would_dispatch`.
- Stdin scan-JSON peek uses `Stat()` TTY detection plus `bufio` skip-ws / `Peek` / `UnreadByte`. Piped `"  \n{...}"` decodes; decode errors are exit 2 (no silent rescan).
- Dry-run does a one-shot `gate.Check`, never polls, never emits `queued`, and annotates `detail` when the gate is currently busy. It never calls `herdr agent prompt` and never writes `state_file`.
- State store (`Load` / `Deduped` / `Record` / `SaveFile`) is implemented and unit-tested; the dry-run path only loads it for dedupe.

## Why
PR 5 of the #211 prsync plan. Operators can see which PRs would be prompted, including the exact prompt text, without sending anything.

## Test plan
- [x] Golden dry-run output (`testdata/golden/dispatch-dry-run.json`)
- [x] Every input PR appears in JSON (never silently dropped), including `--pr` not in the scan document
- [x] Eligibility table: one case per skip reason; `idle`/`done` eligible
- [x] Prompt render: all six variables, null line, empty path
- [x] Dedupe: empty state, subset, new id, replace-not-union
- [x] Dry-run: one-shot gate, no poll, no `queued`, no state write, no `agent prompt`
- [x] CLI: stdin peek, `--pr`+`--all`, herdr missing, corrupt state
- [x] `make check`

Resolves #217