### PR TITLE
feat(prsync): add deterministic agent-free PR comment action

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -11,8 +11,8 @@ that agent a prompt to address unresolved review comments — or, with
 ~--rebase~, a rebase-in-place prompt even when there are no open comments.
 It can also run the join in reverse (~tabs --orphans~) to flag live-agent
 tabs whose PR already merged, so their worktrees and gate slots can be
-reclaimed. ~comment~ posts a conversation-level PR comment (for example
-~/ci~) through ~gh~ with no herdr tab and no concurrency gate.
+reclaimed. ~comment~ posts a conversation-level PR comment through ~gh~
+with no herdr tab and no concurrency gate.
 
 ~scan~ and ~tabs~ are read-only on GitHub. ~comment~ writes a PR comment
 via ~gh~. ~dispatch~ is write-only on herdr (prompt injection). The tool
@@ -56,7 +56,7 @@ Optional: copy [[file:prsync.config.example][prsync.config.example]] to
 prsync scan     [--config PATH] [--repo owner/repo ...] [--json]
 prsync tabs     --orphans [--config PATH] [--json] [--stdin]
 prsync dispatch [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--rebase] [--force] [--stdin]
-prsync comment  [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--stdin] (--body TEXT | --ci)
+prsync comment  [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--stdin] --body TEXT
 prsync gate     [--config PATH]
 prsync version
 #+END_EXAMPLE
@@ -74,12 +74,10 @@ prsync version
 | ~--rebase~ | dispatch | Rebase-in-place prompt; skips the unaddressed-comment gate |
 | ~--force~ | dispatch | Re-dispatch even if dedupe state would skip |
 | ~--stdin~ | dispatch, comment | Read a scan document from stdin (FIFO or regular file). Default is self-scan. |
-| ~--body TEXT~ | comment | Comment body to post |
-| ~--ci~ | comment | Alias for ~--body "/ci"~ |
+| ~--body TEXT~ | comment | Comment body to post (required) |
 
-~--pr~ and ~--all~ together is an error (exit 2). ~--ci~ and ~--body~
-together is an error (exit 2). ~--go~ always sends. ~dry_run=false~ in
-the config also sends without ~--go~ (for cron).
+~--pr~ and ~--all~ together is an error (exit 2). ~--go~ always sends.
+~dry_run=false~ in the config also sends without ~--go~ (for cron).
 
 ~dispatch~ and ~comment~ read a scan document from stdin only when
 ~--stdin~ is set and stdin is a FIFO or regular file (a pipe or
@@ -89,7 +87,7 @@ they cannot hang on a blocking peek. Decode errors are fatal. Without
 
 #+BEGIN_SRC bash
 prsync scan --config ./prsync.config | prsync dispatch --stdin --config ./prsync.config
-prsync scan --config ./prsync.config | prsync comment --stdin --ci --config ./prsync.config
+prsync scan --config ./prsync.config | prsync comment --stdin --body "please retry" --config ./prsync.config
 #+END_SRC
 
 * Configuration
@@ -361,14 +359,15 @@ head-SHA dedupe (use ~--force~ to retry a stuck entry).
 Posts a PR comment through ~gh pr comment~. No herdr tab, no agent, and
 no concurrency gate — this is a GitHub API call, so it works for
 off-machine PRs (a ~tab~ of ~null~ is not a skip). Dry-run by default.
-~--ci~ is ~--body "/ci"~. JSON matches the ~dispatch~ result shape:
+The body is caller-supplied (~--body~); the tool does not special-case
+any comment text. JSON matches the ~dispatch~ result shape:
 ~would_dispatch~ / ~dispatched~ / ~skipped_not_found~, with the comment
 body in ~rendered_prompt~.
 
 #+BEGIN_SRC bash
-prsync comment --config ./prsync.config --pr acme/widgets#123 --ci
-prsync comment --config ./prsync.config --pr acme/widgets#123 --body "/ci" --go
-prsync comment --config ./prsync.config --all --ci
+prsync comment --config ./prsync.config --pr acme/widgets#123 --body "please retry"
+prsync comment --config ./prsync.config --pr acme/widgets#123 --body "please retry" --go
+prsync comment --config ./prsync.config --all --body "please retry"
 #+END_SRC
 
 #+BEGIN_SRC json
@@ -380,7 +379,7 @@ prsync comment --config ./prsync.config --all --ci
       "repo": "acme/widgets",
       "number": 123,
       "action": "would_dispatch",
-      "rendered_prompt": "/ci"
+      "rendered_prompt": "please retry"
     }
   ]
 }
@@ -427,8 +426,8 @@ Against a real herdr ≥ 0.8 and an authenticated ~gh~:
 prsync scan --config ./prsync.config
 prsync dispatch --config ./prsync.config          # review rendered_prompt
 prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done
-prsync comment --config ./prsync.config --ci      # review rendered_prompt
-prsync comment --config ./prsync.config --ci --go
+prsync comment --config ./prsync.config --body "please retry"      # review rendered_prompt
+prsync comment --config ./prsync.config --body "please retry" --go
 prsync gate --config ./prsync.config
 #+END_SRC
 

--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -11,12 +11,15 @@ that agent a prompt to address unresolved review comments — or, with
 ~--rebase~, a rebase-in-place prompt even when there are no open comments.
 It can also run the join in reverse (~tabs --orphans~) to flag live-agent
 tabs whose PR already merged, so their worktrees and gate slots can be
-reclaimed.
+reclaimed. ~comment~ posts a conversation-level PR comment (for example
+~/ci~) through ~gh~ with no herdr tab and no concurrency gate.
 
-The tool is read-only on GitHub and write-only on herdr (prompt injection).
-It shells out to the already-authenticated ~gh~ CLI and to herdr ≥ 0.8. It
+~scan~ and ~tabs~ are read-only on GitHub. ~comment~ writes a PR comment
+via ~gh~. ~dispatch~ is write-only on herdr (prompt injection). The tool
+shells out to the already-authenticated ~gh~ CLI and to herdr ≥ 0.8. It
 never embeds a GitHub token. Dispatch is serialized (one agent at a time)
