### PR TITLE
feat(prsync): add live dispatch --go with dedupe and gate timeout

### DIFF
--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     srcs = [
         "cli_dispatch_test.go",
         "cli_gate_test.go",
+        "cli_integration_test.go",
         "cli_scan_test.go",
         "cli_test.go",
     ],

--- a/devtools/prsync/internal/cli/cli_integration_test.go
+++ b/devtools/prsync/internal/cli/cli_integration_test.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestDispatchGoThenDeduped(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+	raw := mustScanJSON(t, stdinEligibleDoc())
+
+	restore := swapStdin(t, string(raw))
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	restore()
+	if code != ExitOK {
+		t.Fatalf("first --go exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if got.DryRun {
+		t.Fatal("dry_run = true, want false")
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionDispatched {
+		t.Fatalf("first results = %+v, want dispatched", got.Results)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state_file missing after --go: %v", err)
+	}
+
+	restore = swapStdin(t, string(raw))
+	stdout.Reset()
+	stderr.Reset()
+	code = Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	restore()
+	if code != ExitOK {
+		t.Fatalf("second --go exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got = decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionSkippedDeduped {
+		t.Fatalf("second results = %+v, want skipped_deduped", got.Results)
+	}
+}
+
+func TestDispatchGoStallDoesNotWriteState(t *testing.T) {
+	t.Setenv("HERDR_FAKE_PROMPT", "stall")
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionSkippedStalled {
+		t.Fatalf("results = %+v, want skipped_stalled", got.Results)
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state_file written on stall")
+	}
+}
+
+func TestDispatchGoDoneSettlementIsDispatched(t *testing.T) {
+	statusFile := filepath.Join(t.TempDir(), "status")
+	if err := os.WriteFile(statusFile, []byte("idle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERDR_FAKE_STATUS_FILE", statusFile)
+	t.Setenv("HERDR_FAKE_SETTLE", "done")
+	t.Setenv("HERDR_FAKE_PROMPT", "done")
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionDispatched {
+		t.Fatalf("results = %+v, want dispatched (done settlement)", got.Results)
+	}
+	if got.Results[0].Action == dispatch.ActionDispatchedTimeout {
+		t.Fatal("done settlement must not be dispatched_timeout")
+	}
+	settled, err := os.ReadFile(statusFile) //nolint:gosec // test status file
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(settled)) != "done" {
+		t.Fatalf("status file = %q, want done", settled)
+	}
+}
+
+func TestDispatchGoHerdrTimeoutWritesState(t *testing.T) {
+	t.Setenv("HERDR_FAKE_PROMPT", "timeout")
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionDispatchedTimeout {
+		t.Fatalf("results = %+v, want dispatched_timeout", got.Results)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state_file missing after herdr timeout: %v", err)
+	}
+}
+
+func TestDispatchGoMidLoopFatalPartialJSON(t *testing.T) {
+	countFile := filepath.Join(t.TempDir(), "prompt-count")
+	t.Setenv("HERDR_FAKE_PROMPT_SEQ", "success,unparseable")
+	t.Setenv("HERDR_FAKE_PROMPT_COUNT", countFile)
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+	raw := mustScanJSON(t, stdinTwoEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2\n%s", len(got.Results), stdout.String())
+	}
+	if got.Results[0].Action != dispatch.ActionDispatched || got.Results[1].Action != dispatch.ActionFailed {
+		t.Fatalf("results = %+v, want dispatched + failed", got.Results)
+	}
+	st, err := dispatch.LoadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state missing first PR: %#v", st)
+	}
+	if _, ok := st["acme/widgets#124"]; ok {
+		t.Fatalf("state has second PR: %#v", st)
+	}
+}
+
+func TestDispatchGoGateTimeoutExit4(t *testing.T) {
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+	raw := mustScanJSON(t, stdinTwoEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitGateTimeout {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitGateTimeout, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	for _, r := range got.Results {
+		if r.Action != dispatch.ActionQueued {
+			t.Fatalf("result = %+v, want queued", r)
+		}
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state_file written on gate timeout")
+	}
+}
+
+func writeLiveConfig(t *testing.T, ghBin, herdrBin, statePath string) string {
+	t.Helper()
+	return writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + statePath,
+		"gate_poll_ms=1",
+		"gate_timeout_ms=50",
+		"dispatch_timeout_ms=1000",
+	}, "\n")+"\n")
+}
+
+func stdinTwoEligibleDoc() scan.Document {
+	doc := stdinEligibleDoc()
+	second := doc.PRs[0]
+	second.Number = 124
+	second.URL = "https://github.com/acme/widgets/pull/124"
+	pane := "w2:pD"
+	tab := *second.Tab
+	tab.PaneID = &pane
+	tab.TabID = "w2:tD"
+	second.Tab = &tab
+	second.BlockingComments = []scan.Comment{{
+		ThreadID:  "PRRT_second",
+		CommentID: "PRRC_second",
+		Author:    "reviewer-login",
+		Path:      "src/other.go",
+		URL:       "https://github.com/acme/widgets/pull/124#discussion_r2",
+		Body:      "Second comment.",
+	}}
+	doc.PRs = append(doc.PRs, second)
+	return doc
+}

--- a/devtools/prsync/internal/cli/dispatch.go
+++ b/devtools/prsync/internal/cli/dispatch.go
@@ -25,23 +25,24 @@ func newDispatchCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 		configPath string
 		prs        []string
 		all        bool
+		goLive     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "dispatch",
 		Short: "Send unmatched review comments to the matched herdr agent",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runDispatch(cmd.Context(), stdout, exec, configPath, prs, all)
+			return runDispatch(cmd.Context(), stdout, exec, configPath, prs, all, goLive)
 		},
 	}
 	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
 	cmd.Flags().StringArrayVar(&prs, "pr", nil, "limit to owner/repo#N (repeatable)")
 	cmd.Flags().BoolVar(&all, "all", false, "dispatch every PR in the scan document")
