### PR TITLE
feat(prsync): expose {head}/{base} in dispatch prompt template

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -102,7 +102,7 @@ variables are not expanded.
 | ~gate_poll_ms~ | ~2000~ | Gate poll interval (milliseconds). |
 | ~gate_timeout_ms~ | ~1800000~ | Live dispatch gives up waiting on the gate after this many ms (exit 4). |
 | ~dispatch_timeout_ms~ | ~1800000~ | Passed to ~herdr agent prompt --timeout~. |
-| ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{number}~, ~{url}~, ~{comments}~ are substituted. |
+| ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{identifier}~, ~{number}~, ~{title}~, ~{repo}~, ~{url}~, ~{head}~, ~{base}~, ~{comments}~ are substituted. Unknown placeholders are left literal. |
 | ~dispatch_include_drafts~ | ~false~ | ~true~ / ~false~ / ~1~ / ~0~. |
 | ~dispatch_wait_until~ | ~idle done~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
 | ~state_file~ | =$HOME/.config/prsync/state.json= | Dispatch audit / dedupe log. Written only on live send. |

--- a/devtools/prsync/internal/dispatch/prompt.go
+++ b/devtools/prsync/internal/dispatch/prompt.go
@@ -26,6 +26,8 @@ func Render(tmpl string, pr scan.PR) string {
 		{"{title}", pr.Title},
 		{"{repo}", pr.Repo},
 		{"{url}", pr.URL},
+		{"{head}", pr.Head},
+		{"{base}", pr.Base},
 	}
 	sort.Slice(vars, func(i, j int) bool {
 		return len(vars[i].key) > len(vars[j].key)

--- a/devtools/prsync/internal/dispatch/prompt_test.go
+++ b/devtools/prsync/internal/dispatch/prompt_test.go
@@ -111,3 +111,24 @@ func TestRenderNilIdentifier(t *testing.T) {
 		t.Fatalf("Render() = %q, want %q", got, "id=.")
 	}
 }
+
+func TestRenderHeadAndBase(t *testing.T) {
+	t.Parallel()
+
+	pr := scan.PR{Head: "fix-widget", Base: "main"}
+	got := Render("git switch {head}; rebase onto {base}", pr)
+	want := "git switch fix-widget; rebase onto main"
+	if got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderUnknownPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	got := Render("keep {foo} literal", scan.PR{Head: "fix-widget"})
+	want := "keep {foo} literal"
+	if got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}

--- a/devtools/prsync/prsync.config.example
+++ b/devtools/prsync/prsync.config.example
@@ -30,7 +30,9 @@
 # dispatch_timeout_ms=1800000
 
 # Inline prompt, or @/path/to/file (tilde is expanded).
-# Review comment bodies are interpolated into the prompt as text.
+# Substituted: {identifier} {number} {title} {repo} {url} {head} {base} {comments}.
+# Unknown placeholders are left literal. Review comment bodies are interpolated
+# into the prompt as text.
 # dispatch_prompt_template=
 
 # true / false / 1 / 0


### PR DESCRIPTION
## Summary
- `dispatch_prompt_template` can now substitute `{head}` and `{base}` from the PR's `HeadRefName` / `BaseRefName`.
- Operators can write branch-switch prompts (`git switch {head}`, rebase onto `{base}`) without a `gh pr checkout` round-trip.
- Docs and the example config list `{identifier}` (not `{ticket}`) plus the full placeholder set. Unknown placeholders stay literal.

## Test plan
- [x] `{head}` / `{base}` render the PR branch names
- [x] Unknown `{foo}` is left literal
- [x] `make check` is green

Resolves #227