-and dry-run by default. All commands emit JSON on stdout.
+and dry-run by default; ~comment~ is also dry-run by default. All commands
+emit JSON on stdout.
 
 Related tracker: [[https://github.com/jaeyeom/experimental/issues/211][#211]].
 
@@ -38,9 +41,10 @@ After ~go install~, put ~$GOPATH/bin~ / ~$GOBIN~ on ~PATH~.
 
 - ~gh~ authenticated (~gh auth login~). ~prsync~ never calls ~gh auth token~.
 - herdr ≥ 0.8 on ~PATH~ for matching and dispatch. Missing herdr: ~scan~
-  degrades (tabs are unset); ~dispatch~ and ~gate~ exit 3. Present but older
-  than 0.8, or unparseable ~herdr --version~: every command that would talk
-  to herdr (including ~scan~) exits 3.
+  degrades (tabs are unset); ~dispatch~ and ~gate~ exit 3; ~comment~ still
+  runs (it does not need a tab). Present but older than 0.8, or unparseable
+  ~herdr --version~: every command that would talk to herdr (including
+  ~scan~) exits 3. ~comment --stdin~ never talks to herdr.
 - Linux or macOS. No Windows requirement.
 
 Optional: copy [[file:prsync.config.example][prsync.config.example]] to
@@ -52,35 +56,40 @@ Optional: copy [[file:prsync.config.example][prsync.config.example]] to
 prsync scan     [--config PATH] [--repo owner/repo ...] [--json]
 prsync tabs     --orphans [--config PATH] [--json] [--stdin]
 prsync dispatch [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--rebase] [--force] [--stdin]
+prsync comment  [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--stdin] (--body TEXT | --ci)
 prsync gate     [--config PATH]
 prsync version
 #+END_EXAMPLE
 
 | Flag | Commands | Effect |
 |------+----------+--------|
-| ~--config PATH~ | scan, tabs, dispatch, gate | Use this file (must exist) |
+| ~--config PATH~ | scan, tabs, dispatch, comment, gate | Use this file (must exist) |
 | ~--repo owner/repo~ | scan | Repeatable; replaces ~repos~ entirely |
 | ~--json~ | scan, tabs | Accepted no-op (stdout is always JSON) |
 | ~--orphans~ | tabs | Required; report live-agent tabs with no open/draft PR |
 | ~--stdin~ | tabs | Reuse open-PR↔tab matches from a scan document on stdin (else self-resolve) |
-| ~--pr owner/repo#N~ | dispatch | Repeatable; limit candidates |
-| ~--all~ | dispatch | Every PR in the scan document (default when no ~--pr~) |
-| ~--go~ | dispatch | Live send (default is dry-run) |
+| ~--pr owner/repo#N~ | dispatch, comment | Repeatable; limit candidates |
+| ~--all~ | dispatch, comment | Every PR in the scan document (default when no ~--pr~) |
+| ~--go~ | dispatch, comment | Live send (default is dry-run) |
 | ~--rebase~ | dispatch | Rebase-in-place prompt; skips the unaddressed-comment gate |
 | ~--force~ | dispatch | Re-dispatch even if dedupe state would skip |
-| ~--stdin~ | dispatch | Read a scan document from stdin (FIFO or regular file). Default is self-scan. |
+| ~--stdin~ | dispatch, comment | Read a scan document from stdin (FIFO or regular file). Default is self-scan. |
+| ~--body TEXT~ | comment | Comment body to post |
+| ~--ci~ | comment | Alias for ~--body "/ci"~ |
 
-~--pr~ and ~--all~ together is an error (exit 2). ~--go~ always sends.
-~dry_run=false~ in the config also sends without ~--go~ (for cron).
+~--pr~ and ~--all~ together is an error (exit 2). ~--ci~ and ~--body~
+together is an error (exit 2). ~--go~ always sends. ~dry_run=false~ in
+the config also sends without ~--go~ (for cron).
 
-~dispatch~ reads a scan document from stdin only when ~--stdin~ is set
-and stdin is a FIFO or regular file (a pipe or redirected file). Sockets,
-TTYs, and other non-file stdin are ignored so dispatch cannot hang on a
-blocking peek. Decode errors are fatal. Without ~--stdin~, dispatch
-always self-scans.
+~dispatch~ and ~comment~ read a scan document from stdin only when
+~--stdin~ is set and stdin is a FIFO or regular file (a pipe or
+redirected file). Sockets, TTYs, and other non-file stdin are ignored so
+they cannot hang on a blocking peek. Decode errors are fatal. Without
+~--stdin~, they always self-scan.
 
 #+BEGIN_SRC bash
 prsync scan --config ./prsync.config | prsync dispatch --stdin --config ./prsync.config
+prsync scan --config ./prsync.config | prsync comment --stdin --ci --config ./prsync.config
 #+END_SRC
 
 * Configuration
@@ -347,6 +356,36 @@ prompt to every PR that has a ready tab; auto-picking behind/conflicting
 PRs is a follow-up. Scan documents without ~merge_state_status~ keep
 head-SHA dedupe (use ~--force~ to retry a stuck entry).
 
+** comment
+
+Posts a PR comment through ~gh pr comment~. No herdr tab, no agent, and
+no concurrency gate — this is a GitHub API call, so it works for
+off-machine PRs (a ~tab~ of ~null~ is not a skip). Dry-run by default.
+~--ci~ is ~--body "/ci"~. JSON matches the ~dispatch~ result shape:
+~would_dispatch~ / ~dispatched~ / ~skipped_not_found~, with the comment
+body in ~rendered_prompt~.
+
+#+BEGIN_SRC bash
+prsync comment --config ./prsync.config --pr acme/widgets#123 --ci
+prsync comment --config ./prsync.config --pr acme/widgets#123 --body "/ci" --go
+prsync comment --config ./prsync.config --all --ci
+#+END_SRC
+
+#+BEGIN_SRC json
+{
+  "generated_at": "2026-01-01T09:00:00Z",
+  "dry_run": true,
+  "results": [
+    {
+      "repo": "acme/widgets",
+      "number": 123,
+      "action": "would_dispatch",
+      "rendered_prompt": "/ci"
+    }
+  ]
+}
+#+END_SRC
+
 ** gate
 
 #+BEGIN_SRC bash
@@ -388,6 +427,8 @@ Against a real herdr ≥ 0.8 and an authenticated ~gh~:
 prsync scan --config ./prsync.config
 prsync dispatch --config ./prsync.config          # review rendered_prompt
 prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done
+prsync comment --config ./prsync.config --ci      # review rendered_prompt
+prsync comment --config ./prsync.config --ci --go
 prsync gate --config ./prsync.config
 #+END_SRC
 
@@ -405,6 +446,8 @@ This procedure is README-only; CI uses fixture binaries, not live herdr.
 
 - ~prsync~ never calls ~gh auth token~ and never prints the environment.
   Auth is the operator's existing ~gh~ login plus the local herdr socket.
+- ~comment --go~ posts the given body as a GitHub PR comment. Dry-run
+  first; there is no extra confirmation beyond ~--go~.
 - Review comment bodies are interpolated into the dispatch prompt as text.
   ~prsync~ does not execute them. The *agent* may follow malicious review
   text — this is inherent to the product. Do not treat the prompt as

--- a/devtools/prsync/internal/cli/BUILD.bazel
+++ b/devtools/prsync/internal/cli/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "comment.go",
         "dispatch.go",
         "exit.go",
         "gate.go",
@@ -14,6 +15,7 @@ go_library(
     importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/cli",
     visibility = ["//devtools/prsync:__subpackages__"],
     deps = [
+        "//devtools/prsync/internal/comment:go_default_library",
         "//devtools/prsync/internal/config:go_default_library",
         "//devtools/prsync/internal/dispatch:go_default_library",
         "//devtools/prsync/internal/gh:go_default_library",
@@ -28,6 +30,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cli_comment_test.go",
         "cli_dispatch_test.go",
         "cli_gate_test.go",
         "cli_integration_test.go",

--- a/devtools/prsync/internal/cli/cli_comment_test.go
+++ b/devtools/prsync/internal/cli/cli_comment_test.go
@@ -1,0 +1,313 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestCommentBadPR(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--pr", "not-a-pr", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid --pr") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestCommentPRAndAll(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--pr", "acme/widgets#1", "--all", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot combine --pr and --all") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestCommentRequiresBodyOrCI(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--pr", "acme/widgets#1"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--body") && !strings.Contains(stderr.String(), "--ci") {
+		t.Fatalf("stderr = %q, want --body/--ci requirement", stderr.String())
+	}
+}
+
+func TestCommentCIAndBodyConflict(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--ci", "--body", "other"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot combine --ci and --body") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestCommentStdinJSONDryRunCI(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	sentinel := filepath.Join(t.TempDir(), "comment")
+	t.Setenv("GH_FAKE_COMMENT_SENTINEL", sentinel)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--pr", "acme/widgets#123", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if !got.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %+v", got.Results)
+	}
+	if got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("action = %q, want would_dispatch", got.Results[0].Action)
+	}
+	if got.Results[0].RenderedPrompt != "/ci" {
+		t.Fatalf("rendered_prompt = %q, want /ci", got.Results[0].RenderedPrompt)
+	}
+	if got.Results[0].PaneID != "" {
+		t.Fatalf("pane_id = %q, want empty", got.Results[0].PaneID)
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("gh pr comment was invoked on dry-run")
+	}
+}
+
+func TestCommentStdinOffMachineNoTab(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+	doc := stdinEligibleDoc()
+	doc.PRs[0].Tab = nil
+	raw := mustScanJSON(t, doc)
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--body", "nudge"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("results = %+v, want would_dispatch without a tab", got.Results)
+	}
+	if got.Results[0].RenderedPrompt != "nudge" {
+		t.Fatalf("rendered_prompt = %q, want nudge", got.Results[0].RenderedPrompt)
+	}
+}
+
+func TestCommentGoPostsViaGH(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	sentinel := filepath.Join(t.TempDir(), "comment")
+	t.Setenv("GH_FAKE_COMMENT_SENTINEL", sentinel)
+	promptSentinel := filepath.Join(t.TempDir(), "prompt")
+	t.Setenv("HERDR_FAKE_PROMPT_SENTINEL", promptSentinel)
+	t.Setenv("HERDR_FAKE_AGENT_STATUS", "working")
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--ci", "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if got.DryRun {
+		t.Fatal("dry_run = true, want false")
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionDispatched {
+		t.Fatalf("results = %+v, want dispatched", got.Results)
+	}
+	if got.Results[0].RenderedPrompt != "/ci" {
+		t.Fatalf("rendered_prompt = %q, want /ci", got.Results[0].RenderedPrompt)
+	}
+	body, err := os.ReadFile(sentinel) //nolint:gosec // test sentinel
+	if err != nil {
+		t.Fatalf("gh pr comment was not invoked: %v", err)
+	}
+	gotArgs := strings.TrimSpace(string(body))
+	if !strings.Contains(gotArgs, "comment 123") || !strings.Contains(gotArgs, "--repo acme/widgets") || !strings.Contains(gotArgs, "--body /ci") {
+		t.Fatalf("gh args = %q", gotArgs)
+	}
+	if _, err := os.Stat(promptSentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("herdr agent prompt was invoked")
+	}
+}
+
+func TestCommentDoesNotNeedHerdr(t *testing.T) {
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=prsync-test-missing-gh",
+		"herdr_bin=prsync-test-missing-herdr",
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, want 0, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("results = %+v, want would_dispatch without herdr", got.Results)
+	}
+}
+
+func TestCommentAllScopesToScanDoc(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+	doc := stdinEligibleDoc()
+	extra := doc.PRs[0]
+	extra.Repo = "acme/gizmos"
+	extra.Number = 50
+	extra.Tab = nil
+	doc.PRs = append(doc.PRs, extra)
+	raw := mustScanJSON(t, doc)
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--all", "--config", cfgPath, "--body", "hello"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	for _, item := range got.Results {
+		if item.Action != dispatch.ActionWouldDispatch || item.RenderedPrompt != "hello" {
+			t.Fatalf("item = %+v, want would_dispatch hello", item)
+		}
+	}
+	if got.Results[0].Repo != "acme/gizmos" || got.Results[1].Repo != "acme/widgets" {
+		t.Fatalf("results = %+v, want gizmos then widgets", got.Results)
+	}
+}
+
+func TestCommentInternalScanDryRun(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	sentinel := filepath.Join(t.TempDir(), "comment")
+	t.Setenv("GH_FAKE_COMMENT_SENTINEL", sentinel)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"gh_bin=" + ghBin,
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"repos=acme/widgets",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--config", cfgPath, "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if !got.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("results = %+v", got.Results)
+	}
+	if got.Results[0].Repo != "acme/widgets" || got.Results[0].Number != 123 {
+		t.Fatalf("result = %+v, want acme/widgets#123", got.Results[0])
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal("gh pr comment was invoked on dry-run")
+	}
+}
+
+func TestCommentNotFoundPR(t *testing.T) {
+	_, herdrBin := fixtureBins(t)
+	cfgPath := writeScanConfig(t, strings.Join([]string{
+		"herdr_bin=" + herdrBin,
+		"author=alice",
+		"state_file=" + filepath.Join(t.TempDir(), "state.json"),
+	}, "\n")+"\n")
+	raw := mustScanJSON(t, stdinEligibleDoc())
+	restore := swapStdin(t, string(raw))
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{
+		"comment", "--stdin", "--config", cfgPath, "--ci",
+		"--pr", "acme/widgets#123",
+		"--pr", "acme/missing#9",
+	}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	got := decodeDispatch(t, stdout.Bytes())
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	actions := map[string]string{}
+	for _, r := range got.Results {
+		actions[r.Repo] = r.Action
+	}
+	if actions["acme/missing"] != dispatch.ActionSkippedNotFound {
+		t.Fatalf("actions = %v", actions)
+	}
+	if actions["acme/widgets"] != dispatch.ActionWouldDispatch {
+		t.Fatalf("actions = %v", actions)
+	}
+}

