### PR TITLE
fix(ansible): use a real 24-hour upgrade cache TTL

### DIFF
--- a/devtools/setup-dev/ansible/BUILD.bazel
+++ b/devtools/setup-dev/ansible/BUILD.bazel
@@ -41,7 +41,16 @@ org_lint_tests([
 sh_binary(
     name = "ensure",
     srcs = ["ensure.sh"],
-    data = ["community_general.sh"],
+    data = [
+        "cache_expired.sh",
+        "community_general.sh",
+    ],
+)
+
+sh_test(
+    name = "cache_expired_test",
+    srcs = ["cache_expired_test.sh"],
+    data = ["cache_expired.sh"],
 )
 
 sh_test(

--- a/devtools/setup-dev/ansible/README.org
+++ b/devtools/setup-dev/ansible/README.org
@@ -24,6 +24,12 @@ filenames.
   ./ensure.sh [rule]...
 #+end_src
 
+=ensure.sh= refreshes system package managers (=nala= on Debian/Ubuntu,
+=brew= on macOS, =pkg= on Termux) and a few toolchains (=rustup=, Termux
+=pip=, =ansible-galaxy=) at most once every 24 hours. Stamp files live in
+=$HOME/.cache/last_upgrade/=; delete one to force that refresh on the
+next run.
+
 ** Ansible version requirement
 
 Playbooks use =ansible.builtin.deb822_repository= (ansible-core >= 2.15).

--- a/devtools/setup-dev/ansible/cache_expired.sh
+++ b/devtools/setup-dev/ansible/cache_expired.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Portable cache freshness helper sourced by ensure.sh.
+#
+# Do not use `find FILE -mtime +1` for a 24-hour TTL. GNU find ignores the
+# fractional 24-hour period, so -mtime +1 means "at least two days old".
+# Compare epoch seconds instead so Linux (GNU), macOS (BSD), and Termux
+# share a real 24-hour window.
+
+# Print FILE's mtime as epoch seconds. GNU stat first, BSD stat fallback.
+_cache_file_mtime() {
+    _cfm_out=$(stat -c %Y "$1" 2>/dev/null) \
+        || _cfm_out=$(stat -f %m "$1" 2>/dev/null) \
+        || return 1
+    case "$_cfm_out" in
+        '' | *[!0-9]*) return 1 ;;
+    esac
+    printf '%s\n' "$_cfm_out"
+}
+
+# True if FILE is missing or at least MAX_AGE seconds old.
+# Usage: cache_expired FILE [MAX_AGE_SEC] [NOW_EPOCH]
+# MAX_AGE_SEC defaults to 86400 (24 hours). NOW_EPOCH is for tests.
+cache_expired() {
+    _ce_file="$1"
+    _ce_max_age="${2:-86400}"
+    _ce_now="${3:-}"
+    if [ ! -f "$_ce_file" ]; then
+        return 0
+    fi
+    if [ -z "$_ce_now" ]; then
+        _ce_now=$(date +%s) || return 0
+    fi
+    _ce_mtime=$(_cache_file_mtime "$_ce_file") || return 0
+    [ "$((_ce_now - _ce_mtime))" -ge "$_ce_max_age" ]
+}

--- a/devtools/setup-dev/ansible/cache_expired_test.sh
+++ b/devtools/setup-dev/ansible/cache_expired_test.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tests for cache_expired: a portable 24-hour (86400s) freshness check.
+#
+# GNU find -mtime +1 is NOT 24 hours: it ignores the fractional day, so a
+# file must be at least two days old to match. These tests lock in second-
+# based comparison so Linux, macOS, and Termux share a real 24-hour TTL.
+set -eu
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+sh -n "$SCRIPT_DIR/cache_expired.sh"
+sh -n "$SCRIPT_DIR/cache_expired_test.sh"
+# shellcheck disable=SC1091  # Sourced from the same directory as this script
+. "$SCRIPT_DIR/cache_expired.sh"
+
+_tmp=$(mktemp -d)
+trap 'rm -rf "$_tmp"' EXIT
+
+_f="$_tmp/cache"
+touch "$_f"
+_mtime=$(stat -c %Y "$_f" 2>/dev/null || stat -f %m "$_f")
+
+# Missing file is always expired (refresh).
+if ! cache_expired "$_tmp/missing"; then
+    fail "missing cache file must be expired"
+fi
+
+# Fresh file is valid for a 24-hour TTL.
+if cache_expired "$_f" 86400 "$_mtime"; then
+    fail "just-created cache must not be expired at mtime"
+fi
+if cache_expired "$_f" 86400 "$((_mtime + 23 * 3600))"; then
+    fail "23-hour-old cache must still be valid for a 24-hour TTL"
+fi
+
+# Exactly 24 hours and beyond is expired.
+if ! cache_expired "$_f" 86400 "$((_mtime + 86400))"; then
+    fail "exactly 24-hour-old cache must be expired"
+fi
+if ! cache_expired "$_f" 86400 "$((_mtime + 25 * 3600))"; then
+    fail "25-hour-old cache must be expired"
+fi
+
+# Regression: GNU find -mtime +1 treats 30 hours as still "today+1" (not
+# old enough). A real 24-hour TTL must refresh.
+if ! cache_expired "$_f" 86400 "$((_mtime + 30 * 3600))"; then
+    fail "30-hour-old cache must be expired (find -mtime +1 would skip this)"
+fi
+
+# Default TTL is 24 hours when max-age is omitted.
+if cache_expired "$_f" "" "$((_mtime + 23 * 3600))"; then
+    fail "default TTL must keep a 23-hour-old cache valid"
+fi
+if ! cache_expired "$_f" "" "$((_mtime + 86400))"; then
+    fail "default TTL must expire a 24-hour-old cache"
+fi
+
+# Custom TTL: 30-hour-old cache is still valid if the limit is 48 hours.
+if cache_expired "$_f" $((48 * 3600)) "$((_mtime + 30 * 3600))"; then
+    fail "30-hour-old cache must still be valid for a 48-hour TTL"
+fi
+
+# Live clock: a file touched just now is not expired for a 24-hour TTL.
+if cache_expired "$_f"; then
+    fail "just-created cache must not be expired against the live clock"
+fi
+
+echo "All cache_expired tests passed."

--- a/devtools/setup-dev/ansible/ensure.sh
+++ b/devtools/setup-dev/ansible/ensure.sh
@@ -46,6 +46,10 @@ PIP_CACHE="$CACHE_DIR/pip"
 RUSTUP_CACHE="$CACHE_DIR/rustup-update"
 ANSIBLE_GALAXY_CACHE="$CACHE_DIR/ansible-galaxy-collection"
 
+# Portable 24-hour cache TTL (see cache_expired.sh). Do not use find -mtime +1.
+# shellcheck disable=SC1091  # Sourced from the same directory as this script
+. "$(dirname "$0")/cache_expired.sh"
+
 # Detect OS
 OS="$(uname -s)"
 
@@ -240,7 +244,7 @@ if [ -n "$TERMUX_VERSION" ]; then
     # Upgrading pkg is necessary to avoid issues on Termux. Instead of handling
     # that in Ansible, we do it here.
     # Only upgrade if not done in the last 24 hours
-    if [ ! -f "$PKG_CACHE" ] || [ "$(find "$PKG_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+    if cache_expired "$PKG_CACHE"; then
         pkg upgrade -y
         pkg install -y rust python-pip python-cryptography
         touch "$PKG_CACHE"
@@ -469,7 +473,7 @@ STUBEOF
     fi
 
     # Install necessary packages for Ansible and also install ansible.
-    if [ ! -f "$PIP_CACHE" ] || [ "$(find "$PIP_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+    if cache_expired "$PIP_CACHE"; then
         pip install -U ansible
     fi
 elif [ "$OS" = "Darwin" ]; then
@@ -501,7 +505,7 @@ elif [ "$OS" = "Darwin" ]; then
 
     # Update Homebrew
     # Only update if not done in the last 24 hours
-    if [ ! -f "$BREW_CACHE" ] || [ "$(find "$BREW_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+    if cache_expired "$BREW_CACHE"; then
         echo "Updating Homebrew..."
         brew update && brew upgrade
         touch "$BREW_CACHE"
@@ -549,7 +553,7 @@ else
 
         # Upgrade packages with nala
         # Only upgrade if not done in the last 24 hours
-        if [ ! -f "$NALA_CACHE" ] || [ "$(find "$NALA_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+        if cache_expired "$NALA_CACHE"; then
             echo "Upgrading packages with nala..."
             sudo nala upgrade -y
             touch "$NALA_CACHE"
@@ -692,7 +696,7 @@ fi
 # Update rustup if installed (upgrades rust toolchain and all components)
 # Only update if not done in the last 24 hours
 if command -v rustup >/dev/null 2>&1; then
-    if [ ! -f "$RUSTUP_CACHE" ] || [ "$(find "$RUSTUP_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+    if cache_expired "$RUSTUP_CACHE"; then
         echo "Updating Rust toolchain via rustup..."
         rustup update
         touch "$RUSTUP_CACHE"
@@ -739,8 +743,7 @@ fi
 if community_general_needs_repair "$_cg_has_apt" "$_cg_termux" "$OS" \
     "$_cg_has_bundled" "$_cg_has_user_galaxy" "$_cg_upgraded" ||
     [ "$ANSIBLE_WAS_UPGRADED" = true ] ||
-    [ ! -f "$ANSIBLE_GALAXY_CACHE" ] ||
-    [ "$(find "$ANSIBLE_GALAXY_CACHE" -mtime +1 2>/dev/null | wc -l)" -gt 0 ]; then
+    cache_expired "$ANSIBLE_GALAXY_CACHE"; then
     _cg_plan=$(community_general_plan "$OS" "$_cg_termux" "$_cg_upgraded" \
         "$_cg_has_apt" "$_cg_has_bundled" "$_cg_core")
     case "$_cg_plan" in


### PR DESCRIPTION
## Summary
- `ensure.sh` intended a 24-hour TTL for nala/brew/pkg/rustup/pip/ansible-galaxy stamps, but `find FILE -mtime +1` is not 24 hours. GNU find ignores the fractional day, so the file must be at least two days old to match. That is why `./ensure.sh all` on Ubuntu skipped `sudo nala upgrade` after ~44 hours.
- Replace those checks with `cache_expired`, which compares epoch seconds using GNU `stat -c %Y` (Linux/Termux) or BSD `stat -f %m` (macOS) against `date +%s`.
- Missing stamp files still count as expired. Default TTL is 86400 seconds.
- Document the stamp directory in `README.org` (`$HOME/.cache/last_upgrade/`).

## Test plan
- [x] `sh cache_expired_test.sh` — covers missing/fresh/23h/24h/25h/30h (the GNU find regression) and live clock
- [x] `bazel test //devtools/setup-dev/ansible:cache_expired_test`
- [x] `make check` from repo root
- [x] Confirmed a 44-hour-old `nala-upgrade` stamp is expired under the new check