### PR TITLE
feat(gh-nudge): filter PRs by require and skip labels

### DIFF
--- a/devtools/gh-nudge/README.org
+++ b/devtools/gh-nudge/README.org
@@ -153,6 +153,15 @@ settings {
   reminder_threshold_hours = 24  // Hours between reminders for same PR/reviewer
   working_hours_only = true
   dm_by_default = true
+  // Skip nudging unless the PR has all of these labels. Empty means no requirement.
+  require_labels {
+    "ready-for-review"
+  }
+  // Skip nudging if the PR has any of these labels. Empty means no skip filter.
+  skip_labels {
+    "wip"
+    "do-not-nudge"
+  }
 }
 #+end_src
 
@@ -208,6 +217,11 @@ Create a configuration file at ~$HOME/.config/gh-nudge/config.yaml~:
     working_hours_only: true
     message_template: "Hey <@{slack_id}>, the PR '{title}' has been waiting for your review for {hours} hours. {url}"
     dm_by_default: true  # Send DMs to reviewers by default
+    require_labels:  # Skip unless the PR has all of these labels
+      - "ready-for-review"
+    skip_labels:  # Skip if the PR has any of these labels
+      - "wip"
+      - "do-not-nudge"
 #+end_src
 
 *Note*: YAML support may be deprecated in a future release. Consider migrating

--- a/devtools/gh-nudge/cmd/gh-nudge/main.go
+++ b/devtools/gh-nudge/cmd/gh-nudge/main.go
@@ -165,6 +165,16 @@ func processPullRequest(
 ) {
 	slog.Debug("Processing pull request", "title", pr.Title, "url", pr.URL)
 
+	if !pr.AllowsNudge(cfg.Settings.RequireLabels, cfg.Settings.SkipLabels) {
+		slog.Info("Skipping pull request due to label filter",
+			"pr", pr.Title,
+			"url", pr.URL,
+			"labels", pr.Labels,
+			"require_labels", cfg.Settings.RequireLabels,
+			"skip_labels", cfg.Settings.SkipLabels)
+		return
+	}
+
 	// Process each reviewer
 	for _, reviewer := range pr.ReviewRequests {
 		err := processReviewer(pr, reviewer, slackClient, notificationTracker, cfg)

--- a/devtools/gh-nudge/internal/config/config.go
+++ b/devtools/gh-nudge/internal/config/config.go
@@ -46,10 +46,12 @@ type ChannelRoutingConfig struct {
 
 // SettingsConfig contains general application settings.
 type SettingsConfig struct {
-	ReminderThresholdHours int    `yaml:"reminder_threshold_hours"`
-	WorkingHoursOnly       bool   `yaml:"working_hours_only"`
-	MessageTemplate        string `yaml:"message_template"`
-	DMByDefault            bool   `yaml:"dm_by_default"`
+	ReminderThresholdHours int      `yaml:"reminder_threshold_hours"`
+	WorkingHoursOnly       bool     `yaml:"working_hours_only"`
+	MessageTemplate        string   `yaml:"message_template"`
+	DMByDefault            bool     `yaml:"dm_by_default"`
+	RequireLabels          []string `yaml:"require_labels"`
+	SkipLabels             []string `yaml:"skip_labels"`
 }
 
 // LoadConfig loads the configuration from the specified file path.
@@ -125,6 +127,8 @@ func convertPklConfig(pklCfg *pklconfig.Config) *Config {
 			WorkingHoursOnly:       pklCfg.Settings.WorkingHoursOnly,
 			MessageTemplate:        pklCfg.Settings.MessageTemplate,
 			DMByDefault:            pklCfg.Settings.DmByDefault,
+			RequireLabels:          pklCfg.Settings.RequireLabels,
+			SkipLabels:             pklCfg.Settings.SkipLabels,
 		},
 	}
 

--- a/devtools/gh-nudge/internal/config/config_test.go
+++ b/devtools/gh-nudge/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	pklconfig "github.com/jaeyeom/experimental/devtools/gh-nudge/internal/config/pkl"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -404,4 +406,95 @@ slack:
 			t.Errorf("Expected second channel '#js-reviews', got %q", cfg.Slack.ChannelRouting[1].Channel)
 		}
 	})