--- a/devtools/prsync/internal/cli/cli_comment_test.go
+++ b/devtools/prsync/internal/cli/cli_comment_test.go
@@ -18,7 +18,7 @@ func TestCommentBadPR(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--pr", "not-a-pr", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--pr", "not-a-pr", "--body", "please retry"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
 	}
@@ -34,7 +34,7 @@ func TestCommentPRAndAll(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--pr", "acme/widgets#1", "--all", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--pr", "acme/widgets#1", "--all", "--body", "please retry"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
 	}
@@ -43,7 +43,7 @@ func TestCommentPRAndAll(t *testing.T) {
 	}
 }
 
-func TestCommentRequiresBodyOrCI(t *testing.T) {
+func TestCommentRequiresBody(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
@@ -51,25 +51,38 @@ func TestCommentRequiresBodyOrCI(t *testing.T) {
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "--body") && !strings.Contains(stderr.String(), "--ci") {
-		t.Fatalf("stderr = %q, want --body/--ci requirement", stderr.String())
+	if !strings.Contains(stderr.String(), "--body") {
+		t.Fatalf("stderr = %q, want --body requirement", stderr.String())
 	}
 }
 
-func TestCommentCIAndBodyConflict(t *testing.T) {
+func TestCommentEmptyBody(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--ci", "--body", "other"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--body", "  "}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "cannot combine --ci and --body") {
+	if !strings.Contains(stderr.String(), "--body must not be empty") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
 }
 
-func TestCommentStdinJSONDryRunCI(t *testing.T) {
+func TestCommentRejectsCIFlag(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"comment", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unknown flag") || !strings.Contains(stderr.String(), "--ci") {
+		t.Fatalf("stderr = %q, want unknown flag --ci", stderr.String())
+	}
+}
+
+func TestCommentStdinJSONDryRun(t *testing.T) {
 	ghBin, herdrBin := fixtureBins(t)
 	sentinel := filepath.Join(t.TempDir(), "comment")
 	t.Setenv("GH_FAKE_COMMENT_SENTINEL", sentinel)
@@ -86,7 +99,7 @@ func TestCommentStdinJSONDryRunCI(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--pr", "acme/widgets#123", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--pr", "acme/widgets#123", "--body", "please retry"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -100,8 +113,8 @@ func TestCommentStdinJSONDryRunCI(t *testing.T) {
 	if got.Results[0].Action != dispatch.ActionWouldDispatch {
 		t.Fatalf("action = %q, want would_dispatch", got.Results[0].Action)
 	}
-	if got.Results[0].RenderedPrompt != "/ci" {
-		t.Fatalf("rendered_prompt = %q, want /ci", got.Results[0].RenderedPrompt)
+	if got.Results[0].RenderedPrompt != "please retry" {
+		t.Fatalf("rendered_prompt = %q, want please retry", got.Results[0].RenderedPrompt)
 	}
 	if got.Results[0].PaneID != "" {
 		t.Fatalf("pane_id = %q, want empty", got.Results[0].PaneID)
@@ -158,7 +171,7 @@ func TestCommentGoPostsViaGH(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--ci", "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--body", "please retry", "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -169,15 +182,15 @@ func TestCommentGoPostsViaGH(t *testing.T) {
 	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionDispatched {
 		t.Fatalf("results = %+v, want dispatched", got.Results)
 	}
-	if got.Results[0].RenderedPrompt != "/ci" {
-		t.Fatalf("rendered_prompt = %q, want /ci", got.Results[0].RenderedPrompt)
+	if got.Results[0].RenderedPrompt != "please retry" {
+		t.Fatalf("rendered_prompt = %q, want please retry", got.Results[0].RenderedPrompt)
 	}
 	body, err := os.ReadFile(sentinel) //nolint:gosec // test sentinel
 	if err != nil {
 		t.Fatalf("gh pr comment was not invoked: %v", err)
 	}
 	gotArgs := strings.TrimSpace(string(body))
-	if !strings.Contains(gotArgs, "comment 123") || !strings.Contains(gotArgs, "--repo acme/widgets") || !strings.Contains(gotArgs, "--body /ci") {
+	if !strings.Contains(gotArgs, "comment 123") || !strings.Contains(gotArgs, "--repo acme/widgets") || !strings.Contains(gotArgs, "--body please retry") {
 		t.Fatalf("gh args = %q", gotArgs)
 	}
 	if _, err := os.Stat(promptSentinel); !errors.Is(err, fs.ErrNotExist) {
@@ -198,7 +211,7 @@ func TestCommentDoesNotNeedHerdr(t *testing.T) {
 	defer restore()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--stdin", "--config", cfgPath, "--body", "please retry"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, want 0, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -257,7 +270,7 @@ func TestCommentInternalScanDryRun(t *testing.T) {
 	}, "\n")+"\n")
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--config", cfgPath, "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--config", cfgPath, "--body", "please retry"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitOK {
 		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -289,7 +302,7 @@ func TestCommentNotFoundPR(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := Execute(context.Background(), []string{
-		"comment", "--stdin", "--config", cfgPath, "--ci",
+		"comment", "--stdin", "--config", cfgPath, "--body", "please retry",
 		"--pr", "acme/widgets#123",
 		"--pr", "acme/missing#9",
 	}, &stdout, &stderr, executor.NewBasicExecutor())

--- a/devtools/prsync/internal/cli/cli_comment_test.go
+++ b/devtools/prsync/internal/cli/cli_comment_test.go
@@ -69,16 +69,16 @@ func TestCommentEmptyBody(t *testing.T) {
 	}
 }
 
-func TestCommentRejectsCIFlag(t *testing.T) {
+func TestCommentUnknownFlag(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
-	code := Execute(context.Background(), []string{"comment", "--ci"}, &stdout, &stderr, executor.NewBasicExecutor())
+	code := Execute(context.Background(), []string{"comment", "--not-a-flag"}, &stdout, &stderr, executor.NewBasicExecutor())
 	if code != ExitUsage {
 		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "unknown flag") || !strings.Contains(stderr.String(), "--ci") {
-		t.Fatalf("stderr = %q, want unknown flag --ci", stderr.String())
+	if !strings.Contains(stderr.String(), "unknown flag") {
+		t.Fatalf("stderr = %q, want unknown flag", stderr.String())
 	}
 }
 

--- a/devtools/prsync/internal/cli/comment.go
+++ b/devtools/prsync/internal/cli/comment.go
@@ -24,14 +24,13 @@ func newCommentCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 		goLive     bool
 		readStdin  bool
 		body       string
-		ci         bool
 	)
 	cmd := &cobra.Command{
 		Use:   "comment",
 		Short: "Post a PR comment via gh (no herdr tab)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			resolved, err := resolveCommentBody(body, cmd.Flags().Changed("body"), ci)
+			resolved, err := resolveCommentBody(body, cmd.Flags().Changed("body"))
 			if err != nil {
 				return &ExitError{Code: ExitUsage, Err: err}
 			}
@@ -44,7 +43,6 @@ func newCommentCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	cmd.Flags().BoolVar(&goLive, "go", false, "post comments (default is dry-run)")
 	cmd.Flags().BoolVar(&readStdin, "stdin", false, "read a scan document from stdin (otherwise self-scan)")
 	cmd.Flags().StringVar(&body, "body", "", "comment body text")
-	cmd.Flags().BoolVar(&ci, "ci", false, "alias for --body /ci")
 	return cmd
 }
 
@@ -82,15 +80,9 @@ func runComment(ctx context.Context, stdout io.Writer, exec executor.Executor, c
 	return nil
 }
 
-func resolveCommentBody(body string, bodySet, ci bool) (string, error) {
-	if ci && bodySet {
-		return "", errors.New("cannot combine --ci and --body")
-	}
-	if !ci && !bodySet {
-		return "", errors.New("require --body or --ci")
-	}
-	if ci {
-		body = "/ci"
+func resolveCommentBody(body string, bodySet bool) (string, error) {
+	if !bodySet {
+		return "", errors.New("require --body")
 	}
 	if strings.TrimSpace(body) == "" {
 		return "", errors.New("--body must not be empty")

--- a/devtools/prsync/internal/cli/comment.go
+++ b/devtools/prsync/internal/cli/comment.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/comment"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	executor "github.com/jaeyeom/go-cmdexec"
+	"github.com/spf13/cobra"
+)
+
+func newCommentCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
+	var (
+		configPath string
+		prs        []string
+		all        bool
+		goLive     bool
+		readStdin  bool
+		body       string
+		ci         bool
+	)
+	cmd := &cobra.Command{
+		Use:   "comment",
+		Short: "Post a PR comment via gh (no herdr tab)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			resolved, err := resolveCommentBody(body, cmd.Flags().Changed("body"), ci)
+			if err != nil {
+				return &ExitError{Code: ExitUsage, Err: err}
+			}
+			return runComment(cmd.Context(), stdout, exec, configPath, prs, all, goLive, readStdin, resolved)
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
+	cmd.Flags().StringArrayVar(&prs, "pr", nil, "limit to owner/repo#N (repeatable)")
+	cmd.Flags().BoolVar(&all, "all", false, "comment on every PR in the scan document")
+	cmd.Flags().BoolVar(&goLive, "go", false, "post comments (default is dry-run)")
+	cmd.Flags().BoolVar(&readStdin, "stdin", false, "read a scan document from stdin (otherwise self-scan)")
+	cmd.Flags().StringVar(&body, "body", "", "comment body text")
+	cmd.Flags().BoolVar(&ci, "ci", false, "alias for --body /ci")
+	return cmd
+}
+
+func runComment(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, prs []string, all, goLive, readStdin bool, body string) error {
+	if all && len(prs) > 0 {
+		return &ExitError{Code: ExitUsage, Err: errors.New("cannot combine --pr and --all")}
+	}
+	for _, p := range prs {
+		if _, _, err := dispatch.ParsePR(p); err != nil {
+			return &ExitError{Code: ExitUsage, Err: err}
+		}
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if goLive {
+		cfg.DryRun = false
+	}
+	doc, err := loadScanDoc(ctx, cfg, exec, readStdin)
+	if err != nil {
+		return err
+	}
+	out, err := comment.Run(ctx, gh.NewClient(exec, cfg.GHBin), cfg, comment.Request{
+		Doc:  doc,
+		PRs:  prs,
+		Body: body,
+	}, time.Now())
+	if writeErr := writeDispatchJSON(stdout, out); writeErr != nil {
+		return writeErr
+	}
+	if err != nil {
+		return scanExit(err, cfg)
+	}
+	return nil
+}
+
+func resolveCommentBody(body string, bodySet, ci bool) (string, error) {
+	if ci && bodySet {
+		return "", errors.New("cannot combine --ci and --body")
+	}
+	if !ci && !bodySet {
+		return "", errors.New("require --body or --ci")
+	}
+	if ci {
+		body = "/ci"
+	}
+	if strings.TrimSpace(body) == "" {
+		return "", errors.New("--body must not be empty")
+	}
+	return body, nil
+}

--- a/devtools/prsync/internal/cli/root.go
+++ b/devtools/prsync/internal/cli/root.go
@@ -31,6 +31,7 @@ func newRoot(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	root.AddCommand(newScanCmd(stdout, exec))
 	root.AddCommand(newTabsCmd(stdout, exec))
 	root.AddCommand(newDispatchCmd(stdout, exec))
+	root.AddCommand(newCommentCmd(stdout, exec))
 	root.AddCommand(newGateCmd(stdout, exec))
 	return root
 }

--- a/devtools/prsync/internal/cli/testdata/fixtures/gh-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/gh-fake.sh
@@ -30,6 +30,16 @@ case "${cmd} ${sub}" in
     cat "${DIR}/gh-pr-list.json"
     exit 0
     ;;
+  "pr comment")
+    if [ -n "${GH_FAKE_COMMENT_SENTINEL-}" ]; then
+      printf '%s\n' "$*" > "$GH_FAKE_COMMENT_SENTINEL"
+    fi
+    if [ -n "${GH_FAKE_COMMENT_FAIL-}" ]; then
+      printf '%s\n' "gh-fake: comment failed" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
   "api graphql")
     cat "${DIR}/gh-review-threads.json"
     exit 0

--- a/devtools/prsync/internal/comment/BUILD.bazel
+++ b/devtools/prsync/internal/comment/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["comment.go"],
+    importpath = "github.com/jaeyeom/experimental/devtools/prsync/internal/comment",
+    visibility = ["//devtools/prsync:__subpackages__"],
+    deps = [
+        "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/dispatch:go_default_library",
+        "//devtools/prsync/internal/scan:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["comment_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//devtools/prsync/internal/config:go_default_library",
+        "//devtools/prsync/internal/dispatch:go_default_library",
+        "//devtools/prsync/internal/scan:go_default_library",
+    ],
+)

--- a/devtools/prsync/internal/comment/comment.go
+++ b/devtools/prsync/internal/comment/comment.go
@@ -1,0 +1,68 @@
+// Package comment posts deterministic PR comments via gh, without a herdr tab.
+package comment
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+// GH is the GitHub surface comment uses.
+type GH interface {
+	CommentPR(ctx context.Context, repo string, number int, body string) error
+}
+
+// Request is the candidate-set input to Run.
+type Request struct {
+	Doc  scan.Document
+	PRs  []string
+	Body string
+}
+
+// Run evaluates the candidate set and posts comments. Dry-run never calls
+// GitHub. Live send is a gh API call per eligible PR and does not wait on
+// the concurrency gate or require a herdr tab.
+func Run(ctx context.Context, g GH, cfg config.Config, req Request, now time.Time) (dispatch.Document, error) {
+	doc := dispatch.Document{
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		DryRun:      cfg.DryRun,
+		Results:     []dispatch.Item{},
+	}
+	cands, err := dispatch.Candidates(req.Doc, req.PRs)
+	if err != nil {
+		return doc, fmt.Errorf("comment candidates: %w", err)
+	}
+	for _, c := range cands {
+		if err := ctx.Err(); err != nil {
+			item := dispatch.Item{Repo: c.Repo, Number: c.Number, Action: dispatch.ActionFailed, Detail: err.Error()}
+			doc.Results = append(doc.Results, item)
+			return doc, fmt.Errorf("comment: %w", err)
+		}
+		item := dispatch.Item{Repo: c.Repo, Number: c.Number}
+		if c.PR == nil {
+			item.Action = dispatch.ActionSkippedNotFound
+			doc.Results = append(doc.Results, item)
+			continue
+		}
+		if cfg.DryRun {
+			item.Action = dispatch.ActionWouldDispatch
+			item.RenderedPrompt = req.Body
+			doc.Results = append(doc.Results, item)
+			continue
+		}
+		if err := g.CommentPR(ctx, c.Repo, c.Number, req.Body); err != nil {
+			item.Action = dispatch.ActionFailed
+			item.Detail = err.Error()
+			doc.Results = append(doc.Results, item)
+			return doc, fmt.Errorf("%w: %w", dispatch.ErrFailed, err)
+		}
+		item.Action = dispatch.ActionDispatched
+		item.RenderedPrompt = req.Body
+		doc.Results = append(doc.Results, item)
+	}
+	return doc, nil
+}

--- a/devtools/prsync/internal/comment/comment_test.go
+++ b/devtools/prsync/internal/comment/comment_test.go
@@ -1,0 +1,200 @@
+package comment
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/dispatch"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/scan"
+)
+
+var fixtureNow = time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+
+func TestRunDryRunWouldDispatch(t *testing.T) {
+	t.Parallel()
+
+	g := &fakeGH{}
+	got, err := Run(context.Background(), g, config.Defaults(), Request{
+		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, false)}},
+		Body: "/ci",
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if !got.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if got.GeneratedAt != "2026-01-01T09:00:00Z" {
+		t.Fatalf("generated_at = %q", got.GeneratedAt)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got.Results))
+	}
+	item := got.Results[0]
+	if item.Repo != "acme/widgets" || item.Number != 123 {
+		t.Fatalf("item = %+v", item)
+	}
+	if item.Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("action = %q, want would_dispatch", item.Action)
+	}
+	if item.RenderedPrompt != "/ci" {
+		t.Fatalf("rendered_prompt = %q, want /ci", item.RenderedPrompt)
+	}
+	if item.PaneID != "" {
+		t.Fatalf("pane_id = %q, want empty (not tab-bound)", item.PaneID)
+	}
+	if len(g.calls) != 0 {
+		t.Fatalf("CommentPR called on dry-run: %+v", g.calls)
+	}
+}
+
+func TestRunDryRunCommentsOffMachinePR(t *testing.T) {
+	t.Parallel()
+
+	got, err := Run(context.Background(), &fakeGH{}, config.Defaults(), Request{
+		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, true)}},
+		Body: "please /ci",
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != dispatch.ActionWouldDispatch {
+		t.Fatalf("results = %+v, want would_dispatch for no-tab PR", got.Results)
+	}
+}
+
+func TestRunSkippedNotFound(t *testing.T) {
+	t.Parallel()
+
+	got, err := Run(context.Background(), &fakeGH{}, config.Defaults(), Request{
+		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, false)}},
+		PRs:  []string{"acme/widgets#123", "acme/missing#9"},
+		Body: "/ci",
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2 (never drop)", len(got.Results))
+	}
+	byRepo := map[string]string{}
+	for _, item := range got.Results {
+		byRepo[item.Repo] = item.Action
+	}
+	if byRepo["acme/missing"] != dispatch.ActionSkippedNotFound {
+		t.Fatalf("actions = %v", byRepo)
+	}
+	if byRepo["acme/widgets"] != dispatch.ActionWouldDispatch {
+		t.Fatalf("actions = %v", byRepo)
+	}
+}
+
+func TestRunLivePostsComment(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.DryRun = false
+	g := &fakeGH{}
+	got, err := Run(context.Background(), g, cfg, Request{
+		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, true), pr("acme/gizmos", 50, false)}},
+		Body: "/ci",
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if got.DryRun {
+		t.Fatal("dry_run = true, want false")
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(got.Results))
+	}
+	if got.Results[0].Repo != "acme/gizmos" || got.Results[0].Action != dispatch.ActionDispatched {
+		t.Fatalf("first = %+v, want dispatched acme/gizmos#50 (sorted)", got.Results[0])
+	}
+	if got.Results[1].Repo != "acme/widgets" || got.Results[1].Action != dispatch.ActionDispatched {
+		t.Fatalf("second = %+v, want dispatched acme/widgets#123", got.Results[1])
+	}
+	if got.Results[0].RenderedPrompt != "/ci" || got.Results[1].RenderedPrompt != "/ci" {
+		t.Fatalf("missing comment body on results: %+v", got.Results)
+	}
+	want := []commentCall{
+		{repo: "acme/gizmos", number: 50, body: "/ci"},
+		{repo: "acme/widgets", number: 123, body: "/ci"},
+	}
+	if len(g.calls) != len(want) {
+		t.Fatalf("calls = %+v, want %+v", g.calls, want)
+	}
+	for i, call := range g.calls {
+		if call != want[i] {
+			t.Fatalf("call[%d] = %+v, want %+v", i, call, want[i])
+		}
+	}
+}
+
+func TestRunLiveFailureStopsBatch(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.DryRun = false
+	g := &fakeGH{err: errors.New("boom")}
+	got, err := Run(context.Background(), g, cfg, Request{
+		Doc:  scan.Document{PRs: []scan.PR{pr("acme/gizmos", 50, false), pr("acme/widgets", 123, false)}},
+		Body: "/ci",
+	}, fixtureNow)
+	if !errors.Is(err, dispatch.ErrFailed) {
+		t.Fatalf("error = %v, want ErrFailed", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (stop on failure)", len(got.Results))
+	}
+	if got.Results[0].Action != dispatch.ActionFailed || got.Results[0].Detail != "boom" {
+		t.Fatalf("result = %+v, want failed boom", got.Results[0])
+	}
+	if len(g.calls) != 1 {
+		t.Fatalf("calls = %+v, want 1", g.calls)
+	}
+}
+
+func TestRunInvalidPRFlag(t *testing.T) {
+	t.Parallel()
+
+	_, err := Run(context.Background(), &fakeGH{}, config.Defaults(), Request{
+		PRs:  []string{"not-a-pr"},
+		Body: "/ci",
+	}, fixtureNow)
+	if err == nil {
+		t.Fatal("error = nil, want invalid --pr")
+	}
+	if !strings.Contains(err.Error(), "invalid --pr") {
+		t.Fatalf("error = %v, want invalid --pr", err)
+	}
+}
+
+type commentCall struct {
+	repo   string
+	number int
+	body   string
+}
+
+type fakeGH struct {
+	calls []commentCall
+	err   error
+}
+
+func (f *fakeGH) CommentPR(_ context.Context, repo string, number int, body string) error {
+	f.calls = append(f.calls, commentCall{repo: repo, number: number, body: body})
+	return f.err
+}
+
+func pr(repo string, number int, noTab bool) scan.PR {
+	p := scan.PR{Repo: repo, Number: number}
+	if !noTab {
+		pane := "w2:pC"
+		p.Tab = &scan.Tab{TabID: "w2:tC", PaneID: &pane, AgentStatus: "idle"}
+	}
+	return p
+}

--- a/devtools/prsync/internal/comment/comment_test.go
+++ b/devtools/prsync/internal/comment/comment_test.go
@@ -20,7 +20,7 @@ func TestRunDryRunWouldDispatch(t *testing.T) {
 	g := &fakeGH{}
 	got, err := Run(context.Background(), g, config.Defaults(), Request{
 		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, false)}},
-		Body: "/ci",
+		Body: "please retry",
 	}, fixtureNow)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
