### PR TITLE
feat(prsync): ask before resolving judgment review comments

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -104,7 +104,7 @@ variables are not expanded.
 | ~gate_poll_ms~ | ~2000~ | Gate poll interval (milliseconds). |
 | ~gate_timeout_ms~ | ~1800000~ | Live dispatch gives up waiting on the gate after this many ms (exit 4). |
 | ~dispatch_timeout_ms~ | ~1800000~ | Passed to ~herdr agent prompt --timeout~. |
-| ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{identifier}~, ~{number}~, ~{title}~, ~{repo}~, ~{url}~, ~{head}~, ~{base}~, ~{comments}~ are substituted. Unknown placeholders are left literal. |
+| ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{identifier}~, ~{number}~, ~{title}~, ~{repo}~, ~{url}~, ~{head}~, ~{base}~, ~{comments}~ are substituted. Unknown placeholders are left literal. Default: apply mechanical / unambiguous fixes; for a design decision, tradeoff, or disagreement, pause and ask the user (with a recommended option) before editing / resolving / pushing. |
 | ~rebase_prompt_template~ | built-in | Same substitution as ~dispatch_prompt_template~. Used only with ~dispatch --rebase~. Default: check out ~{head}~, fetch, rebase onto ~origin/{base}~, resolve conflicts, ~--force-with-lease~, no new worktree. |
 | ~dispatch_include_drafts~ | ~false~ | ~true~ / ~false~ / ~1~ / ~0~. |
 | ~dispatch_wait_until~ | ~idle done blocked~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
@@ -220,7 +220,7 @@ prsync dispatch --config ./prsync.config --pr acme/widgets#123
       "number": 123,
       "action": "would_dispatch",
       "pane_id": "w2:pC",
-      "rendered_prompt": "Address the unresolved review comments on PR #123 (https://github.com/acme/widgets/pull/123).\n\nUnaddressed threads:\n- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)\n\nFor each thread: understand the reviewer's ask, make the change (or reply if you\ndisagree, with reasoning), resolve the thread, and push. Do not touch other PRs."
+      "rendered_prompt": "Address the unresolved review comments on PR #123 (https://github.com/acme/widgets/pull/123).\n\nUnaddressed threads:\n- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)\n\nTriage each thread before acting:\n- Mechanical / unambiguous (typo, nil check, rename, obvious bug): make the\n  change, resolve the thread, and continue.\n- Design decision, tradeoff, or disagreement: pause and ask the user how to\n  proceed, with a recommended option. Do not edit, resolve, or push for that\n  thread until they answer.\n\nPush after the mechanical threads are done (and after the user answers any\nquestions). Do not touch other PRs."
     }
   ]
 }

--- a/devtools/prsync/internal/config/config.go
+++ b/devtools/prsync/internal/config/config.go
@@ -19,8 +19,15 @@ const defaultPromptTemplate = `Address the unresolved review comments on PR #{nu
 Unaddressed threads:
 {comments}
 
-For each thread: understand the reviewer's ask, make the change (or reply if you
-disagree, with reasoning), resolve the thread, and push. Do not touch other PRs.`
+Triage each thread before acting:
+- Mechanical / unambiguous (typo, nil check, rename, obvious bug): make the
+  change, resolve the thread, and continue.
+- Design decision, tradeoff, or disagreement: pause and ask the user how to
+  proceed, with a recommended option. Do not edit, resolve, or push for that
+  thread until they answer.
+
+Push after the mechanical threads are done (and after the user answers any
+questions). Do not touch other PRs.`
 
 const defaultRebasePromptTemplate = `Rebase PR #{number} ({url}) onto origin/{base} in this working directory. Do not create a new worktree.
 

