### PR TITLE
fix(devcheck): load package deps so Go 1.27 type-checks stdlib imports

### DIFF
--- a/baseball/baseball_test.go
+++ b/baseball/baseball_test.go
@@ -167,6 +167,7 @@ func Test_computeResult(t *testing.T) {
 	properties.Property("shuffle no out", prop.ForAll(
 		func(a []int) bool {
 			b := append([]int(nil), a...)
+			// #nosec G404
 			rand.Shuffle(len(b), func(i, j int) { b[i], b[j] = b[j], b[i] })
 			r := computeResult(a, b)
 			return r.Out == 0

--- a/devtools/devcheck/internal/detector/unnecessary_interface_assertion_linter.go
+++ b/devtools/devcheck/internal/detector/unnecessary_interface_assertion_linter.go
@@ -45,7 +45,7 @@ func (l *UnnecessaryInterfaceAssertionLinter) Lint(paths []string) ([]string, er
 func (l *UnnecessaryInterfaceAssertionLinter) loadPackages(paths []string) ([]*packages.Package, error) {
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
-			packages.NeedImports | packages.NeedTypes | packages.NeedTypesSizes |
+			packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesSizes |
 			packages.NeedSyntax | packages.NeedTypesInfo,
 		Dir: l.Dir,
 	}


### PR DESCRIPTION
## Summary
- Add `packages.NeedDeps` to the unnecessary-interface-assertion linter's `packages.Load` mode so stdlib imports (e.g. `fmt`) get types.
- This stops Go 1.27's `log.Fatalf` (`package "fmt" without types was imported from "testmodule/necessary"`), which has been failing GitHub Actions **Go Test** on `main` since stable became 1.27.0.
- After that test passed, CI lint started running and failed on gosec G404 for `rand.Shuffle` in `baseball/baseball_test.go`. Add the same `#nosec G404` used on the other `math/rand` calls in that package.

Resolves #246

## Test plan
- [x] Reproduced the fatal with `GOTOOLCHAIN=go1.27.0 go test ./devtools/devcheck/internal/detector/ -count=1 -run TestUnnecessaryInterfaceAssertionLinter`
- [x] Same test and the full detector package pass on Go 1.27.0 and Go 1.26.6 after the change
- [x] Reproduced G404 with `golangci/golangci-lint:v2.13.1` on `./baseball/...`; clean after `#nosec G404`
- [x] `make check` is green
- [ ] Confirm GitHub Actions **Go Test** is green on this PR