@@ -41,8 +41,8 @@ func TestRunDryRunWouldDispatch(t *testing.T) {
 	if item.Action != dispatch.ActionWouldDispatch {
 		t.Fatalf("action = %q, want would_dispatch", item.Action)
 	}
-	if item.RenderedPrompt != "/ci" {
-		t.Fatalf("rendered_prompt = %q, want /ci", item.RenderedPrompt)
+	if item.RenderedPrompt != "please retry" {
+		t.Fatalf("rendered_prompt = %q, want please retry", item.RenderedPrompt)
 	}
 	if item.PaneID != "" {
 		t.Fatalf("pane_id = %q, want empty (not tab-bound)", item.PaneID)
@@ -57,7 +57,7 @@ func TestRunDryRunCommentsOffMachinePR(t *testing.T) {
 
 	got, err := Run(context.Background(), &fakeGH{}, config.Defaults(), Request{
 		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, true)}},
-		Body: "please /ci",
+		Body: "please retry",
 	}, fixtureNow)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
@@ -73,7 +73,7 @@ func TestRunSkippedNotFound(t *testing.T) {
 	got, err := Run(context.Background(), &fakeGH{}, config.Defaults(), Request{
 		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, false)}},
 		PRs:  []string{"acme/widgets#123", "acme/missing#9"},
-		Body: "/ci",
+		Body: "please retry",
 	}, fixtureNow)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