+
+	t.Run("should load label filter settings", func(t *testing.T) {
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "config.yaml")
+
+		configContent := `
+github:
+  owner: "test-org"
+  repos:
+    - "repo1"
+
+slack:
+  token: "xoxb-test-token"
+
+settings:
+  require_labels:
+    - "ready-for-review"
+  skip_labels:
+    - "wip"
+    - "do-not-nudge"
+`
+		err := os.WriteFile(configPath, []byte(configContent), 0o600)
+		if err != nil {
+			t.Fatalf("Failed to write test config file: %v", err)
+		}
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if len(cfg.Settings.RequireLabels) != 1 || cfg.Settings.RequireLabels[0] != "ready-for-review" {
+			t.Errorf("Expected require_labels [ready-for-review], got %v", cfg.Settings.RequireLabels)
+		}
+		if len(cfg.Settings.SkipLabels) != 2 {
+			t.Fatalf("Expected 2 skip_labels, got %d", len(cfg.Settings.SkipLabels))
+		}
+		if cfg.Settings.SkipLabels[0] != "wip" || cfg.Settings.SkipLabels[1] != "do-not-nudge" {
+			t.Errorf("Expected skip_labels [wip do-not-nudge], got %v", cfg.Settings.SkipLabels)
+		}
+	})
+
+	t.Run("should default label filters to empty", func(t *testing.T) {
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, "config.yaml")
+
+		configContent := `
+github:
+  owner: "test-org"
+  repos:
+    - "repo1"
+
+slack:
+  token: "xoxb-test-token"
+`
+		err := os.WriteFile(configPath, []byte(configContent), 0o600)
+		if err != nil {
+			t.Fatalf("Failed to write test config file: %v", err)
+		}
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		if len(cfg.Settings.RequireLabels) != 0 {
+			t.Errorf("Expected empty require_labels, got %v", cfg.Settings.RequireLabels)
+		}
+		if len(cfg.Settings.SkipLabels) != 0 {
+			t.Errorf("Expected empty skip_labels, got %v", cfg.Settings.SkipLabels)
+		}
+	})
+}
+
+func TestConvertPklConfigLabelFilters(t *testing.T) {
+	pklCfg := &pklconfig.Config{
+		Settings: pklconfig.SettingsConfig{
+			ReminderThresholdHours: 24,
+			RequireLabels:          []string{"ready-for-review"},
+			SkipLabels:             []string{"wip", "do-not-nudge"},
+		},
+	}
+
+	cfg := convertPklConfig(pklCfg)
+
+	if len(cfg.Settings.RequireLabels) != 1 || cfg.Settings.RequireLabels[0] != "ready-for-review" {
+		t.Errorf("Expected require_labels [ready-for-review], got %v", cfg.Settings.RequireLabels)
+	}
+	if len(cfg.Settings.SkipLabels) != 2 || cfg.Settings.SkipLabels[0] != "wip" || cfg.Settings.SkipLabels[1] != "do-not-nudge" {
+		t.Errorf("Expected skip_labels [wip do-not-nudge], got %v", cfg.Settings.SkipLabels)
+	}
 }

--- a/devtools/gh-nudge/internal/config/pkl/SettingsConfig.pkl.go
+++ b/devtools/gh-nudge/internal/config/pkl/SettingsConfig.pkl.go
@@ -14,4 +14,10 @@ type SettingsConfig struct {
 
 	// Send DMs to reviewers by default instead of channel messages
 	DmByDefault bool `pkl:"dm_by_default"`
+
+	// Skip nudging unless the PR has all of these labels. Empty means no requirement.
+	RequireLabels []string `pkl:"require_labels"`
+
+	// Skip nudging if the PR has any of these labels. Empty means no skip filter.
+	SkipLabels []string `pkl:"skip_labels"`
 }

