### PR TITLE
fix(prsync): wait for idle/done instead of settling on blocked

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -107,22 +107,25 @@ variables are not expanded.
 | ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{identifier}~, ~{number}~, ~{title}~, ~{repo}~, ~{url}~, ~{head}~, ~{base}~, ~{comments}~ are substituted. Unknown placeholders are left literal. Default: apply mechanical / unambiguous fixes; for a design decision, tradeoff, or disagreement, pause and ask the user (with a recommended option) before editing / resolving / pushing. |
 | ~rebase_prompt_template~ | built-in | Same substitution as ~dispatch_prompt_template~. Used only with ~dispatch --rebase~. Default: check out ~{head}~, fetch, rebase onto ~origin/{base}~, resolve conflicts, ~--force-with-lease~, no new worktree. |
 | ~dispatch_include_drafts~ | ~false~ | ~true~ / ~false~ / ~1~ / ~0~. |
-| ~dispatch_wait_until~ | ~idle done blocked~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
-| ~state_file~ | =$HOME/.config/prsync/state.json= | Dispatch audit / dedupe log. Written only on live send. |
+| ~dispatch_wait_until~ | ~idle done~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
+| ~state_file~ | =$HOME/.config/prsync/state.json= | Dispatch audit / dedupe log. Written only on live ~dispatched~ / ~dispatched_timeout~. |
 | ~dry_run~ | ~true~ | ~true~ / ~false~ / ~1~ / ~0~. ~--go~ overrides to live. |
 
-~dispatch_wait_until=idle done blocked~ (the default) treats a settled
-unfocused agent as ready-for-input, and treats a user-blocked agent as
-a terminal settlement for this send. Live dispatch therefore runs:
+~dispatch_wait_until=idle done~ (the default) waits until the agent
+truly finishes — including after the user answers a question in that
+tab. Live dispatch therefore runs:
 
 #+BEGIN_EXAMPLE
-herdr agent prompt <pane_id> <prompt> --wait --until idle --until done --until blocked --timeout …
+herdr agent prompt <pane_id> <prompt> --wait --until idle --until done --timeout …
 #+END_EXAMPLE
 
-A ~blocked~ settlement is ~dispatched_blocked~ (not plain ~dispatched~)
-and stops the batch so the next agent does not start while the user is
-answering. Set ~dispatch_wait_until=idle~ only if you want to wait until
-herdr reports ~idle~ (can take about 30 minutes if the agent settles to
+If the user never answers, the wait ends at ~dispatch_timeout_ms~
+(~dispatched_timeout~; state is written so it is not retried blindly).
+A ~blocked~ settlement (~dispatched_blocked~) happens only when
+~blocked~ is included in ~dispatch_wait_until~: the batch stops, but
+dedupe state is not written, so a re-run can retry the same comment.
+Set ~dispatch_wait_until=idle~ only if you want to wait until herdr
+reports ~idle~ (can take about 30 minutes if the agent settles to
 ~done~ instead).
 
 See [[file:prsync.config.example][prsync.config.example]] for a commented copy of every key.
@@ -226,8 +229,7 @@ prsync dispatch --config ./prsync.config --pr acme/widgets#123
 }
 #+END_SRC
 
-Live send (writes ~state_file~ on ~dispatched~ / ~dispatched_timeout~ /
-~dispatched_blocked~):
+Live send (writes ~state_file~ on ~dispatched~ / ~dispatched_timeout~):
 
 #+BEGIN_SRC bash
 prsync dispatch --config ./prsync.config --go
@@ -290,17 +292,17 @@ Against a real herdr ≥ 0.8 and an authenticated ~gh~:
 #+BEGIN_SRC bash
 prsync scan --config ./prsync.config
 prsync dispatch --config ./prsync.config          # review rendered_prompt
-prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done --until blocked
+prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done
 prsync gate --config ./prsync.config
 #+END_SRC
 
 Confirm:
 
 - ~agent prompt~ targets a ~pane_id~ (~w2:pC~, not a tab id).