@@ -101,7 +101,7 @@ func TestRunLivePostsComment(t *testing.T) {
 	g := &fakeGH{}
 	got, err := Run(context.Background(), g, cfg, Request{
 		Doc:  scan.Document{PRs: []scan.PR{pr("acme/widgets", 123, true), pr("acme/gizmos", 50, false)}},
-		Body: "/ci",
+		Body: "please retry",
 	}, fixtureNow)
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
@@ -118,12 +118,12 @@ func TestRunLivePostsComment(t *testing.T) {
 	if got.Results[1].Repo != "acme/widgets" || got.Results[1].Action != dispatch.ActionDispatched {
 		t.Fatalf("second = %+v, want dispatched acme/widgets#123", got.Results[1])
 	}
-	if got.Results[0].RenderedPrompt != "/ci" || got.Results[1].RenderedPrompt != "/ci" {
+	if got.Results[0].RenderedPrompt != "please retry" || got.Results[1].RenderedPrompt != "please retry" {
 		t.Fatalf("missing comment body on results: %+v", got.Results)
 	}
 	want := []commentCall{
-		{repo: "acme/gizmos", number: 50, body: "/ci"},
-		{repo: "acme/widgets", number: 123, body: "/ci"},
+		{repo: "acme/gizmos", number: 50, body: "please retry"},
+		{repo: "acme/widgets", number: 123, body: "please retry"},
 	}
 	if len(g.calls) != len(want) {
 		t.Fatalf("calls = %+v, want %+v", g.calls, want)
@@ -143,7 +143,7 @@ func TestRunLiveFailureStopsBatch(t *testing.T) {
 	g := &fakeGH{err: errors.New("boom")}
 	got, err := Run(context.Background(), g, cfg, Request{
 		Doc:  scan.Document{PRs: []scan.PR{pr("acme/gizmos", 50, false), pr("acme/widgets", 123, false)}},
-		Body: "/ci",
+		Body: "please retry",
 	}, fixtureNow)
 	if !errors.Is(err, dispatch.ErrFailed) {
 		t.Fatalf("error = %v, want ErrFailed", err)
@@ -164,7 +164,7 @@ func TestRunInvalidPRFlag(t *testing.T) {
 
 	_, err := Run(context.Background(), &fakeGH{}, config.Defaults(), Request{
 		PRs:  []string{"not-a-pr"},
-		Body: "/ci",
+		Body: "please retry",
 	}, fixtureNow)
 	if err == nil {
 		t.Fatal("error = nil, want invalid --pr")

--- a/devtools/prsync/internal/gh/client.go
+++ b/devtools/prsync/internal/gh/client.go
@@ -130,6 +130,13 @@ func (c *Client) ListOpenPRs(ctx context.Context, repo, author string) ([]PRList
 	return prs, nil
 }
 
+// CommentPR runs `gh pr comment <number> --repo <repo> --body <body>`.
+func (c *Client) CommentPR(ctx context.Context, repo string, number int, body string) error {
+	_, err := c.requireOK(ctx, defaultCallTimeout,
+		"pr", "comment", strconv.Itoa(number), "--repo", repo, "--body", body)
+	return err
+}
+
 // ReviewThreads paginates GraphQL review threads. Hitting 50 pages is an error.
 func (c *Client) ReviewThreads(ctx context.Context, owner, repo string, number int) ([]Thread, error) {
 	var threads []Thread

--- a/devtools/prsync/internal/gh/client_test.go
+++ b/devtools/prsync/internal/gh/client_test.go
@@ -359,6 +359,40 @@ func TestReviewThreads(t *testing.T) {
 	})
 }
 
+func TestCommentPR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "pr", "comment", "123",
+			"--repo", "acme/widgets", "--body", "/ci").
+			WillSucceed("", 0).Build()
+		if err := NewClient(mock, testGHBin).CommentPR(context.Background(), "acme/widgets", 123, "/ci"); err != nil {
+			t.Fatalf("CommentPR() unexpected error: %v", err)
+		}
+		if err := mock.AssertExpectationsMet(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("nonzero exit", func(t *testing.T) {
+		t.Parallel()
+		mock := newGHMock()
+		mock.ExpectCommandWithArgs(testGHBin, "pr", "comment", "9",
+			"--repo", "acme/widgets", "--body", "hello").
+			WillFail("GraphQL: Could not resolve to a PullRequest", 1).Build()
+		err := NewClient(mock, testGHBin).CommentPR(context.Background(), "acme/widgets", 9, "hello")
+		if err == nil {
+			t.Fatal("CommentPR() error = nil, want failure")
+		}
+		var proc *ProcError
+		if !errors.As(err, &proc) {
+			t.Fatalf("CommentPR() error = %v, want ProcError", err)
+		}
+	})
+}
+
 func newGHMock() *executor.MockExecutor {
 	mock := executor.NewMockExecutor()
 	mock.SetAvailableCommand(testGHBin, true)

--- a/devtools/prsync/internal/gh/client_test.go
+++ b/devtools/prsync/internal/gh/client_test.go
@@ -366,9 +366,9 @@ func TestCommentPR(t *testing.T) {
 		t.Parallel()
 		mock := newGHMock()
 		mock.ExpectCommandWithArgs(testGHBin, "pr", "comment", "123",
-			"--repo", "acme/widgets", "--body", "/ci").
+			"--repo", "acme/widgets", "--body", "please retry").
 			WillSucceed("", 0).Build()
-		if err := NewClient(mock, testGHBin).CommentPR(context.Background(), "acme/widgets", 123, "/ci"); err != nil {
+		if err := NewClient(mock, testGHBin).CommentPR(context.Background(), "acme/widgets", 123, "please retry"); err != nil {
 			t.Fatalf("CommentPR() unexpected error: %v", err)
 		}
 		if err := mock.AssertExpectationsMet(); err != nil {


### PR DESCRIPTION
## Summary
- Add `prsync comment` to post a PR comment via `gh` with no herdr tab and no concurrency gate.
- Dry-run by default; `--go` posts. `--body TEXT` is required; the tool does not special-case `/ci`.
- `--all` / `--stdin` reuse scan scoping. JSON matches the dispatch result shape (`would_dispatch` / `dispatched` / `skipped_not_found`).

Resolves #253

## Test plan
- [x] `TestCommentPR` — `gh pr comment --repo --body`
- [x] Dry-run would_dispatch; live dispatched; skipped_not_found
- [x] Off-machine (no tab) and missing herdr still comment
- [x] `--body` / `--all` / `--stdin` CLI coverage; unknown flags are rejected
- [x] `make check` is green (306 tests pass, lint/semgrep clean)