### PR TITLE
fix(prsync): omit no_pr orphan tabs whose agent is still working

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -233,8 +233,9 @@ For each live-agent tab whose label yields a ticket via ~title_id_pattern~,
 - ~merged~ — the ticket's PR is merged (or closed) → *safe to close*;
   ~pr~ carries the number, repo, ~state~, and ~merged_at~ (null for a
   closed-but-unmerged PR).
-- ~no_pr~ — no PR found at all → *verify before closing* (may be
-  unpushed local WIP).
+- ~no_pr~ — no PR found at all, and the agent is ~idle~ or ~blocked~
+  → *verify before closing* (may be unpushed local WIP). A ~working~
+  agent with no PR is in-progress work, not an orphan, and is omitted.
 
 Tabs with an open/draft PR are not orphans and are omitted. Agent-less
 scratch tabs and unparseable / non-ticket labels are skipped.
@@ -268,7 +269,7 @@ prsync tabs --orphans --config ./prsync.config
       "workspace_id": "w2",
       "label": "AP-1287",
       "ticket": "AP-1287",
-      "agent_status": "working",
+      "agent_status": "idle",
       "bucket": "no_pr",
       "pr": null
     }

--- a/devtools/prsync/internal/scan/orphan.go
+++ b/devtools/prsync/internal/scan/orphan.go
@@ -74,9 +74,11 @@ func OrphansStarted(doc OrphanDocument) bool {
 }
 
 // Orphans walks live-agent herdr tabs and reports the ones with no open or
