### PR TITLE
fix(prsync): do not hang dispatch on idle non-TTY stdin

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -46,7 +46,7 @@ Optional: copy [[file:prsync.config.example][prsync.config.example]] to
 
 #+BEGIN_EXAMPLE
 prsync scan     [--config PATH] [--repo owner/repo ...] [--json]
-prsync dispatch [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--rebase]
+prsync dispatch [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--rebase] [--stdin]
 prsync gate     [--config PATH]
 prsync version
 #+END_EXAMPLE
@@ -60,15 +60,19 @@ prsync version
 | ~--all~ | dispatch | Every PR in the scan document (default when no ~--pr~) |
 | ~--go~ | dispatch | Live send (default is dry-run) |
 | ~--rebase~ | dispatch | Rebase-in-place prompt; skips the unaddressed-comment gate |
+| ~--stdin~ | dispatch | Read a scan document from stdin (FIFO or regular file). Default is self-scan. |
 
 ~--pr~ and ~--all~ together is an error (exit 2). ~--go~ always sends.
 ~dry_run=false~ in the config also sends without ~--go~ (for cron).
 
-~dispatch~ reads a scan document from stdin when stdin is not a TTY and
-the first non-whitespace byte is ~{~. Decode errors are fatal.
+~dispatch~ reads a scan document from stdin only when ~--stdin~ is set
+and stdin is a FIFO or regular file (a pipe or redirected file). Sockets,
+TTYs, and other non-file stdin are ignored so dispatch cannot hang on a
+blocking peek. Decode errors are fatal. Without ~--stdin~, dispatch
+always self-scans.
 
 #+BEGIN_SRC bash
-prsync scan --config ./prsync.config | prsync dispatch --config ./prsync.config
+prsync scan --config ./prsync.config | prsync dispatch --stdin --config ./prsync.config
 #+END_SRC
 
 * Configuration

--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -41,5 +41,6 @@ go_test(
         "//devtools/prsync/internal/scan:go_default_library",
         "//devtools/prsync/internal/version:go_default_library",
         "@com_github_jaeyeom_go_cmdexec//:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/devtools/prsync/internal/cli/cli_dispatch_test.go
+++ b/devtools/prsync/internal/cli/cli_dispatch_test.go
@@ -5,16 +5,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
 	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
 	executor "github.com/jaeyeom/go-cmdexec"
+	"golang.org/x/sys/unix"
 )
 
 func TestPeekScanJSONLeadingWhitespace(t *testing.T) {
@@ -79,7 +82,7 @@ func TestPeekScanJSONEmpty(t *testing.T) {
 	}
 }
 
-func TestStdinIsTTY(t *testing.T) {
+func TestStdinIsScanSource(t *testing.T) {
 	t.Parallel()
 
 	r, w, err := os.Pipe()
@@ -90,11 +93,68 @@ func TestStdinIsTTY(t *testing.T) {
 		r.Close()
 		w.Close()
 	})
-	if stdinIsTTY(r) {
-		t.Fatal("pipe must not be a TTY")
+	if !stdinIsScanSource(r) {
+		t.Fatal("pipe must be a scan source")
 	}
-	if !stdinIsTTY(nil) {
-		t.Fatal("nil stdin treated as TTY (internal scan)")
+	regular, err := os.CreateTemp(t.TempDir(), "scan-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { regular.Close() })
+	if !stdinIsScanSource(regular) {
+		t.Fatal("regular file must be a scan source")
+	}
+	if stdinIsScanSource(nil) {
+		t.Fatal("nil stdin must not be a scan source")
+	}
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { devNull.Close() })
+	if stdinIsScanSource(devNull) {
+		t.Fatal("/dev/null must not be a scan source")
+	}
+}
+
+func TestReadStdinScanDoesNotBlockOnSocket(t *testing.T) {
+	t.Parallel()
+
+	for _, wantStdin := range []bool{false, true} {
+		t.Run(fmt.Sprintf("wantStdin=%v", wantStdin), func(t *testing.T) {
+			t.Parallel()
+			fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f := os.NewFile(uintptr(fds[0]), "stdin-socket")
+			peer := os.NewFile(uintptr(fds[1]), "stdin-socket-peer")
+			t.Cleanup(func() {
+				f.Close()
+				peer.Close()
+			})
+
+			type result struct {
+				fromStdin bool
+				err       error
+			}
+			ch := make(chan result, 1)
+			go func() {
+				_, fromStdin, err := readStdinScan(f, wantStdin)
+				ch <- result{fromStdin: fromStdin, err: err}
+			}()
+			select {
+			case got := <-ch:
+				if got.err != nil {
+					t.Fatalf("error = %v", got.err)
+				}
+				if got.fromStdin {
+					t.Fatal("socket stdin treated as scan document")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("readStdinScan blocked on idle socket stdin")
+			}
+		})
 	}
 }
 
@@ -127,6 +187,33 @@ func TestDispatchPRAndAll(t *testing.T) {
 	}
 }
 
+func TestDispatchWithoutStdinFlagIgnoresPipedJSON(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+
+	piped := stdinEligibleDoc()
+	piped.PRs[0].Repo = "other/repo"
+	piped.PRs[0].Number = 999
+	restore := swapStdin(t, string(mustScanJSON(t, piped)))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Repo != "acme/widgets" || got.Results[0].Number != 123 {
+		t.Fatalf("used piped stdin without --stdin: %+v", got.Results)
+	}
+}
+
 func TestDispatchStdinJSONDryRun(t *testing.T) {
 	ghBin, herdrBin := fixtureBins(t)
 	statePath := filepath.Join(t.TempDir(), "state.json")
@@ -145,7 +232,7 @@ func TestDispatchStdinJSONDryRun(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -175,7 +262,7 @@ func TestDispatchStdinDecodeError(t *testing.T) {
 	defer restore()
 	cfgPath := writeScanConfig(t, "author=alice\nrepos=acme/widgets\nstate_file="+filepath.Join(t.TempDir(), "s.json")+"\n")
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
 	}
@@ -201,7 +288,7 @@ func TestDispatchRebaseAddressedWouldDispatch(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--rebase", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--rebase", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -232,7 +319,7 @@ func TestDispatchAddressedWithoutRebaseIsSkipped(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -255,7 +342,7 @@ func TestDispatchNotFoundPR(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := Execute(context.Background(), []string{
-		"dispatch", "--config", cfgPath,
+		"dispatch", "--stdin", "--config", cfgPath,
 		"--pr", "acme/widgets#123",
 		"--pr", "acme/missing#9",
 	}, &stdout, &stderr, executor.NewBasicExecutor())
@@ -317,7 +404,7 @@ func TestDispatchHerdrMissing(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitPrecondition {
 		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
 	}
@@ -342,7 +429,7 @@ func TestDispatchCorruptState(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitUsage, stderr.String(), stdout.String())
 	}

--- a/devtools/prsync/internal/cli/cli_integration_test.go
+++ b/devtools/prsync/internal/cli/cli_integration_test.go
@@ -23,7 +23,7 @@ func TestDispatchGoThenDeduped(t *testing.T) {
 
 	restore := swapStdin(t, string(raw))
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	restore()
 	if code != ExitOK {
 		t.Fatalf("first --go exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -42,7 +42,7 @@ func TestDispatchGoThenDeduped(t *testing.T) {
 	restore = swapStdin(t, string(raw))
 	stdout.Reset()
 	stderr.Reset()
-	code = Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code = Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	restore()
 	if code != ExitOK {
 		t.Fatalf("second --go exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -63,7 +63,7 @@ func TestDispatchGoStallDoesNotWriteState(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -93,7 +93,7 @@ func TestDispatchGoDoneSettlementIsDispatched(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -122,7 +122,7 @@ func TestDispatchGoBlockedStopsBatch(t *testing.T) {
 	restore := swapStdin(t, string(raw))
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	restore()
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -144,7 +144,7 @@ func TestDispatchGoBlockedStopsBatch(t *testing.T) {
 	restore = swapStdin(t, string(raw))
 	stdout.Reset()
 	stderr.Reset()
-	code = Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code = Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	restore()
 	if code != ExitOK {
 		t.Fatalf("second --go exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
@@ -171,7 +171,7 @@ func TestDispatchGoHerdrTimeoutWritesState(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -196,7 +196,7 @@ func TestDispatchGoMidLoopFatalPartialJSON(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitPrecondition {
 		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
 	}
@@ -229,7 +229,7 @@ func TestDispatchGoGateTimeoutExit4(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"dispatch", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"dispatch", "--stdin", "--config", cfgPath, "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitGateTimeout {
 		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitGateTimeout, stderr.String(), stdout.String())
 	}

--- a/devtools/prsync/internal/cli/dispatch.go
+++ b/devtools/prsync/internal/cli/dispatch.go
@@ -27,13 +27,14 @@ func newDispatchCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 		all        bool
 		goLive     bool
 		rebase     bool
+		readStdin  bool
 	)
 	cmd := &cobra.Command{
 		Use:   "dispatch",
 		Short: "Send unmatched review comments to the matched herdr agent",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runDispatch(cmd.Context(), stdout, exec, configPath, prs, all, goLive, rebase)
+			return runDispatch(cmd.Context(), stdout, exec, configPath, prs, all, goLive, rebase, readStdin)
 		},
 	}
 	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
@@ -41,10 +42,11 @@ func newDispatchCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	cmd.Flags().BoolVar(&all, "all", false, "dispatch every PR in the scan document")
 	cmd.Flags().BoolVar(&goLive, "go", false, "send prompts (default is dry-run)")
 	cmd.Flags().BoolVar(&rebase, "rebase", false, "dispatch a rebase-in-place prompt (skips the unaddressed-comment gate)")
+	cmd.Flags().BoolVar(&readStdin, "stdin", false, "read a scan document from stdin (otherwise self-scan)")
 	return cmd
 }
 
-func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, prs []string, all, goLive, rebase bool) error {
+func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, prs []string, all, goLive, rebase, readStdin bool) error {
 	if all && len(prs) > 0 {
 		return &ExitError{Code: ExitUsage, Err: errors.New("cannot combine --pr and --all")}
 	}
@@ -60,7 +62,7 @@ func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, 
 	if goLive {
 		cfg.DryRun = false
 	}
-	doc, err := loadScanDoc(ctx, cfg, exec)
+	doc, err := loadScanDoc(ctx, cfg, exec, readStdin)
 	if err != nil {
 		return err
 	}
@@ -80,8 +82,8 @@ func runDispatch(ctx context.Context, stdout io.Writer, exec executor.Executor, 
 	return nil
 }
 
-func loadScanDoc(ctx context.Context, cfg config.Config, exec executor.Executor) (scan.Document, error) {
-	doc, fromStdin, err := readStdinScan(os.Stdin)
+func loadScanDoc(ctx context.Context, cfg config.Config, exec executor.Executor, readStdin bool) (scan.Document, error) {
+	doc, fromStdin, err := readStdinScan(os.Stdin, readStdin)
 	if err != nil {
 		return scan.Document{}, &ExitError{Code: ExitUsage, Err: fmt.Errorf("stdin scan JSON: %w", err)}
 	}
@@ -102,19 +104,26 @@ func loadScanDoc(ctx context.Context, cfg config.Config, exec executor.Executor)
 	return doc, nil
 }
 
-func readStdinScan(f *os.File) (scan.Document, bool, error) {
-	if stdinIsTTY(f) {
+func readStdinScan(f *os.File, wantStdin bool) (scan.Document, bool, error) {
+	if !wantStdin || !stdinIsScanSource(f) {
 		return scan.Document{}, false, nil
 	}
 	return peekScanJSON(f)
 }
 
-func stdinIsTTY(f *os.File) bool {
+// stdinIsScanSource reports whether f is a FIFO or regular file. Sockets,
+// TTYs, and other char devices are excluded so a blocking first-byte peek
+// cannot hang.
+func stdinIsScanSource(f *os.File) bool {
 	if f == nil {
-		return true
+		return false
 	}
 	fi, err := f.Stat()
-	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+	if err != nil {
+		return false
+	}
+	m := fi.Mode()
+	return m.IsRegular() || m&os.ModeNamedPipe != 0
 }
 
 func peekScanJSON(r io.Reader) (scan.Document, bool, error) {


### PR DESCRIPTION
## Summary
- `prsync dispatch` no longer peeks stdin unless `--stdin` is set, so an idle non-TTY (open socket, hanging pipe) cannot block forever before any work starts.
- Even with `--stdin`, stdin is read only when it is a FIFO or regular file. Sockets, TTYs, and other char devices are ignored and dispatch self-scans instead.
- Breaking change for the old heuristic: `prsync scan --json | prsync dispatch` is now `… | prsync dispatch --stdin`.

## Test plan
- [x] Idle socket stdin does not block, with or without `--stdin`
- [x] Piped JSON is ignored unless `--stdin` is set
- [x] `--stdin` still reads FIFO scan JSON
- [x] `make check` is green

Resolves #239