-	cmd.Flags().Bool("go", false, "send prompts (default is dry-run)")
+	cmd.Flags().BoolVar(&goLive, "go", false, "send prompts (default is dry-run)")
 	return cmd
 }
 
-func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, prs []string, all bool) error {
+func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, prs []string, all, goLive bool) error {
 	if all && len(prs) > 0 {
 		return &ExitError{Code: ExitUsage, Err: errors.New("cannot combine --pr and --all")}
 	}
@@ -53,6 +54,9 @@ func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, 
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
+	}
+	if goLive {
+		cfg.DryRun = false
 	}
 	doc, err := loadScanDoc(ctx, cfg, exec)
 	if err != nil {
@@ -155,6 +159,12 @@ func writeDispatchJSON(w io.Writer, doc dispatch.Document) error {
 func dispatchExit(err error, cfg config.Config) error {
 	if errors.Is(err, dispatch.ErrCorruptState) {
 		return &ExitError{Code: ExitUsage, Err: err}
+	}
+	if errors.Is(err, dispatch.ErrTimeout) {
+		return &ExitError{Code: ExitGateTimeout, Err: err}
+	}
+	if errors.Is(err, dispatch.ErrLock) {
+		return &ExitError{Code: ExitPrecondition, Err: err}
 	}
 	if errors.Is(err, herdr.ErrNotInstalled) {
 		return &ExitError{Code: ExitPrecondition, Err: fmt.Errorf("herdr binary not found (herdr_bin=%q)", cfg.HerdrBin)}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-prompt-done.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-prompt-done.json
@@ -1,0 +1,10 @@
+{
+  "result": {
+    "agent": {
+      "pane_id": "w2:pC",
+      "tab_id": "w2:tC",
+      "agent": "codex",
+      "agent_status": "done"
+    }
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
@@ -40,8 +40,64 @@ case "${1-} ${2-}" in
     if [ -n "${HERDR_FAKE_PROMPT_SENTINEL-}" ]; then
       printf '%s\n' "called" > "$HERDR_FAKE_PROMPT_SENTINEL"
     fi
-    cat "${DIR}/herdr-agent-prompt.json"
-    exit 0
+    if [ -n "${HERDR_FAKE_SETTLE-}" ] && [ -n "${HERDR_FAKE_STATUS_FILE-}" ]; then
+      printf '%s\n' "$HERDR_FAKE_SETTLE" > "$HERDR_FAKE_STATUS_FILE"
+    fi
+    outcome=${HERDR_FAKE_PROMPT:-success}
+    if [ -n "${HERDR_FAKE_PROMPT_SEQ-}" ]; then
+      count=0
+      if [ -n "${HERDR_FAKE_PROMPT_COUNT-}" ] && [ -f "$HERDR_FAKE_PROMPT_COUNT" ]; then
+        count=$(cat "$HERDR_FAKE_PROMPT_COUNT")
+      fi
+      i=0
+      rest=$HERDR_FAKE_PROMPT_SEQ
+      while [ -n "$rest" ]; do
+        tok=${rest%%,*}
+        if [ "$rest" = "$tok" ]; then
+          rest=
+        else
+          rest=${rest#*,}
+        fi
+        if [ "$i" -eq "$count" ]; then
+          outcome=$tok
+          break
+        fi
+        i=$((i + 1))
+      done
+      if [ -n "${HERDR_FAKE_PROMPT_COUNT-}" ]; then
+        printf '%s\n' $((count + 1)) > "$HERDR_FAKE_PROMPT_COUNT"
+      fi
+    fi
+    case "$outcome" in
+      stall)
+        cat "${DIR}/herdr-error-stalled.json" >&2
+        exit 1
+        ;;
+      timeout)
+        cat "${DIR}/herdr-error-timeout.json" >&2
+        exit 1
+        ;;
+      kill)
+        sleep 30
+        exit 1
+        ;;
+      unparseable)
+        printf '%s\n' "not-json"
+        exit 0
+        ;;
+      done)
+        cat "${DIR}/herdr-agent-prompt-done.json"
+        exit 0
+        ;;
+      success)
+        cat "${DIR}/herdr-agent-prompt.json"
+        exit 0
+        ;;
+      *)
+        printf '%s\n' "herdr-fake: unknown prompt outcome: $outcome" >&2
+        exit 1
+        ;;
+    esac
     ;;
   *)
     printf '%s\n' "herdr-fake: unexpected: $*" >&2