-// draft PR. openTabs is the set of tab ids a caller-supplied scan already
-// matched to an open PR; those are skipped without a GitHub search. A non-nil
-// error is fatal after the caller emits the document when OrphansStarted.
+// draft PR. A no_pr tab whose agent is still working is omitted (in-progress,
+// not reclaimable). openTabs is the set of tab ids a caller-supplied scan
+// already matched to an open PR; those are skipped without a GitHub search.
+// A non-nil error is fatal after the caller emits the document when
+// OrphansStarted.
 func Orphans(ctx context.Context, deps OrphanDeps, cfg config.Config, openTabs map[string]struct{}, now time.Time) (OrphanDocument, error) {
 	doc := OrphanDocument{
 		GeneratedAt: now.UTC().Format(time.RFC3339),
@@ -179,6 +181,10 @@ func classifyTab(ctx context.Context, client OrphanGH, cfg config.Config, author
 	}
 	resolving := pickResolving(candidates)
 	if resolving == nil {
+		if status == "working" {
+			// Active work that has not opened a PR yet is not an orphan.
+			return OrphanTab{}, false, nil
+		}
 		orphan.Bucket = BucketNoPR
 		return orphan, true, nil
 	}

--- a/devtools/prsync/internal/scan/orphan_test.go
+++ b/devtools/prsync/internal/scan/orphan_test.go
@@ -63,7 +63,7 @@ func TestOrphansNoPRBucket(t *testing.T) {
 	g := &orphanGH{search: map[string][]gh.PRSearchItem{"AP-1287": {}}}
 	h := stubHerdr{
 		tabs:   []herdr.Tab{liveTab("w2:tB", "w2", "AP-1287")},
-		agents: []herdr.Agent{liveAgent("w2:pB", "w2:tB", "working")},
+		agents: []herdr.Agent{liveAgent("w2:pB", "w2:tB", "idle")},
 	}
 	doc, err := Orphans(context.Background(), OrphanDeps{GH: g, Herdr: h}, orphanCfg(), nil, fixtureNow)
 	if err != nil {
@@ -73,7 +73,72 @@ func TestOrphansNoPRBucket(t *testing.T) {
 		t.Fatalf("orphan_tabs = %+v, want 1", doc.OrphanTabs)
 	}
 	got := doc.OrphanTabs[0]
-	if got.Bucket != BucketNoPR || got.PR != nil || got.AgentStatus != "working" {
+	if got.Bucket != BucketNoPR || got.PR != nil || got.AgentStatus != "idle" {
+		t.Fatalf("orphan = %+v", got)
+	}
+}
+
+func TestOrphansOmitsNoPRWhenAgentWorking(t *testing.T) {
+	t.Parallel()
+
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{"AP-1287": {}}}
+	h := stubHerdr{
+		tabs:   []herdr.Tab{liveTab("w2:tB", "w2", "AP-1287")},
+		agents: []herdr.Agent{liveAgent("w2:pB", "w2:tB", "working")},
+	}
+	doc, err := Orphans(context.Background(), OrphanDeps{GH: g, Herdr: h}, orphanCfg(), nil, fixtureNow)
+	if err != nil {
+		t.Fatalf("Orphans() unexpected error: %v", err)
+	}
+	if len(doc.OrphanTabs) != 0 {
+		t.Fatalf("orphan_tabs = %+v, want empty (working agent is in-progress, not an orphan)", doc.OrphanTabs)
+	}
+}
+
+func TestOrphansNoPRBlockedStillSurfaced(t *testing.T) {
+	t.Parallel()
+
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{"AP-1288": {}}}
+	h := stubHerdr{
+		tabs:   []herdr.Tab{liveTab("w2:tH", "w2", "AP-1288")},
+		agents: []herdr.Agent{liveAgent("w2:pH", "w2:tH", "blocked")},
+	}
+	doc, err := Orphans(context.Background(), OrphanDeps{GH: g, Herdr: h}, orphanCfg(), nil, fixtureNow)
+	if err != nil {
+		t.Fatalf("Orphans() unexpected error: %v", err)
+	}
+	if len(doc.OrphanTabs) != 1 {
+		t.Fatalf("orphan_tabs = %+v, want 1", doc.OrphanTabs)
+	}
+	got := doc.OrphanTabs[0]
+	if got.Bucket != BucketNoPR || got.PR != nil || got.AgentStatus != "blocked" {
+		t.Fatalf("orphan = %+v", got)
+	}
+}
+
+func TestOrphansMergedWorkingUnaffected(t *testing.T) {
+	t.Parallel()
+
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{
+			Number: 32347, Title: "[AP-1306] Fix", URL: "https://gh/acme/x/pull/32347",
+			State: "merged", ClosedAt: "2026-08-18T22:19:28Z",
+			Repository: gh.SearchRepository{NameWithOwner: "acme/x"},
+		}},
+	}}
+	h := stubHerdr{
+		tabs:   []herdr.Tab{liveTab("w2:tA", "w2", "AP-1306")},
+		agents: []herdr.Agent{liveAgent("w2:pA", "w2:tA", "working")},
+	}
+	doc, err := Orphans(context.Background(), OrphanDeps{GH: g, Herdr: h}, orphanCfg(), nil, fixtureNow)
+	if err != nil {
+		t.Fatalf("Orphans() unexpected error: %v", err)
+	}
+	if len(doc.OrphanTabs) != 1 {
+		t.Fatalf("orphan_tabs = %+v, want 1", doc.OrphanTabs)
+	}
+	got := doc.OrphanTabs[0]
+	if got.Bucket != BucketMerged || got.AgentStatus != "working" {
 		t.Fatalf("orphan = %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- `prsync tabs --orphans` no longer reports a `no_pr` tab when `agent_status` is `working`. That is in-progress work, not an orphan.
- `idle` and `blocked` agents with no PR still surface as `no_pr` (verify before closing).
- `merged` and open-PR tabs are unchanged.

Resolves #251

## Test plan
- [x] `TestOrphansOmitsNoPRWhenAgentWorking` — working + no PR is omitted
- [x] idle and blocked still classify as `no_pr`
- [x] working + merged still classifies as `merged`
- [x] `make check` is green (305 tests pass, lint/semgrep clean)