-- Default wait is ~--wait --until idle --until done --until blocked~ (from
+- Default wait is ~--wait --until idle --until done~ (from
   ~dispatch_wait_until~).
-- ~--wait --until idle --until done --until blocked~ returns after the agent
-  settles or blocks awaiting the user.
+- ~--wait --until idle --until done~ returns after the agent settles
+  (after the user answers, if it asked).
 
 This procedure is README-only; CI uses fixture binaries, not live herdr.
 

--- a/devtools/prsync/internal/cli/cli_integration_test.go
+++ b/devtools/prsync/internal/cli/cli_integration_test.go
@@ -120,10 +120,10 @@ func TestDispatchGoBlockedStopsBatch(t *testing.T) {
 	cfgPath := writeLiveConfig(t, ghBin, herdrBin, statePath)
 	raw := mustScanJSON(t, stdinTwoEligibleDoc())
 	restore := swapStdin(t, string(raw))
-	defer restore()
 
 	var stdout, stderr bytes.Buffer
 	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	restore()
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -137,15 +137,27 @@ func TestDispatchGoBlockedStopsBatch(t *testing.T) {
 	if got.Results[1].Action != dispatch.ActionQueued || got.Results[1].Number != 124 {
 		t.Fatalf("second = %+v, want queued #124", got.Results[1])
 	}
-	st, err := dispatch.LoadFile(statePath)
-	if err != nil {
-		t.Fatal(err)
+	if _, err := os.Stat(statePath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state_file written on blocked send")
 	}
-	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
-		t.Fatalf("state missing first PR: %#v", st)
+
+	restore = swapStdin(t, string(raw))
+	stdout.Reset()
+	stderr.Reset()
+	code = Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	restore()
+	if code != ExitOK {
+		t.Fatalf("second --go exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
-	if _, ok := st["acme/widgets#124"]; ok {
-		t.Fatalf("state has second PR: %#v", st)
+	got = decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("second len(results) = %d, want 2\n%s", len(got.Results), stdout.String())
+	}
+	if got.Results[0].Action == dispatch.ActionSkippedDeduped {
+		t.Fatal("blocked PR must not be skipped_deduped on re-run")
+	}
+	if got.Results[0].Action != dispatch.ActionDispatchedBlocked || got.Results[0].Number != 123 {
+		t.Fatalf("second first = %+v, want dispatched_blocked #123", got.Results[0])
 	}
 }
 

--- a/devtools/prsync/internal/config/config.go
+++ b/devtools/prsync/internal/config/config.go
@@ -96,7 +96,7 @@ func Defaults() Config {
 		GateTimeout:          1800000 * time.Millisecond,
 		PromptTemplate:       defaultPromptTemplate,
 		RebasePromptTemplate: defaultRebasePromptTemplate,
-		WaitUntil:            []string{"idle", "done", "blocked"},
+		WaitUntil:            []string{"idle", "done"},
 		DispatchTimeout:      1800000 * time.Millisecond,
 		StateFile:            "~/.config/prsync/state.json",
 		DryRun:               true,

--- a/devtools/prsync/internal/config/config_test.go
+++ b/devtools/prsync/internal/config/config_test.go
@@ -460,7 +460,7 @@ func TestDefaults(t *testing.T) {
 	if got.DispatchTimeout != 1800000*time.Millisecond {
 		t.Fatalf("DispatchTimeout = %s", got.DispatchTimeout)
 	}
-	if !slices.Equal(got.WaitUntil, []string{"idle", "done", "blocked"}) {
+	if !slices.Equal(got.WaitUntil, []string{"idle", "done"}) {
 		t.Fatalf("WaitUntil = %#v", got.WaitUntil)
 	}
 	if !got.DryRun {

--- a/devtools/prsync/internal/dispatch/dispatch.go
+++ b/devtools/prsync/internal/dispatch/dispatch.go
@@ -127,10 +127,10 @@ func Evaluate(c Candidate, cfg config.Config, st State, rebase bool) Item {
 
 // Run evaluates the candidate set. Dry-run does a one-shot gate.Check, never
 // polls, never emits queued, and never writes state. Live send polls the gate
-// one PR at a time, writes state on dispatched / dispatched_timeout /
-// dispatched_blocked, and returns ErrTimeout or ErrFailed after emitting
-// partial results. A blocked settlement stops the batch so the user can
-// answer before the next agent starts.
+// one PR at a time, writes state on dispatched / dispatched_timeout, and
+// returns ErrTimeout or ErrFailed after emitting partial results. A blocked
+// settlement does not write dedupe state and stops the batch so a re-run can
+// retry the same comment after the user answers.
 func Run(ctx context.Context, h Herdr, store StateStore, cfg config.Config, req Request, now time.Time) (Document, error) {
 	doc := Document{
 		GeneratedAt: now.UTC().Format(time.RFC3339),
@@ -205,7 +205,7 @@ func dispatchLive(ctx context.Context, h Herdr, store StateStore, cfg config.Con
 		}
 		item = sendPrompt(ctx, h, cfg, c, req.Rebase)
 		doc.Results = append(doc.Results, item)
-		if item.Action == ActionDispatched || item.Action == ActionDispatchedTimeout || item.Action == ActionDispatchedBlocked {
+		if item.Action == ActionDispatched || item.Action == ActionDispatchedTimeout {
 			if req.Rebase {
 				st.RecordHead(prKey(c.Repo, c.Number), c.PR.HeadSHA, now)
 			} else {

--- a/devtools/prsync/internal/dispatch/dispatch_test.go
+++ b/devtools/prsync/internal/dispatch/dispatch_test.go
@@ -224,8 +224,8 @@ func TestRunLiveDispatchedWritesState(t *testing.T) {
 	if h.promptN != 1 {
 		t.Fatalf("Prompt calls = %d, want 1", h.promptN)
 	}
-	if !slices.Equal(h.sawUntil, []string{"idle", "done", "blocked"}) {
-		t.Fatalf("until = %v, want [idle done blocked]", h.sawUntil)
+	if !slices.Equal(h.sawUntil, []string{"idle", "done"}) {
+		t.Fatalf("until = %v, want [idle done]", h.sawUntil)
 	}
 
 	st, err := LoadFile(store.Path)
@@ -350,6 +350,9 @@ func TestRunLiveRebaseBlockedStopsAdvancing(t *testing.T) {
 	}
 	if h.promptN != 1 {
 		t.Fatalf("Prompt calls = %d, want 1 (gate/serial unchanged)", h.promptN)
+	}
+	if _, err := os.Stat(store.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state file written on blocked rebase")
 	}
 }
 
@@ -488,12 +491,8 @@ func TestRunLiveBlockedSettlementIsDispatchedBlocked(t *testing.T) {
 	if got.Results[0].PaneID == "" || got.Results[0].RenderedPrompt == "" {
 		t.Fatalf("blocked item missing pane/prompt: %+v", got.Results[0])
 	}
-	st, err := LoadFile(store.Path)
-	if err != nil {
-		t.Fatalf("LoadFile() error = %v", err)
-	}
-	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
-		t.Fatalf("state after blocked send = %#v", st)
+	if _, err := os.Stat(store.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state file written on transient blocked settlement")
 	}
 }
 
@@ -529,15 +528,57 @@ func TestRunLiveBlockedStopsAdvancing(t *testing.T) {
 	if h.promptN != 1 {
 		t.Fatalf("Prompt calls = %d, want 1 (do not start the next agent)", h.promptN)
 	}
+	if _, err := os.Stat(store.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("state file written on blocked send")
+	}
+}
+
+func TestRunLiveBlockedDoesNotDedupeOnRerun(t *testing.T) {
+	t.Parallel()
+
+	cfg, store := liveCfg(t)
+	pr := fixtureEligiblePR()
+	h := &scriptHerdr{
+		lists: [][]herdr.Agent{{idleAgent("w2:pC", "w2:tC")}},
+		prompts: []herdr.PromptOutcome{
+			{
+				Status: herdr.PromptMatched,
+				Agent:  herdr.Agent{PaneID: "w2:pC", AgentStatus: "blocked"},
+			},
+			{
+				Status: herdr.PromptMatched,
+				Agent:  herdr.Agent{PaneID: "w2:pC", AgentStatus: "idle"},
+			},
+		},
+	}
+	got, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{pr}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("first Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionDispatchedBlocked {
+		t.Fatalf("first = %+v, want dispatched_blocked", got.Results)
+	}
+
+	got2, err := Run(context.Background(), h, store, cfg, Request{
+		Doc: scan.Document{PRs: []scan.PR{pr}},
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("second Run() unexpected error: %v", err)
+	}
+	if len(got2.Results) != 1 || got2.Results[0].Action != ActionDispatched {
+		t.Fatalf("second = %+v, want dispatched (blocked must not skip as deduped)", got2.Results)
+	}
+	if h.promptN != 2 {
+		t.Fatalf("Prompt calls = %d, want 2", h.promptN)
+	}
 	st, err := LoadFile(store.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !st.Deduped("acme/widgets#123", []string{"PRRC_widget"}) {
-		t.Fatalf("state missing first PR: %#v", st)
-	}
-	if _, ok := st["acme/widgets#124"]; ok {
-		t.Fatalf("state has second PR: %#v", st)
+		t.Fatalf("state after real completion = %#v", st)
 	}
 }
 

--- a/devtools/prsync/prsync.config.example
+++ b/devtools/prsync/prsync.config.example
@@ -49,15 +49,15 @@
 
 # Whitespace-separated herdr --until tokens. Each token becomes its own
 # `herdr agent prompt --until <token>` flag. At least one token required.
-# Default `idle done blocked` treats a settled unfocused agent as
-# ready-for-input and treats a user-blocked agent as a terminal
-# settlement (dispatched_blocked; the batch stops so the next agent
-# does not start). Live dispatch then runs:
-# --wait --until idle --until done --until blocked
+# Default `idle done` waits until the agent truly finishes (after the
+# user answers a question in that tab). Live dispatch then runs:
+# --wait --until idle --until done
 # Set `idle` only to wait until herdr reports idle (can take ~30 min if
-# the agent settles to done instead).
-# dispatch_wait_until=idle done blocked
+# the agent settles to done instead). Include `blocked` only if you want
+# the per-send wait to return while the agent is awaiting the user
+# (dispatched_blocked; the batch stops, but dedupe state is not written).
+# dispatch_wait_until=idle done
 
-# Written only on live send (dispatched / dispatched_timeout /
-# dispatched_blocked).
+# Written only on live send (dispatched / dispatched_timeout). Never
+# written on a transient blocked settlement.
 # state_file=~/.config/prsync/state.json


### PR DESCRIPTION
## Summary
- Default `dispatch_wait_until` is `idle done` again (drop `blocked`), so `herdr agent prompt --wait` blocks until the agent truly finishes after the user answers.
- Dedupe state is written only on `dispatched` / `dispatched_timeout`, never on a transient `blocked` settlement. A mid-question re-run is no longer `skipped_deduped`.
- The gate's hold-on-`blocked` from #232 stays as a cross-run backstop. If `blocked` is still listed in `dispatch_wait_until`, the batch still stops as `dispatched_blocked` but does not record state.

## Test plan
- [x] Default `WaitUntil` is `[idle done]`; live send passes those tokens to herdr
- [x] Blocked settlement does not write state; a second run is not `skipped_deduped`
- [x] Timeout still writes state; true idle/done completion still writes state
- [x] `make check` is green

Resolves #234