--- a/devtools/prsync/internal/config/config_test.go
+++ b/devtools/prsync/internal/config/config_test.go
@@ -475,6 +475,18 @@ func TestDefaults(t *testing.T) {
 	if !regexp.MustCompile(`Address the unresolved review comments`).MatchString(got.PromptTemplate) {
 		t.Fatalf("PromptTemplate missing built-in text: %q", got.PromptTemplate)
 	}
+	if !regexp.MustCompile(`(?i)mechanical`).MatchString(got.PromptTemplate) {
+		t.Fatalf("PromptTemplate missing mechanical-triage: %q", got.PromptTemplate)
+	}
+	if !regexp.MustCompile(`(?i)ask the user`).MatchString(got.PromptTemplate) {
+		t.Fatalf("PromptTemplate missing ask-the-user: %q", got.PromptTemplate)
+	}
+	if !regexp.MustCompile(`(?i)recommend`).MatchString(got.PromptTemplate) {
+		t.Fatalf("PromptTemplate missing recommended option: %q", got.PromptTemplate)
+	}
+	if regexp.MustCompile(`make the change \(or reply if you`).MatchString(got.PromptTemplate) {
+		t.Fatalf("PromptTemplate still instructs autonomous resolve: %q", got.PromptTemplate)
+	}
 	if !regexp.MustCompile(`Check out \{head\}`).MatchString(got.RebasePromptTemplate) {
 		t.Fatalf("RebasePromptTemplate missing checkout: %q", got.RebasePromptTemplate)
 	}

--- a/devtools/prsync/internal/dispatch/prompt_test.go
+++ b/devtools/prsync/internal/dispatch/prompt_test.go
@@ -90,6 +90,15 @@ func TestRenderDefaultTemplate(t *testing.T) {
 	if strings.Contains(got, "{") {
 		t.Fatalf("unreplaced placeholder: %q", got)
 	}
+	if !strings.Contains(strings.ToLower(got), "ask the user") {
+		t.Fatalf("missing ask-the-user: %q", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "recommend") {
+		t.Fatalf("missing recommended option: %q", got)
+	}
+	if strings.Contains(got, "understand the reviewer's ask, make the change") {
+		t.Fatalf("still autonomous resolve: %q", got)
+	}
 }
 
 func TestRenderLongestKeyFirst(t *testing.T) {

--- a/devtools/prsync/internal/dispatch/testdata/golden/dispatch-dry-run.json
+++ b/devtools/prsync/internal/dispatch/testdata/golden/dispatch-dry-run.json
@@ -17,7 +17,7 @@
       "number": 123,
       "action": "would_dispatch",
       "pane_id": "w2:pC",
-      "rendered_prompt": "Address the unresolved review comments on PR #123 (https://github.com/acme/widgets/pull/123).\n\nUnaddressed threads:\n- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)\n\nFor each thread: understand the reviewer's ask, make the change (or reply if you\ndisagree, with reasoning), resolve the thread, and push. Do not touch other PRs."
+      "rendered_prompt": "Address the unresolved review comments on PR #123 (https://github.com/acme/widgets/pull/123).\n\nUnaddressed threads:\n- src/widget.go:42 — reviewer-login: This should handle the nil case. (https://github.com/acme/widgets/pull/123#discussion_r1)\n\nTriage each thread before acting:\n- Mechanical / unambiguous (typo, nil check, rename, obvious bug): make the\n  change, resolve the thread, and continue.\n- Design decision, tradeoff, or disagreement: pause and ask the user how to\n  proceed, with a recommended option. Do not edit, resolve, or push for that\n  thread until they answer.\n\nPush after the mechanical threads are done (and after the user answers any\nquestions). Do not touch other PRs."
     },
     {
       "repo": "acme/widgets",

--- a/devtools/prsync/prsync.config.example
+++ b/devtools/prsync/prsync.config.example
@@ -33,6 +33,9 @@
 # Substituted: {identifier} {number} {title} {repo} {url} {head} {base} {comments}.
 # Unknown placeholders are left literal. Review comment bodies are interpolated
 # into the prompt as text.
+# Default: apply mechanical / unambiguous fixes; for a design decision,
+# tradeoff, or disagreement, pause and ask the user (with a recommended
+# option) before editing / resolving / pushing.
 # dispatch_prompt_template=
 
 # Used only by `prsync dispatch --rebase`. Same placeholders as


### PR DESCRIPTION
## Summary
- Default `dispatch_prompt_template` now **triages** each review thread instead of resolving autonomously.
- Mechanical / unambiguous fixes (typo, nil check, rename, obvious bug) still apply, resolve, and continue.
- Design decisions, tradeoffs, or disagreement: pause and **ask the user** how to proceed, with a recommended option. Do not edit, resolve, or push that thread until they answer.
- No new config key: override the whole prompt with `dispatch_prompt_template` if you want the old autonomous behavior. Relies on #229 so a blocked ask holds the concurrency gate.

## Test plan
- [x] Defaults and rendered-prompt tests require triage / ask-the-user / recommended-option wording and reject the old autonomous instruction
- [x] Dry-run golden and README example match the new default prompt
- [x] `make check` is green

Resolves #231