### PR TITLE
feat(prsync): omit draft PRs from scan by default

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -3,8 +3,9 @@
 
 * Overview
 
-~prsync~ surveys the author's open GitHub pull requests, classifies which
-ones still need attention, matches each PR to a running
+~prsync~ surveys the author's open GitHub pull requests (drafts omitted
+by default), classifies which ones still need attention, matches each PR
+to a running
 [[https://herdr.dev/][herdr]] agent tab, and — on explicit request — sends
 that agent a prompt to address unresolved review comments — or, with
 ~--rebase~, a rebase-in-place prompt even when there are no open comments.
@@ -116,7 +117,7 @@ variables are not expanded.
 | ~dispatch_timeout_ms~ | ~1800000~ | Passed to ~herdr agent prompt --timeout~. |
 | ~dispatch_prompt_template~ | built-in | Inline text, or ~@/path/to/file~. ~{identifier}~, ~{number}~, ~{title}~, ~{repo}~, ~{url}~, ~{head}~, ~{base}~, ~{comments}~ are substituted. Unknown placeholders are left literal. Default: check out ~{head}~ (via ~gh pr checkout {number}~ if needed), bring it up to date with ~origin/{base}~, then apply mechanical / unambiguous fixes; for a design decision, tradeoff, or disagreement, pause and ask the user (with a recommended option) before editing / resolving / pushing. After the addressed threads are pushed, re-request each human reviewer whose listed comments are all done (~gh pr edit {number} --add-reviewer <login>~). Skip bots, skip already-pending reviewers, and do not dismiss reviews. |
 | ~rebase_prompt_template~ | built-in | Same substitution as ~dispatch_prompt_template~. Used only with ~dispatch --rebase~. Default: check out ~{head}~, fetch, rebase onto ~origin/{base}~, resolve conflicts, ~--force-with-lease~, no new worktree. |
-| ~dispatch_include_drafts~ | ~false~ | ~true~ / ~false~ / ~1~ / ~0~. |
+| ~dispatch_include_drafts~ | ~false~ | ~true~ / ~false~ / ~1~ / ~0~. When true, ~scan~ includes draft PRs and ~dispatch~ may send to them. |
 | ~dispatch_wait_until~ | ~idle done~ | Whitespace-separated tokens. Each becomes its own ~--until~ flag on ~herdr agent prompt~. At least one token required. |
 | ~state_file~ | =$HOME/.config/prsync/state.json= | Dispatch audit / dedupe log. Written only on live ~dispatched~ / ~dispatched_timeout~. |
 | ~dry_run~ | ~true~ | ~true~ / ~false~ / ~1~ / ~0~. ~--go~ overrides to live. |
@@ -209,7 +210,8 @@ prsync scan --config ./prsync.config
 }
 #+END_SRC
 
-~bucket~ is ~needs_you~ | ~ready~ | ~waiting~ | ~draft~. ~APPROVED~ with
+Draft PRs are omitted unless ~dispatch_include_drafts~ is true. ~bucket~
+is ~needs_you~ | ~ready~ | ~waiting~ | ~draft~. ~APPROVED~ with
 leftover ~review_requests~ is ~needs_you~, not ready to merge. ~tab~ is
 ~null~ when no unique herdr tab matches.
 

--- a/devtools/prsync/internal/scan/scan.go
+++ b/devtools/prsync/internal/scan/scan.go
@@ -135,6 +135,9 @@ func classifyRepos(ctx context.Context, client GH, cfg config.Config, repos []st
 			if err := ctx.Err(); err != nil {
 				return fmt.Errorf("scan: %w", err)
 			}
+			if item.IsDraft && !cfg.IncludeDrafts {
+				continue
+			}
 			classified, err := classifyPR(ctx, client, cfg, owner, name, repo, item)
 			if err != nil {
 				return err

--- a/devtools/prsync/internal/scan/scan_test.go
+++ b/devtools/prsync/internal/scan/scan_test.go
@@ -313,6 +313,65 @@ func TestRunDeletedAuthorIsBlocking(t *testing.T) {
 	}
 }
 
+func TestRunOmitsDraftsByDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	g := &scriptGH{
+		list: map[string]listResult{
+			"acme/widgets": {prs: append(fixturePRs(), fixtureDraftPR())},
+		},
+		threads: map[int][]gh.Thread{
+			123: fixtureThreads(),
+			200: fixtureThreads(),
+		},
+	}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, []string{"acme/widgets"}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(doc.PRs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1 (draft omitted)", len(doc.PRs))
+	}
+	if doc.PRs[0].Number != 123 || doc.PRs[0].IsDraft {
+		t.Fatalf("pr = #%d is_draft=%v, want #123 non-draft", doc.PRs[0].Number, doc.PRs[0].IsDraft)
+	}
+	if g.threadCalls[200] != 0 {
+		t.Fatalf("ReviewThreads(#200) calls = %d, want 0 for omitted draft", g.threadCalls[200])
+	}
+}
+
+func TestRunIncludesDraftsWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Author = "alice"
+	cfg.IncludeDrafts = true
+	g := &scriptGH{
+		list: map[string]listResult{
+			"acme/widgets": {prs: append(fixturePRs(), fixtureDraftPR())},
+		},
+		threads: map[int][]gh.Thread{
+			123: fixtureThreads(),
+			200: fixtureThreads(),
+		},
+	}
+	doc, err := Run(context.Background(), depsWith(g, fixtureHerdr{}), cfg, []string{"acme/widgets"}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(doc.PRs) != 2 {
+		t.Fatalf("len(prs) = %d, want 2 (draft included)", len(doc.PRs))
+	}
+	if doc.PRs[1].Number != 200 || !doc.PRs[1].IsDraft {
+		t.Fatalf("second pr = #%d is_draft=%v, want #200 draft", doc.PRs[1].Number, doc.PRs[1].IsDraft)
+	}
+	if g.threadCalls[200] != 1 {
+		t.Fatalf("ReviewThreads(#200) calls = %d, want 1", g.threadCalls[200])
+	}
+}
+
 type fixtureGH struct{}
 
 func (fixtureGH) AuthStatus(context.Context) error { return nil }
@@ -388,6 +447,7 @@ type scriptGH struct {
 	list         map[string]listResult
 	threads      map[int][]gh.Thread
 	threadErr    error
+	threadCalls  map[int]int
 }
 
 func (g *scriptGH) AuthStatus(context.Context) error { return g.authErr }
@@ -415,6 +475,10 @@ func (g *scriptGH) ListOpenPRs(_ context.Context, repo, _ string) ([]gh.PRListIt
 }
 
 func (g *scriptGH) ReviewThreads(_ context.Context, _, _ string, number int) ([]gh.Thread, error) {
+	if g.threadCalls == nil {
+		g.threadCalls = map[int]int{}
+	}
+	g.threadCalls[number]++
 	if g.threadErr != nil {
 		return nil, g.threadErr
 	}
@@ -445,6 +509,16 @@ func fixturePRs() []gh.PRListItem {
 			{Name: "ci", Status: "COMPLETED", Conclusion: "SUCCESS"},
 		},
 	}}