--- a/devtools/prsync/internal/dispatch/BUILD.bazel
+++ b/devtools/prsync/internal/dispatch/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//devtools/prsync/internal/herdr:go_default_library",
         "//devtools/prsync/internal/scan:go_default_library",
         "@com_github_google_renameio_v2//:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )
 

--- a/devtools/prsync/internal/dispatch/dispatch.go
+++ b/devtools/prsync/internal/dispatch/dispatch.go
@@ -2,6 +2,7 @@ package dispatch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -9,15 +10,25 @@ import (
 	"time"
 
 	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
 	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
 )
 
 var prFlagPattern = regexp.MustCompile(`^([^/#]+/[^/#]+)#(\d+)$`)
 
-// StateStore loads dedupe state. Dry-run loads but never writes.
+// StateStore loads and saves dedupe state. Dry-run loads but never writes.
 type StateStore interface {
 	Load() (State, error)
+	Save(State) error
 }
+
+// locker is implemented by FileStore for exclusive live-path writes.
+type locker interface {
+	WithLock(func() error) error
+}
+
+// ErrFailed is returned when a live prompt is PromptError (exit 3).
+var ErrFailed = errors.New("dispatch failed")
 
 // Request is the candidate-set input to Run.
 type Request struct {
@@ -110,18 +121,27 @@ func Evaluate(c Candidate, cfg config.Config, st State) Item {
 	return r
 }
 
-// Run evaluates the candidate set. The dry-run path does a one-shot gate.Check,
-// never polls, never emits queued, and never writes state.
+// Run evaluates the candidate set. Dry-run does a one-shot gate.Check, never
+// polls, never emits queued, and never writes state. Live send polls the gate
+// one PR at a time, writes state on dispatched / dispatched_timeout, and
+// returns ErrTimeout or ErrFailed after emitting partial results.
 func Run(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, now time.Time) (Document, error) {
 	doc := Document{
 		GeneratedAt: now.UTC().Format(time.RFC3339),
-		DryRun:      true,
+		DryRun:      cfg.DryRun,
 		Results:     []Item{},
 	}
 	cands, err := Candidates(req.Doc, req.PRs)
 	if err != nil {
 		return doc, err
 	}
+	if cfg.DryRun {
+		return runDry(ctx, h, store, cfg, req, cands, doc)
+	}
+	return runLive(ctx, h, store, cfg, req, now, cands, doc)
+}
+
+func runDry(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, cands []Candidate, doc Document) (Document, error) {
 	st, err := loadState(store)
 	if err != nil {
 		return doc, err
@@ -133,6 +153,139 @@ func Run(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req 
 		return doc, err
 	}
 	return doc, nil
+}
+
+func runLive(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, now time.Time, cands []Candidate, doc Document) (Document, error) {
+	if l, ok := store.(locker); ok {
+		var liveErr error
+		lockErr := l.WithLock(func() error {
+			doc, liveErr = dispatchLive(ctx, h, store, cfg, req, now, cands, doc)
+			return nil
+		})
+		if lockErr != nil {
+			return doc, fmt.Errorf("lock state: %w", lockErr)
+		}
+		return doc, liveErr
+	}
+	return dispatchLive(ctx, h, store, cfg, req, now, cands, doc)
+}
+
+func dispatchLive(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, now time.Time, cands []Candidate, doc Document) (Document, error) {
+	st, err := loadState(store)
+	if err != nil {
+		return doc, err
+	}
+	matched := MatchedTabs(req.Doc)
+	clock := Clock(realClock{})
+	sleeper := Sleeper(realSleeper{})
+	for i, c := range cands {
+		if err := ctx.Err(); err != nil {
+			doc.Results = append(doc.Results, failItem(c, err))
+			return doc, fmt.Errorf("dispatch: %w", err)
+		}
+		item := Evaluate(c, cfg, st)
+		if item.Action != "" {
+			doc.Results = append(doc.Results, item)
+			continue
+		}
+		_, err := Wait(ctx, h, cfg, req.RunnerPane, matched, clock, sleeper)
+		if errors.Is(err, ErrTimeout) {
+			queueRest(&doc, cands, i)
+			return doc, err
+		}
+		if err != nil {
+			doc.Results = append(doc.Results, failItem(c, err))
+			return doc, err
+		}
+		item = sendPrompt(ctx, h, cfg, c)
+		doc.Results = append(doc.Results, item)
+		if item.Action == ActionDispatched || item.Action == ActionDispatchedTimeout {
+			st.Record(prKey(c.Repo, c.Number), commentIDs(*c.PR), now)
+			if err := saveState(store, st); err != nil {
+				return doc, err
+			}
+		}
+		if item.Action == ActionFailed {
+			if err := ctx.Err(); err != nil {
+				return doc, fmt.Errorf("dispatch: %w", err)
+			}
+			return doc, fmt.Errorf("%w: %s", ErrFailed, item.Detail)
+		}
+	}
+	return doc, nil
+}
+
+func sendPrompt(ctx context.Context, h Herdr, cfg config.Config, c Candidate) Item {
+	pr := *c.PR
+	pane := *pr.Tab.PaneID
+	rendered := Render(cfg.PromptTemplate, pr)
+	out := h.Prompt(ctx, pane, rendered, cfg.WaitUntil, cfg.DispatchTimeout)
+	item := Item{Repo: c.Repo, Number: c.Number}
+	switch out.Status {
+	case herdr.PromptMatched:
+		item.Action = ActionDispatched
+		item.PaneID = pane
+		item.RenderedPrompt = rendered
+	case herdr.PromptStalled:
+		item.Action = ActionSkippedStalled
+	case herdr.PromptTimeout:
+		item.Action = ActionDispatchedTimeout
+		item.PaneID = pane
+		item.RenderedPrompt = rendered
+	default:
+		item.Action = ActionFailed
+		if out.Err != nil {
+			item.Detail = out.Err.Error()
+		} else {
+			item.Detail = "herdr prompt failed"
+		}
+	}
+	return item
+}
+
+func queueRest(doc *Document, cands []Candidate, from int) {
+	for _, c := range cands[from:] {
+		doc.Results = append(doc.Results, Item{
+			Repo:   c.Repo,
+			Number: c.Number,
+			Action: ActionQueued,
+		})
+	}
+}
+
+func failItem(c Candidate, err error) Item {
+	item := Item{Repo: c.Repo, Number: c.Number, Action: ActionFailed}
+	if err != nil {
+		item.Detail = err.Error()
+	}
+	return item
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+type realSleeper struct{}
+
+func (realSleeper) Sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("sleep: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func saveState(store StateStore, st State) error {
+	if store == nil {
+		return errors.New("save state: nil store")
+	}
+	if err := store.Save(st); err != nil {
+		return fmt.Errorf("save state: %w", err)
+	}
+	return nil
 }
 
 func evaluateDry(c Candidate, cfg config.Config, st State) Item {

--- a/devtools/prsync/internal/dispatch/dispatch_test.go
+++ b/devtools/prsync/internal/dispatch/dispatch_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -159,6 +160,287 @@ func TestRunDryRunHerdrRequired(t *testing.T) {
 	if !errors.Is(err, herdr.ErrNotInstalled) {
 		t.Fatalf("error = %v, want ErrNotInstalled", err)
 	}
+}
+
+func TestRunLiveDispatchedWritesState(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+	pr := fixtureEligiblePR()
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{pr}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if got.DryRun {
+		t.Fatal("dry_run = true, want false")
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionDispatched {
+		t.Fatalf("results = %+v, want dispatched", got.Results)
+	}
+	if got.Results[0].PaneID != "w2:pC" || got.Results[0].RenderedPrompt == "" {
+		t.Fatalf("dispatched item missing pane/prompt: %+v", got.Results[0])
+	}
+	if h.promptN != 1 {
+		t.Fatalf("Prompt calls = %d, want 1", h.promptN)
+	}
+	if !slices.Equal(h.sawUntil, []string{"idle", "done"}) {
+		t.Fatalf("until = %v, want [idle done]", h.sawUntil)
+	}
+
+	st, err := LoadFile(store.Path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state after send = %#v", st)
+	}
+
+	got2, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{pr}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("second Run() unexpected error: %v", err)
+	}
+	if len(got2.Results) != 1 || got2.Results[0].Action != ActionSkippedDeduped {
+		t.Fatalf("second results = %+v, want skipped_deduped", got2.Results)
+	}
+	if h.promptN != 1 {
+		t.Fatalf("Prompt calls after dedupe = %d, want 1", h.promptN)
+	}
+}
+
+func TestRunLiveStallDoesNotWriteState(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	h := &scriptHerdr{
+		lists:   [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{{Status: herdr.PromptStalled}},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionSkippedStalled {
+		t.Fatalf("results = %+v, want skipped_stalled", got.Results)
+	}
+	if got.Results[0].PaneID != "" || got.Results[0].RenderedPrompt != "" {
+		t.Fatalf("stalled item should omit pane/prompt: %+v", got.Results[0])
+	}
+	if _, err := os.Stat(store.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state file written on stall")
+	}
+}
+
+func TestRunLiveHerdrTimeoutWritesState(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	h := &scriptHerdr{
+		lists:   [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{{Status: herdr.PromptTimeout}},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionDispatchedTimeout {
+		t.Fatalf("results = %+v, want dispatched_timeout", got.Results)
+	}
+	if got.Results[0].PaneID == "" || got.Results[0].RenderedPrompt == "" {
+		t.Fatalf("timeout item missing pane/prompt: %+v", got.Results[0])
+	}
+	st, err := LoadFile(store.Path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state after herdr timeout = %#v", st)
+	}
+}
+
+func TestRunLiveProcessKillNoWrite(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	h := &scriptHerdr{
+		lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{{
+			Status: herdr.PromptError,
+			Err:    errors.New("run herdr: process timeout"),
+		}},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err == nil {
+		t.Fatal("Run() error = nil, want failed")
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionFailed {
+		t.Fatalf("results = %+v, want failed", got.Results)
+	}
+	if got.Results[0].PaneID != "" || got.Results[0].RenderedPrompt != "" {
+		t.Fatalf("failed item should omit pane/prompt: %+v", got.Results[0])
+	}
+	if got.Results[0].Detail == "" {
+		t.Fatal("failed item missing detail")
+	}
+	if _, err := os.Stat(store.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state file written on process-kill PromptError")
+	}
+}
+
+func TestRunLiveDoneSettlementIsDispatched(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	pr := fixtureEligiblePR()
+	pr.Tab.AgentStatus = "done"
+	h := &scriptHerdr{
+		lists:   [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{{Status: herdr.PromptMatched, Agent: herdr.Agent{PaneID: "w2:pC", AgentStatus: "done"}}},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{pr}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionDispatched {
+		t.Fatalf("results = %+v, want dispatched (done settlement)", got.Results)
+	}
+	if got.Results[0].Action == ActionDispatchedTimeout {
+		t.Fatal("done settlement must not be dispatched_timeout")
+	}
+}
+
+func TestRunLiveReplaceNotUnion(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	pre := State{}
+	pre.Record("acme/widgets#123", []string{"PRRC_old", "PRRC_gone"}, fixtureNow)
+	if err := SaveFile(store.Path, pre); err != nil {
+		t.Fatal(err)
+	}
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+	if _, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	st, err := LoadFile(store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := st["acme/widgets#123"].DispatchedCommentIDs
+	if !slices.Equal(got, []string{"PRRC_widget"}) {
+		t.Fatalf("ids = %v, want [PRRC_widget] (replace, not union)", got)
+	}
+}
+
+func TestRunLiveMidLoopFatalPartialJSON(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	pr2 := fixtureEligiblePR()
+	pr2.Number = 124
+	pr2.BlockingComments = []scan.Comment{{CommentID: "PRRC_second"}}
+	h := &scriptHerdr{
+		lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{
+			{Status: herdr.PromptMatched},
+			{Status: herdr.PromptError, Err: errors.New("unparseable result")},
+		},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR(), pr2}},
+	}, fixtureNow)
+	if err == nil {
+		t.Fatal("Run() error = nil, want mid-loop fatal")
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Action != ActionDispatched || got.Results[0].Number != 123 {
+		t.Fatalf("first = %+v, want dispatched #123", got.Results[0])
+	}
+	if got.Results[1].Action != ActionFailed || got.Results[1].Number != 124 {
+		t.Fatalf("second = %+v, want failed #124", got.Results[1])
+	}
+	st, err := LoadFile(store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state missing first PR: %#v", st)
+	}
+	if _, ok := st["acme/widgets#124"]; ok {
+		t.Fatalf("state has second PR: %#v", st)
+	}
+}
+
+func TestRunLiveGateTimeoutQueuesRest(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	pr2 := fixtureEligiblePR()
+	pr2.Number = 124
+	h := &scriptHerdr{lists: [][]herdr.Agent{{workingAgent("w2:pX", "w2:tX")}}}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR(), pr2}},
+	}, fixtureNow)
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("error = %v, want ErrTimeout", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	for _, r := range got.Results {
+		if r.Action != ActionQueued {
+			t.Fatalf("result = %+v, want queued", r)
+		}
+	}
+	if h.promptN != 0 {
+		t.Fatalf("Prompt calls = %d, want 0 on gate timeout", h.promptN)
+	}
+	if _, err := os.Stat(store.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state file written on gate timeout")
+	}
+}
+
+func TestRunDryRunDoesNotCallPrompt(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	h := &scriptHerdr{lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}}}
+	if _, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if h.promptN != 0 {
+		t.Fatalf("Prompt calls = %d, want 0 on dry-run", h.promptN)
+	}
+}
+
+func liveCfg(t *testing.T) (config.Config, FileStore) {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.DryRun = false
+	cfg.GatePoll = time.Millisecond
+	cfg.GateTimeout = 50 * time.Millisecond
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	cfg.StateFile = store.Path
+	return cfg, store
 }
 
 func TestRunRecordsEveryInputPR(t *testing.T) {

--- a/devtools/prsync/internal/dispatch/gate.go
+++ b/devtools/prsync/internal/dispatch/gate.go
@@ -1,4 +1,4 @@
-// Package dispatch implements eligibility, dry-run dispatch, and the concurrency gate.
+// Package dispatch implements eligibility, dry-run and live dispatch, and the concurrency gate.
 package dispatch
 
 import (
@@ -27,10 +27,11 @@ type Sleeper interface {
 	Sleep(ctx context.Context, d time.Duration) error
 }
 
-// Herdr is the herdr surface the gate uses.
+// Herdr is the herdr surface the gate and live dispatch use.
 type Herdr interface {
 	RequireMin(ctx context.Context, minimum string) error
 	AgentList(ctx context.Context) ([]herdr.Agent, error)
+	Prompt(ctx context.Context, paneID, text string, until []string, timeout time.Duration) herdr.PromptOutcome
 }
 
 // Result is the outbound gate JSON document.

--- a/devtools/prsync/internal/dispatch/gate_test.go
+++ b/devtools/prsync/internal/dispatch/gate_test.go
@@ -246,9 +246,23 @@ type scriptHerdr struct {
 	lists    [][]herdr.Agent
 	listErrs []error
 	n        int
+	prompts  []herdr.PromptOutcome
+	promptN  int
+	sawUntil []string
 }
 
 func (s *scriptHerdr) RequireMin(context.Context, string) error { return s.minErr }
+
+func (s *scriptHerdr) Prompt(_ context.Context, _, _ string, until []string, _ time.Duration) herdr.PromptOutcome {
+	s.sawUntil = append([]string(nil), until...)
+	if s.promptN < len(s.prompts) {
+		out := s.prompts[s.promptN]
+		s.promptN++
+		return out
+	}
+	s.promptN++
+	return herdr.PromptOutcome{Status: herdr.PromptMatched}
+}
 
 func (s *scriptHerdr) AgentList(context.Context) ([]herdr.Agent, error) {
 	i := s.n

--- a/devtools/prsync/internal/dispatch/state.go
+++ b/devtools/prsync/internal/dispatch/state.go
@@ -5,15 +5,42 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"math/rand/v2" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/renameio/v2"
+	"golang.org/x/sys/unix"
 )
 
 // ErrCorruptState is returned when state_file exists but is not valid JSON.
 var ErrCorruptState = errors.New("corrupt state file")
+
+// ErrLock is returned when the state_file lock cannot be acquired.
+var ErrLock = errors.New("state file lock not acquired")
+
+type lockRetryConfig struct {
+	MaxRetries    int
+	InitialDelay  time.Duration
+	MaxDelay      time.Duration
+	BackoffFactor float64
+}
+
+func defaultLockRetry() lockRetryConfig {
+	return lockRetryConfig{
+		MaxRetries:    10,
+		InitialDelay:  50 * time.Millisecond,
+		MaxDelay:      2 * time.Second,
+		BackoffFactor: 1.5,
+	}
+}
+
+// heldLocks tracks lock files owned by this process (re-homed LockManager).
+var heldLocks sync.Map
 
 // State is the on-disk dedupe map keyed by owner/repo#N.
 type State map[string]Entry
@@ -32,6 +59,111 @@ type FileStore struct {
 // Load implements StateStore.
 func (s FileStore) Load() (State, error) {
 	return LoadFile(s.Path)
+}
+
+// Save implements StateStore.
+func (s FileStore) Save(st State) error {
+	return SaveFile(s.Path, st)
+}
+
+// AcquireLock creates state_file.lock with O_EXCL + PID. The returned function
+// closes the file and removes the lock. Retry shape matches gh-nudge's
+// DefaultFileLockConfig (~5s). A live holder returns ErrLock.
+func (s FileStore) AcquireLock() (func(), error) {
+	return acquireLockRetry(s.Path+".lock", defaultLockRetry())
+}
+
+// WithLock runs fn while holding the exclusive state lock.
+func (s FileStore) WithLock(fn func() error) error {
+	unlock, err := s.AcquireLock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return fn()
+}
+
+func acquireLockRetry(lockPath string, cfg lockRetryConfig) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, fmt.Errorf("%w: create lock dir: %v", ErrLock, err)
+	}
+	var lastErr error
+	delay := cfg.InitialDelay
+	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
+		unlock, err := tryAcquireLock(lockPath)
+		if err == nil {
+			return unlock, nil
+		}
+		lastErr = err
+		if alreadyHeld(err) {
+			return nil, fmt.Errorf("%w: %v", ErrLock, err)
+		}
+		if isStaleLock(lockPath) {
+			_ = os.Remove(lockPath)
+			unlock, err := tryAcquireLock(lockPath)
+			if err == nil {
+				return unlock, nil
+			}
+			lastErr = err
+		}
+		if attempt < cfg.MaxRetries {
+			jitter := 0.75 + rand.Float64()*0.5 //nolint:gosec // G404: lock retry jitter
+			time.Sleep(time.Duration(float64(delay) * jitter))
+			delay = time.Duration(float64(delay) * cfg.BackoffFactor)
+			if delay > cfg.MaxDelay {
+				delay = cfg.MaxDelay
+			}
+		}
+	}
+	return nil, fmt.Errorf("%w: %v", ErrLock, lastErr)
+}
+
+func tryAcquireLock(lockPath string) (func(), error) {
+	if _, loaded := heldLocks.LoadOrStore(lockPath, struct{}{}); loaded {
+		return nil, fmt.Errorf("lock already held for path: %s", lockPath)
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644) //nolint:gosec // lock metadata is not secret
+	if err != nil {
+		heldLocks.Delete(lockPath)
+		return nil, fmt.Errorf("create lock file: %w", err)
+	}
+	lockInfo := fmt.Sprintf("locked_at: %s\npid: %d\n", time.Now().Format(time.RFC3339), os.Getpid())
+	if _, err := fmt.Fprintf(file, "%s", lockInfo); err != nil {
+		_ = file.Close()
+		_ = os.Remove(lockPath)
+		heldLocks.Delete(lockPath)
+		return nil, fmt.Errorf("write lock file: %w", err)
+	}
+	return func() {
+		_ = file.Close()
+		_ = os.Remove(lockPath)
+		heldLocks.Delete(lockPath)
+	}, nil
+}
+
+func alreadyHeld(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "lock already held")
+}
+
+func isStaleLock(lockPath string) bool {
+	content, err := os.ReadFile(lockPath) //nolint:gosec // lock path is state_file + ".lock"
+	if err != nil {
+		return false
+	}
+	var pid int
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.HasPrefix(line, "pid: ") {
+			parsed, convErr := strconv.Atoi(strings.TrimPrefix(line, "pid: "))
+			if convErr == nil {
+				pid = parsed
+				break
+			}
+		}
+	}
+	if pid == 0 {
+		return false
+	}
+	return unix.Kill(pid, 0) == unix.ESRCH
 }
 
 // Deduped reports whether current comment IDs are a subset of the stored set.

--- a/devtools/prsync/internal/dispatch/state_test.go
+++ b/devtools/prsync/internal/dispatch/state_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -107,6 +108,66 @@ func TestSaveFileRoundTrip(t *testing.T) {
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("perm = %o, want 0600", info.Mode().Perm())
 	}
+}
+
+func TestWithLockExclusive(t *testing.T) {
+	t.Parallel()
+
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	unlock, err := store.AcquireLock()
+	if err != nil {
+		t.Fatalf("AcquireLock() error = %v", err)
+	}
+	defer unlock()
+
+	if _, err := os.Stat(store.Path + ".lock"); err != nil {
+		t.Fatalf("lock file missing: %v", err)
+	}
+	data, err := os.ReadFile(store.Path + ".lock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "pid:") || !strings.Contains(string(data), "locked_at:") {
+		t.Fatalf("lock contents = %q", data)
+	}
+
+	_, err = store.AcquireLock()
+	if !errors.Is(err, ErrLock) {
+		t.Fatalf("second AcquireLock() error = %v, want ErrLock", err)
+	}
+}
+
+func TestWithLockReapsStale(t *testing.T) {
+	t.Parallel()
+
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	if err := os.WriteFile(store.Path+".lock", []byte("locked_at: 2020-01-01T00:00:00Z\npid: 999999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := store.AcquireLock()
+	if err != nil {
+		t.Fatalf("AcquireLock() stale error = %v", err)
+	}
+	unlock()
+}
+
+func TestWithLockReleases(t *testing.T) {
+	t.Parallel()
+
+	store := FileStore{Path: filepath.Join(t.TempDir(), "state.json")}
+	unlock, err := store.AcquireLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock()
+	if _, err := os.Stat(store.Path + ".lock"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("lock file still present after release")
+	}
+	unlock2, err := store.AcquireLock()
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	unlock2()
 }
 
 func TestFileStoreLoad(t *testing.T) {


### PR DESCRIPTION
## Summary
- Live `prsync dispatch --go` sends serialized `herdr agent prompt --wait --until idle --until done`.
- Outcome mapping: herdr JSON `code=timeout` → `dispatched_timeout` + state write; process-kill / unparseable → `failed`, exit 3, no write.
- Replace-not-union dedupe of `dispatched_comment_ids` behind an O_EXCL+PID lock and `renameio.WriteFile(..., 0o600)`.
- Partial JSON on mid-loop fatal; exit 4 when the gate times out with leftover work queued.

## Test plan
- [x] `--go` then a second run is `skipped_deduped`
- [x] Stall does not write state; `done` settlement is `dispatched`
- [x] `make check` is green

Resolves #218