--- a/devtools/gh-nudge/internal/github/github.go
+++ b/devtools/gh-nudge/internal/github/github.go
@@ -71,7 +71,7 @@ func (c *Client) GetPendingPullRequests() ([]models.PullRequest, error) {
 	output, err := c.executor.Execute("gh", "pr", "list",
 		"--author", "@me",
 		"--limit", fmt.Sprintf("%d", pullRequestListLimit),
-		"--json", "url,title,reviewRequests,files,mergeable,headRefName,statusCheckRollup,isDraft")
+		"--json", "url,title,reviewRequests,files,mergeable,headRefName,statusCheckRollup,isDraft,labels")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute gh command: %w", err)
 	}

--- a/devtools/gh-nudge/internal/github/github_test.go
+++ b/devtools/gh-nudge/internal/github/github_test.go
@@ -332,6 +332,91 @@ func TestGetPendingPullRequests(t *testing.T) {
 		}
 	})
 
+	t.Run("parses PR labels", func(t *testing.T) {
+		sampleJSON := `[
+			{
+				"title": "Labeled PR",
+				"url": "https://github.com/org/repo/pull/1",
+				"files": [],
+				"reviewRequests": [],
+				"labels": [
+					{"name": "ready-for-review"},
+					{"name": "backend"}
+				]
+			}
+		]`
+
+		client := NewClientWithExecutor(&mockExecutor{output: sampleJSON})
+		prs, err := client.GetPendingPullRequests()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(prs) != 1 {
+			t.Fatalf("expected 1 PR, got %d", len(prs))
+		}
+		if len(prs[0].Labels) != 2 {
+			t.Fatalf("expected 2 labels, got %d", len(prs[0].Labels))
+		}
+		if prs[0].Labels[0].Name != "ready-for-review" {
+			t.Errorf("expected first label 'ready-for-review', got %q", prs[0].Labels[0].Name)
+		}
+		if prs[0].Labels[1].Name != "backend" {
+			t.Errorf("expected second label 'backend', got %q", prs[0].Labels[1].Name)
+		}
+	})
+
+	t.Run("treats PRs without labels field as unlabeled", func(t *testing.T) {
+		sampleJSON := `[
+			{
+				"title": "Unlabeled PR",
+				"url": "https://github.com/org/repo/pull/1",
+				"files": [],
+				"reviewRequests": []
+			}
+		]`
+
+		client := NewClientWithExecutor(&mockExecutor{output: sampleJSON})
+		prs, err := client.GetPendingPullRequests()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(prs) != 1 {
+			t.Fatalf("expected 1 PR, got %d", len(prs))
+		}
+		if len(prs[0].Labels) != 0 {
+			t.Errorf("expected no labels, got %d", len(prs[0].Labels))
+		}
+	})
+
+	t.Run("requests labels in gh pr list JSON fields", func(t *testing.T) {
+		executor := &mockExecutor{captureArgs: true, output: "[]"}
+		client := NewClientWithExecutor(executor)
+
+		if _, err := client.GetPendingPullRequests(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !executor.wasCalled {
+			t.Fatal("expected executor to be called")
+		}
+
+		jsonFields := ""
+		for i, arg := range executor.lastArgs {
+			if arg == "--json" && i+1 < len(executor.lastArgs) {
+				jsonFields = executor.lastArgs[i+1]
+				break
+			}
+		}
+		if jsonFields == "" {
+			t.Fatal("expected --json argument")
+		}
+		if !strings.Contains(jsonFields, "labels") {
+			t.Errorf("expected --json fields to include labels, got %q", jsonFields)
+		}
+	})
+
 	t.Run("parses PR with multiple files", func(t *testing.T) {
 		sampleJSON := `[
 			{

--- a/devtools/gh-nudge/internal/models/pr.go
+++ b/devtools/gh-nudge/internal/models/pr.go
@@ -19,6 +19,12 @@ type PullRequest struct {
 	HeadRefName       string          `json:"headRefName,omitempty"`
 	StatusCheckRollup []StatusCheck   `json:"statusCheckRollup,omitempty"`
 	IsDraft           bool            `json:"isDraft,omitempty"`
+	Labels            []Label         `json:"labels,omitempty"`
+}
+
+// Label represents a GitHub label attached to a pull request.
+type Label struct {
+	Name string `json:"name"`
 }
 
 // StatusCheck represents a single CI check or status from GitHub's statusCheckRollup.
@@ -73,6 +79,33 @@ func (pr *PullRequest) PendingChecks() []StatusCheck {
 		}
 	}
 	return pending
+}
+
+// HasLabel reports whether the pull request has a label with the given name.
+func (pr *PullRequest) HasLabel(name string) bool {
+	for _, label := range pr.Labels {
+		if label.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// AllowsNudge reports whether a nudge should be sent for this pull request
+// given the configured label filters. Empty slices mean no constraint.
+// requireLabels must all be present; skipLabels must all be absent.
+func (pr *PullRequest) AllowsNudge(requireLabels, skipLabels []string) bool {
+	for _, required := range requireLabels {
+		if !pr.HasLabel(required) {
+			return false
+		}
+	}
+	for _, skip := range skipLabels {
+		if pr.HasLabel(skip) {
+			return false
+		}
+	}
+	return true
 }
 
 // File represents a file changed in a pull request.

--- a/devtools/gh-nudge/internal/models/pr_test.go
+++ b/devtools/gh-nudge/internal/models/pr_test.go
@@ -190,3 +190,116 @@ func TestPendingChecks_Empty(t *testing.T) {
 		t.Errorf("expected 0 pending checks, got %d", len(pending))
 	}
 }
+
+func prWithLabels(names ...string) PullRequest {
+	pr := PullRequest{}
+	for _, name := range names {
+		pr.Labels = append(pr.Labels, Label{Name: name})
+	}
+	return pr
+}
+
+func TestPullRequestAllowsNudge(t *testing.T) {
+	tests := []struct {
+		name            string
+		pr              PullRequest
+		requireLabels   []string
+		skipLabels      []string
+		wantAllowsNudge bool
+	}{
+		{
+			name:            "empty filters allow unlabeled PR",
+			pr:              prWithLabels(),
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "empty filters allow labeled PR",
+			pr:              prWithLabels("ready-for-review", "backend"),
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "require labels skip when any required label is missing",
+			pr:              prWithLabels("backend"),
+			requireLabels:   []string{"ready-for-review"},
+			wantAllowsNudge: false,
+		},
+		{
+			name:            "require labels skip when unlabeled",
+			pr:              prWithLabels(),
+			requireLabels:   []string{"ready-for-review"},
+			wantAllowsNudge: false,
+		},
+		{
+			name:            "require labels allow when all required labels are present",
+			pr:              prWithLabels("ready-for-review", "backend"),
+			requireLabels:   []string{"ready-for-review"},
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "require labels skip unless every required label is present",
+			pr:              prWithLabels("ready-for-review"),
+			requireLabels:   []string{"ready-for-review", "needs-review"},
+			wantAllowsNudge: false,
+		},
+		{
+			name:            "require labels allow when every required label is present",
+			pr:              prWithLabels("ready-for-review", "needs-review"),
+			requireLabels:   []string{"ready-for-review", "needs-review"},
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "skip labels skip when any skip label is present",
+			pr:              prWithLabels("wip"),
+			skipLabels:      []string{"wip", "do-not-nudge"},
+			wantAllowsNudge: false,
+		},
+		{
+			name:            "skip labels allow when none of the skip labels are present",
+			pr:              prWithLabels("ready-for-review"),
+			skipLabels:      []string{"wip", "do-not-nudge"},
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "skip labels allow unlabeled PR",
+			pr:              prWithLabels(),
+			skipLabels:      []string{"wip"},
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "label names match exactly including case",
+			pr:              prWithLabels("WIP"),
+			skipLabels:      []string{"wip"},
+			wantAllowsNudge: true,
+		},
+		{
+			name:            "both filters skip when a skip label is present even if required labels match",
+			pr:              prWithLabels("ready-for-review", "wip"),
+			requireLabels:   []string{"ready-for-review"},
+			skipLabels:      []string{"wip"},
+			wantAllowsNudge: false,
+		},
+		{
+			name:            "both filters skip when a required label is missing",
+			pr:              prWithLabels("backend"),
+			requireLabels:   []string{"ready-for-review"},
+			skipLabels:      []string{"wip"},
+			wantAllowsNudge: false,
+		},
+		{
+			name:            "both filters allow when required labels are present and skip labels are not",
+			pr:              prWithLabels("ready-for-review", "backend"),
+			requireLabels:   []string{"ready-for-review"},
+			skipLabels:      []string{"wip"},
+			wantAllowsNudge: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.pr.AllowsNudge(tc.requireLabels, tc.skipLabels)
+			if got != tc.wantAllowsNudge {
+				t.Errorf("AllowsNudge() = %v, want %v", got, tc.wantAllowsNudge)
+			}
+		})
+	}
+}

--- a/devtools/gh-nudge/nudge.org
+++ b/devtools/gh-nudge/nudge.org
@@ -24,9 +24,9 @@ development process and reduces delays in merging important changes.
 - Tracks notification history to prevent excessive reminders
 - Persists notification history between runs to respect reminder thresholds
 
-** TODO Implementation [4/7]
+** TODO Implementation [5/7]
 - [X] Set up GitHub CLI integration
-- [ ] Implement PR filtering logic
+- [X] Implement PR filtering logic
 - [X] Create GitHub-to-Slack username mapping
 - [X] Implement Slack DM integration
 - [X] Implement notification threshold with persistence

--- a/devtools/gh-nudge/pkl/Config.pkl
+++ b/devtools/gh-nudge/pkl/Config.pkl
@@ -43,6 +43,10 @@ class SettingsConfig {
   message_template: String = "Hey <@{slack_id}>, the PR '{title}' has been waiting for your review for {hours} hours."
   /// Send DMs to reviewers by default instead of channel messages
   dm_by_default: Boolean = false
+  /// Skip nudging unless the PR has all of these labels. Empty means no requirement.
+  require_labels: Listing<String> = new {}
+  /// Skip nudging if the PR has any of these labels. Empty means no skip filter.
+  skip_labels: Listing<String> = new {}
 }
 
 /// Root configuration

--- a/devtools/gh-nudge/pkl/example.config.pkl
+++ b/devtools/gh-nudge/pkl/example.config.pkl
@@ -39,4 +39,13 @@ settings {
   reminder_threshold_hours = 24
   working_hours_only = true
   dm_by_default = true
+  // Skip nudging unless the PR has all of these labels.
+  require_labels {
+    "ready-for-review"
+  }
+  // Skip nudging if the PR has any of these labels.
+  skip_labels {
+    "wip"
+    "do-not-nudge"
+  }
 }


### PR DESCRIPTION
## Summary
- `gh-nudge` can now skip reminders based on PR labels from the config file.
- `settings.require_labels`: skip unless the PR has **all** of these labels.
- `settings.skip_labels`: skip if the PR has **any** of these labels.
- Empty lists (the default) leave current behavior unchanged. Label names match exactly, including case.

This lives in `settings` so it applies only to nudging, not `gh-merge`.

## Changes
- Fetch `labels` from `gh pr list --json` and store them on `PullRequest`.
- `AllowsNudge(require, skip)` decides whether a PR should be nudged.
- Pkl and YAML config both accept the new fields; docs and the example config are updated.

## Test plan
- [x] `TestPullRequestAllowsNudge` — require, skip, both, empty filters, case-sensitive names
- [x] `GetPendingPullRequests` parses labels and requests them in `--json`
- [x] YAML load + Pkl conversion of `require_labels` / `skip_labels`
- [x] `make check` from repo root (307 tests pass, lint/semgrep clean)