+}
+
+func fixtureDraftPR() gh.PRListItem {
+	item := fixturePRs()[0]
+	item.Number = 200
+	item.Title = "[PROJ-200] WIP the widget"
+	item.URL = "https://github.com/acme/widgets/pull/200"
+	item.HeadRefName = "wip-widget"
+	item.IsDraft = true
+	return item
 }
 
 func fixtureThreads() []gh.Thread {

--- a/devtools/prsync/prsync.config.example
+++ b/devtools/prsync/prsync.config.example
@@ -48,7 +48,8 @@
 # origin/{base}, resolve conflicts, --force-with-lease, no new worktree.
 # rebase_prompt_template=
 
-# true / false / 1 / 0
+# true / false / 1 / 0. When true, scan includes draft PRs and dispatch
+# may send to them. Default omits drafts from scan.
 # dispatch_include_drafts=false
 # dry_run=true
 


### PR DESCRIPTION
## Summary
- `prsync scan` now omits draft PRs by default, matching dispatch.
- `dispatch_include_drafts=true` includes drafts in scan as well, so dispatch can still send to them.
- Drafts are skipped before review-thread fetches, so they do not cost extra GraphQL.

`tabs --orphans` is unchanged: it still treats an open draft as a live PR (via its own GitHub search), so a tab whose PR is still a draft is not reported as an orphan.

## Test plan
- [x] `TestRunOmitsDraftsByDefault` — mixed list keeps only the non-draft and does not call `ReviewThreads` for the draft
- [x] `TestRunIncludesDraftsWhenConfigured` — `IncludeDrafts` includes the draft and classifies it
- [x] `make check` is green (305 tests pass, lint/semgrep clean)