### PR TITLE
fix(prsync): hold the concurrency gate when an agent is blocked

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -98,25 +98,29 @@ variables are not expanded.
 | ~tab_label_template~ | ~{id}~ | Herdr tab label after substituting ~{id}~. Exact, case-sensitive. |
 | ~herdr_bin~ | ~herdr~ | herdr executable. |
 | ~gh_bin~ | ~gh~ | gh executable. |
-| ~concurrency_wait_on~ | ~any~ | ~any~ (every working agent) or ~managed~ (tabs matched in this scan). ~managed~ runs a scan. |
+| ~concurrency_wait_on~ | ~any~ | ~any~ (every working or blocked agent) or ~managed~ (tabs matched in this scan). ~managed~ runs a scan. |
 | ~gate_poll_ms~ | ~2000~ | Gate poll interval (milliseconds). |
 | ~gate_timeout_ms~ | ~1800000~ | Live dispatch gives up waiting on the gate after this many ms (exit 4). |
 | ~dispatch_timeout_ms~ | ~1800000~ | Passed to ~herdr agent prompt --timeout~. |
 | ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{identifier}~, ~{number}~, ~{title}~, ~{repo}~, ~{url}~, ~{head}~, ~{base}~, ~{comments}~ are substituted. Unknown placeholders are left literal. |
 | ~dispatch_include_drafts~ | ~false~ | ~true~ / ~false~ / ~1~ / ~0~. |
-| ~dispatch_wait_until~ | ~idle done~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
+| ~dispatch_wait_until~ | ~idle done blocked~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
 | ~state_file~ | =$HOME/.config/prsync/state.json= | Dispatch audit / dedupe log. Written only on live send. |
 | ~dry_run~ | ~true~ | ~true~ / ~false~ / ~1~ / ~0~. ~--go~ overrides to live. |
 
-~dispatch_wait_until=idle done~ (the default) treats a settled unfocused
-agent as ready-for-input. Live dispatch therefore runs:
+~dispatch_wait_until=idle done blocked~ (the default) treats a settled
+unfocused agent as ready-for-input, and treats a user-blocked agent as
+a terminal settlement for this send. Live dispatch therefore runs:
 
 #+BEGIN_EXAMPLE
-herdr agent prompt <pane_id> <prompt> --wait --until idle --until done --timeout …
+herdr agent prompt <pane_id> <prompt> --wait --until idle --until done --until blocked --timeout …
 #+END_EXAMPLE
 
-Set ~dispatch_wait_until=idle~ only if you want to wait until herdr reports
-~idle~ (can take about 30 minutes if the agent settles to ~done~ instead).
+A ~blocked~ settlement is ~dispatched_blocked~ (not plain ~dispatched~)
+and stops the batch so the next agent does not start while the user is
+answering. Set ~dispatch_wait_until=idle~ only if you want to wait until
+herdr reports ~idle~ (can take about 30 minutes if the agent settles to
+~done~ instead).
 
 See [[file:prsync.config.example][prsync.config.example]] for a commented copy of every key.
 
@@ -218,7 +222,8 @@ prsync dispatch --config ./prsync.config --pr acme/widgets#123
 }
 #+END_SRC
 
-Live send (writes ~state_file~ on ~dispatched~ / ~dispatched_timeout~):
+Live send (writes ~state_file~ on ~dispatched~ / ~dispatched_timeout~ /
+~dispatched_blocked~):
 
 #+BEGIN_SRC bash
 prsync dispatch --config ./prsync.config --go
@@ -242,7 +247,7 @@ Safe:
 }
 #+END_SRC
 
-Unsafe (exit 1) when a working agent is in the busy set:
+Unsafe (exit 1) when a working or blocked agent is in the busy set:
 
 #+BEGIN_SRC json
 {
@@ -267,16 +272,17 @@ Against a real herdr ≥ 0.8 and an authenticated ~gh~:
 #+BEGIN_SRC bash
 prsync scan --config ./prsync.config
 prsync dispatch --config ./prsync.config          # review rendered_prompt
-prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done
+prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done --until blocked
 prsync gate --config ./prsync.config
 #+END_SRC
 
 Confirm:
 
 - ~agent prompt~ targets a ~pane_id~ (~w2:pC~, not a tab id).
-- Default wait is ~--wait --until idle --until done~ (from
+- Default wait is ~--wait --until idle --until done --until blocked~ (from
   ~dispatch_wait_until~).
-- ~--wait --until idle --until done~ returns after the agent settles.
+- ~--wait --until idle --until done --until blocked~ returns after the agent
+  settles or blocks awaiting the user.
 
 This procedure is README-only; CI uses fixture binaries, not live herdr.
 

--- a/devtools/prsync/internal/cli/cli_gate_test.go
+++ b/devtools/prsync/internal/cli/cli_gate_test.go
@@ -33,6 +33,25 @@ func TestGateSafeWhenIdle(t *testing.T) {
 	}
 }
 
+func TestGateBusyWhenBlocked(t *testing.T) {
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "blocked")
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\nrepos=acme/widgets\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"gate", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUnsafe {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitUnsafe, stderr.String(), stdout.String())
+	}
+	got := decodeGate(t, stdout.Bytes())
+	if got.Safe {
+		t.Fatal("safe = true, want false while an agent is blocked")
+	}
+	if len(got.Busy) != 1 || got.Busy[0].PaneID != "w2:pC" || got.Busy[0].TabID != "w2:tC" {
+		t.Fatalf("busy = %+v, want [{w2:pC w2:tC}]", got.Busy)
+	}
+}
+
 func TestGateBusyWhenWorking(t *testing.T) {
 	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
 	ghBin, herdrBin := fixtureBins(t)

--- a/devtools/prsync/internal/cli/cli_integration_test.go
+++ b/devtools/prsync/internal/cli/cli_integration_test.go
@@ -113,6 +113,42 @@ func TestDispatchGoDoneSettlementIsDispatched(t *testing.T) {
 	}
 }
 
+func TestDispatchGoBlockedStopsBatch(t *testing.T) {
+	t.Setenv("HERDR_FAKE_PROMPT", "blocked")
+	ghBin, herdrBin := fixtureBins(t)
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
+	raw := mustScanJSON(t, stdinTwoEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2\n%s", len(got.Results), stdout.String())
+	}
+	if got.Results[0].Action != dispatch.ActionDispatchedBlocked || got.Results[0].Number != 123 {
+		t.Fatalf("first = %+v, want dispatched_blocked #123", got.Results[0])
+	}
+	if got.Results[1].Action != dispatch.ActionQueued || got.Results[1].Number != 124 {
+		t.Fatalf("second = %+v, want queued #124", got.Results[1])
+	}
+	st, err := dispatch.LoadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state missing first PR: %#v", st)
+	}
+	if _, ok := st["acme/widgets#124"]; ok {
+		t.Fatalf("state has second PR: %#v", st)
+	}
+}
+
 func TestDispatchGoHerdrTimeoutWritesState(t *testing.T) {
 	t.Setenv("HERDR_FAKE_PROMPT", "timeout")
 	ghBin, herdrBin := fixtureBins(t)

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-prompt-blocked.json
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-agent-prompt-blocked.json
@@ -1,0 +1,10 @@
+{
+  "result": {
+    "agent": {
+      "pane_id": "w2:pC",
+      "tab_id": "w2:tC",
+      "agent": "codex",
+      "agent_status": "blocked"
+    }
+  }
+}

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
@@ -89,6 +89,10 @@ case "${1-} ${2-}" in
         cat "${DIR}/herdr-agent-prompt-done.json"
         exit 0
         ;;
+      blocked)
+        cat "${DIR}/herdr-agent-prompt-blocked.json"
+        exit 0
+        ;;
       success)
         cat "${DIR}/herdr-agent-prompt.json"
         exit 0

--- a/devtools/prsync/internal/config/config.go
+++ b/devtools/prsync/internal/config/config.go
@@ -77,7 +77,7 @@ func Defaults() Config {
 		GatePoll:          2000 * time.Millisecond,
 		GateTimeout:       1800000 * time.Millisecond,
 		PromptTemplate:    defaultPromptTemplate,
-		WaitUntil:         []string{"idle", "done"},
+		WaitUntil:         []string{"idle", "done", "blocked"},
 		DispatchTimeout:   1800000 * time.Millisecond,
 		StateFile:         "~/.config/prsync/state.json",
 		DryRun:            true,

--- a/devtools/prsync/internal/config/config_test.go
+++ b/devtools/prsync/internal/config/config_test.go
@@ -453,7 +453,7 @@ func TestDefaults(t *testing.T) {
 	if got.DispatchTimeout != 1800000*time.Millisecond {
 		t.Fatalf("DispatchTimeout = %s", got.DispatchTimeout)
 	}
-	if !slices.Equal(got.WaitUntil, []string{"idle", "done"}) {
+	if !slices.Equal(got.WaitUntil, []string{"idle", "done", "blocked"}) {
 		t.Fatalf("WaitUntil = %#v", got.WaitUntil)
 	}
 	if !got.DryRun {

--- a/devtools/prsync/internal/dispatch/dispatch.go
+++ b/devtools/prsync/internal/dispatch/dispatch.go
@@ -123,8 +123,10 @@ func Evaluate(c Candidate, cfg config.Config, st State) Item {
 
 // Run evaluates the candidate set. Dry-run does a one-shot gate.Check, never
 // polls, never emits queued, and never writes state. Live send polls the gate
-// one PR at a time, writes state on dispatched / dispatched_timeout, and
-// returns ErrTimeout or ErrFailed after emitting partial results.
+// one PR at a time, writes state on dispatched / dispatched_timeout /
+// dispatched_blocked, and returns ErrTimeout or ErrFailed after emitting
+// partial results. A blocked settlement stops the batch so the user can
+// answer before the next agent starts.
 func Run(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, now time.Time) (Document, error) {
 	doc := Document{
 		GeneratedAt: now.UTC().Format(time.RFC3339),
@@ -199,11 +201,15 @@ func dispatchLive(ctx context.Context, h Herdr, store StateStore, cfg config.Con
 		}
 		item = sendPrompt(ctx, h, cfg, c)
 		doc.Results = append(doc.Results, item)
-		if item.Action == ActionDispatched || item.Action == ActionDispatchedTimeout {
+		if item.Action == ActionDispatched || item.Action == ActionDispatchedTimeout || item.Action == ActionDispatchedBlocked {
 			st.Record(prKey(c.Repo, c.Number), commentIDs(*c.PR), now)
 			if err := saveState(store, st); err != nil {
 				return doc, err
 			}
+		}
+		if item.Action == ActionDispatchedBlocked {
+			queueRest(&doc, cands, i+1)
+			return doc, nil
 		}
 		if item.Action == ActionFailed {
 			if err := ctx.Err(); err != nil {
@@ -224,6 +230,9 @@ func sendPrompt(ctx context.Context, h Herdr, cfg config.Config, c Candidate) It
 	switch out.Status {
 	case herdr.PromptMatched:
 		item.Action = ActionDispatched
+		if out.Agent.AgentStatus == "blocked" {
+			item.Action = ActionDispatchedBlocked
+		}
 		item.PaneID = pane
 		item.RenderedPrompt = rendered
 	case herdr.PromptStalled:
@@ -308,7 +317,7 @@ func annotateGate(ctx context.Context, h Herdr, cfg config.Config, req Request, 
 	if res.Safe || len(res.Busy) == 0 {
 		return nil
 	}
-	detail := fmt.Sprintf("gate currently busy: pane %s working", res.Busy[0].PaneID)
+	detail := fmt.Sprintf("gate currently busy: pane %s", res.Busy[0].PaneID)
 	for i := range doc.Results {
 		if doc.Results[i].Action == ActionWouldDispatch {
 			doc.Results[i].Detail = detail

--- a/devtools/prsync/internal/dispatch/dispatch_test.go
+++ b/devtools/prsync/internal/dispatch/dispatch_test.go
@@ -118,7 +118,7 @@ func TestRunDryRunDoesNotPoll(t *testing.T) {
 	if got.Results[0].Action != ActionWouldDispatch {
 		t.Fatalf("action = %q, want would_dispatch (never queued)", got.Results[0].Action)
 	}
-	if got.Results[0].Detail != "gate currently busy: pane w2:pX working" {
+	if got.Results[0].Detail != "gate currently busy: pane w2:pX" {
 		t.Fatalf("detail = %q", got.Results[0].Detail)
 	}
 }
@@ -186,8 +186,8 @@ func TestRunLiveDispatchedWritesState(t *testing.T) {
 	if h.promptN != 1 {
 		t.Fatalf("Prompt calls = %d, want 1", h.promptN)
 	}
-	if !slices.Equal(h.sawUntil, []string{"idle", "done"}) {
-		t.Fatalf("until = %v, want [idle done]", h.sawUntil)
+	if !slices.Equal(h.sawUntil, []string{"idle", "done", "blocked"}) {
+		t.Fatalf("until = %v, want [idle done blocked]", h.sawUntil)
 	}
 
 	st, err := LoadFile(store.Path)
@@ -318,6 +318,85 @@ func TestRunLiveDoneSettlementIsDispatched(t *testing.T) {
 	}
 	if got.Results[0].Action == ActionDispatchedTimeout {
 		t.Fatal("done settlement must not be dispatched_timeout")
+	}
+}
+
+func TestRunLiveBlockedSettlementIsDispatchedBlocked(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	h := &scriptHerdr{
+		lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{{
+			Status: herdr.PromptMatched,
+			Agent:  herdr.Agent{PaneID: "w2:pC", AgentStatus: "blocked"},
+		}},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR()}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionDispatchedBlocked {
+		t.Fatalf("results = %+v, want dispatched_blocked", got.Results)
+	}
+	if got.Results[0].Action == ActionDispatched {
+		t.Fatal("blocked settlement must not be recorded as plain dispatched")
+	}
+	if got.Results[0].PaneID == "" || got.Results[0].RenderedPrompt == "" {
+		t.Fatalf("blocked item missing pane/prompt: %+v", got.Results[0])
+	}
+	st, err := LoadFile(store.Path)
+	if err != nil {
+		t.Fatalf("LoadFile() error = %v", err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state after blocked send = %#v", st)
+	}
+}
+
+func TestRunLiveBlockedStopsAdvancing(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	pr2 := fixtureEligiblePR()
+	pr2.Number = 124
+	pr2.BlockingComments = []scan.Comment{{CommentID: "PRRC_second"}}
+	h := &scriptHerdr{
+		lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{{
+			Status: herdr.PromptMatched,
+			Agent:  herdr.Agent{PaneID: "w2:pC", AgentStatus: "blocked"},
+		}},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{fixtureEligiblePR(), pr2}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Action != ActionDispatchedBlocked || got.Results[0].Number != 123 {
+		t.Fatalf("first = %+v, want dispatched_blocked #123", got.Results[0])
+	}
+	if got.Results[1].Action != ActionQueued || got.Results[1].Number != 124 {
+		t.Fatalf("second = %+v, want queued #124", got.Results[1])
+	}
+	if h.promptN != 1 {
+		t.Fatalf("Prompt calls = %d, want 1 (do not start the next agent)", h.promptN)
+	}
+	st, err := LoadFile(store.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
+		t.Fatalf("state missing first PR: %#v", st)
+	}
+	if _, ok := st["acme/widgets#124"]; ok {
+		t.Fatalf("state has second PR: %#v", st)
 	}
 }
 

--- a/devtools/prsync/internal/dispatch/gate.go
+++ b/devtools/prsync/internal/dispatch/gate.go
@@ -40,7 +40,7 @@ type Result struct {
 	Busy []Busy `json:"busy"`
 }
 
-// Busy is one working agent in the busy set.
+// Busy is one working or blocked agent in the busy set.
 type Busy struct {
 	PaneID string `json:"pane_id"` //nolint:tagliatelle // brief outbound contract
 	TabID  string `json:"tab_id"`  //nolint:tagliatelle // brief outbound contract
@@ -109,7 +109,7 @@ func busySet(agents []herdr.Agent, waitOn, runnerPane string, matchedTabs map[st
 }
 
 func isBusy(agent herdr.Agent, waitOn, runnerPane string, matchedTabs map[string]struct{}) bool {
-	if agent.AgentStatus != "working" {
+	if !holdsGate(agent.AgentStatus) {
 		return false
 	}
 	if runnerPane != "" && agent.PaneID == runnerPane {
@@ -120,4 +120,8 @@ func isBusy(agent herdr.Agent, waitOn, runnerPane string, matchedTabs map[string
 		return ok
 	}
 	return true
+}
+
+func holdsGate(status string) bool {
+	return status == "working" || status == "blocked"
 }

--- a/devtools/prsync/internal/dispatch/gate_test.go
+++ b/devtools/prsync/internal/dispatch/gate_test.go
@@ -104,10 +104,53 @@ func TestCheckManagedBusyWhenMatched(t *testing.T) {
 	}
 }
 
+func TestCheckBlockedIsBusy(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{blockedAgent("w2:pC", "w2:tC")}}}
+	got, err := Check(context.Background(), h, "any", "", nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got.Safe {
+		t.Fatal("safe = true, want false while an agent is blocked awaiting the user")
+	}
+	if len(got.Busy) != 1 || got.Busy[0].PaneID != "w2:pC" || got.Busy[0].TabID != "w2:tC" {
+		t.Fatalf("busy = %+v, want [{w2:pC w2:tC}]", got.Busy)
+	}
+}
+
+func TestCheckBlockedSelfExclusion(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{blockedAgent("w2:pC", "w2:tC")}}}
+	got, err := Check(context.Background(), h, "any", "w2:pC", nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !got.Safe {
+		t.Fatalf("safe = false, want true after excluding runner pane; busy=%+v", got.Busy)
+	}
+}
+
+func TestCheckManagedBusyWhenMatchedBlocked(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{{blockedAgent("w2:pC", "w2:tC")}}}
+	matched := map[string]struct{}{"w2:tC": {}}
+	got, err := Check(context.Background(), h, "managed", "", matched)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got.Safe {
+		t.Fatal("safe = true, want false when a matched tab is blocked")
+	}
+}
+
 func TestCheckNonWorkingStatusesAreSafe(t *testing.T) {
 	t.Parallel()
 
-	for _, status := range []string{"idle", "done", "blocked", "unknown", "none"} {
+	for _, status := range []string{"idle", "done", "unknown", "none"} {
 		t.Run(status, func(t *testing.T) {
 			t.Parallel()
 			h := &scriptHerdr{lists: [][]herdr.Agent{{{
@@ -199,6 +242,34 @@ func TestWaitFlipsWorkingToIdle(t *testing.T) {
 	}
 	if h.n != 2 {
 		t.Fatalf("AgentList calls = %d, want 2 (busy then idle)", h.n)
+	}
+	if sleeper.n != 1 {
+		t.Fatalf("Sleep calls = %d, want 1", sleeper.n)
+	}
+}
+
+func TestWaitFlipsBlockedToIdle(t *testing.T) {
+	t.Parallel()
+
+	h := &scriptHerdr{lists: [][]herdr.Agent{
+		{blockedAgent("w2:pC", "w2:tC")},
+		{idleAgent("w2:pC", "w2:tC")},
+	}}
+	clock := &fakeClock{now: time.Unix(0, 0).UTC()}
+	sleeper := &fakeSleeper{clock: clock}
+	cfg := config.Defaults()
+	cfg.GatePoll = time.Millisecond
+	cfg.GateTimeout = 50 * time.Millisecond
+
+	got, err := Wait(context.Background(), h, cfg, "", nil, clock, sleeper)
+	if err != nil {
+		t.Fatalf("Wait() unexpected error: %v", err)
+	}
+	if !got.Safe {
+		t.Fatalf("safe = false after flip, busy=%+v", got.Busy)
+	}
+	if h.n != 2 {
+		t.Fatalf("AgentList calls = %d, want 2 (blocked then idle)", h.n)
 	}
 	if sleeper.n != 1 {
 		t.Fatalf("Sleep calls = %d, want 1", sleeper.n)
@@ -309,6 +380,10 @@ func workingAgent(paneID, tabID string) herdr.Agent {
 
 func idleAgent(paneID, tabID string) herdr.Agent {
 	return herdr.Agent{PaneID: paneID, TabID: tabID, Agent: "codex", AgentStatus: "idle"}
+}
+
+func blockedAgent(paneID, tabID string) herdr.Agent {
+	return herdr.Agent{PaneID: paneID, TabID: tabID, Agent: "codex", AgentStatus: "blocked"}
 }
 
 func strPtr(s string) *string { return &s }

--- a/devtools/prsync/internal/dispatch/types.go
+++ b/devtools/prsync/internal/dispatch/types.go
@@ -5,6 +5,7 @@ const (
 	ActionWouldDispatch     = "would_dispatch"
 	ActionDispatched        = "dispatched"
 	ActionDispatchedTimeout = "dispatched_timeout"
+	ActionDispatchedBlocked = "dispatched_blocked"
 	ActionSkippedNoTab      = "skipped_no_tab"
 	ActionSkippedNoAgent    = "skipped_no_agent"
 	ActionSkippedBusy       = "skipped_busy"

--- a/devtools/prsync/prsync.config.example
+++ b/devtools/prsync/prsync.config.example
@@ -20,8 +20,8 @@
 # herdr_bin=herdr
 # gh_bin=gh
 
-# Gate busy-set: any (every working agent) | managed (only tabs matched
-# to PRs in the current scan; managed runs a scan).
+# Gate busy-set: any (every working or blocked agent) | managed (only
+# tabs matched to PRs in the current scan; managed runs a scan).
 # concurrency_wait_on=any
 
 # Milliseconds. Parsed as n * time.Millisecond (2000 = 2s, not 2µs).
@@ -41,11 +41,15 @@
 
 # Whitespace-separated herdr --until tokens. Each token becomes its own
 # `herdr agent prompt --until <token>` flag. At least one token required.
-# Default `idle done` treats a settled unfocused agent as ready-for-input.
-# Live dispatch then runs: --wait --until idle --until done
+# Default `idle done blocked` treats a settled unfocused agent as
+# ready-for-input and treats a user-blocked agent as a terminal
+# settlement (dispatched_blocked; the batch stops so the next agent
+# does not start). Live dispatch then runs:
+# --wait --until idle --until done --until blocked
 # Set `idle` only to wait until herdr reports idle (can take ~30 min if
 # the agent settles to done instead).
-# dispatch_wait_until=idle done
+# dispatch_wait_until=idle done blocked
 
-# Written only on live send (dispatched / dispatched_timeout).
+# Written only on live send (dispatched / dispatched_timeout /
+# dispatched_blocked).
 # state_file=~/.config/prsync/state.json


### PR DESCRIPTION
## Summary
- Treat herdr `blocked` (awaiting user input) as busy in `isBusy`, so `prsync dispatch` does not start the next PR while a session is parked on a question.
- Default `dispatch_wait_until` is now `idle done blocked`, matching herdr's own `--until` states.
- A blocked settlement of the just-sent prompt is `dispatched_blocked` (not plain `dispatched`). State is written for dedupe, remaining PRs are `queued`, and the batch stops until the user unblocks it.

## Test plan
- [x] `Check`/`Wait` treat `blocked` as busy (self-exclusion and managed matching still apply)
- [x] Live send emits `dispatched_blocked` and does not start the next agent
- [x] `make check` is green

Resolves #229