### PR TITLE
docs(magit): add README and list the CLI in the parent index

### DIFF
--- a/devtools/README.org
+++ b/devtools/README.org
@@ -186,6 +186,35 @@ queries Anthropic's OAuth usage API. No claude-hud plugin install required.
 
 [[file:claude-usage/README.org][→ Full Documentation]]
 
+*** magit                                                            :active:
+
+Shell wrapper that opens ~magit-status~ in a running Emacs via
+~emacsclient~. Reuses an existing Magit buffer/perspective for the
+repository when one exists; otherwise opens Magit (perspective ~1~
+when persp-mode is available). Does not start Emacs.
+
+*Key Features:*
+- Open Magit for ~$PWD~ or an explicit directory from any terminal
+- ~-c~ new graphical frame; ~-t~ terminal frame in the current tty
+- Perspective-aware reuse of an existing Magit session
+- Canonical-path matching so repos that share a leaf name do not collide
+
+*Installation:*
+#+BEGIN_SRC bash
+  cd devtools/setup-dev/ansible
+  ./ensure.sh magit
+#+END_SRC
+
+*Usage:*
+#+BEGIN_SRC bash
+  magit                 # magit-status for $PWD
+  magit -c              # new graphical frame
+  magit -t              # terminal frame in this tty
+  magit /path/to/repo   # magit-status for that directory
+#+END_SRC
+
+[[file:magit/README.org][→ Full Documentation]]
+
 ** Configuration & Setup
 :PROPERTIES:
 :CUSTOM_ID: configuration
@@ -253,7 +282,7 @@ repo-sync sync myproject
 
 *** Optional (tool-specific)
 - *Bazel* - For tools with Bazel build configuration
-- *Emacs* - For org-lint and other Emacs-related tools
+- *Emacs* - For org-lint, the magit CLI, and other Emacs-related tools
 - *GitHub CLI (gh)* - For gh-nudge utilities
 - *Ansible* - For setup-dev automation
 - *rsync* - For repo-sync file synchronization

--- a/devtools/magit/BUILD.bazel
+++ b/devtools/magit/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//tools/org-lint:defs.bzl", "org_lint_tests")
+
+org_lint_tests(["README.org"])

--- a/devtools/magit/README.org
+++ b/devtools/magit/README.org
@@ -1,0 +1,123 @@
+#+TITLE: magit CLI
+#+DATE: 2026-08-27
+
+* Overview
+
+~magit~ opens ~magit-status~ in an already-running Emacs via ~emacsclient~.
+It is a small shell wrapper for terminal-first Git work: stay in the repo
+directory and jump to Magit without hunting for the right Emacs frame or
+perspective.
+
+The command does *not* start Emacs. If no Emacs server is running, it
+prints an error and exits.
+
+Related issues: [[https://github.com/jaeyeom/experimental/issues/150][#150]],
+[[https://github.com/jaeyeom/experimental/issues/156][#156]].
+
+* Prerequisites
+
+- *Emacs* running as a server so ~emacsclient~ can connect. Start Emacs
+  first (Spacemacs / emacs daemon / ~(server-start)~).
+- *Magit* loaded in that Emacs.
+- *~emacsclient~* on ~PATH~ (comes with Emacs).
+- Optional: *persp-mode*. When available, the wrapper reuses the
+  perspective that already shows Magit for this repository, or switches
+  to perspective ~1~ for a new session. Without persp-mode it still
+  opens ~magit-status~.
+
+* Installation
+
+** Ansible (recommended with setup-dev)
+
+The ~devtools/setup-dev/ansible/magit.yml~ playbook (imported by ~all.yml~)
+symlinks this script to ~$HOME/.local/bin/magit~. It also pulls in Emacs
+setup.
+
+The symlink source is hard-coded to the clone path used by
+~setup-dev~:
+
+#+BEGIN_EXAMPLE
+$HOME/go/src/github.com/jaeyeom/experimental/devtools/magit/magit
+#+END_EXAMPLE
+
+#+BEGIN_SRC bash
+cd ~/go/src/github.com/jaeyeom/experimental/devtools/setup-dev/ansible
+./ensure.sh magit
+# or, as part of the full environment:
+./ensure.sh all
+#+END_SRC
+
+Put ~$HOME/.local/bin~ on ~PATH~ (the user-bin playbook does this in
+the shell profile).
+
+** Manual symlink
+
+From a clone of this repository:
+
+#+BEGIN_SRC bash
+mkdir -p ~/.local/bin
+ln -sf "$(pwd)/devtools/magit/magit" ~/.local/bin/magit
+chmod +x devtools/magit/magit
+#+END_SRC
+
+Or run the script by path without installing it:
+
+#+BEGIN_SRC bash
+./devtools/magit/magit
+#+END_SRC
+
+* Usage
+
+#+BEGIN_SRC bash
+magit                 # magit-status for $PWD in the current Emacs frame
+magit -c              # same, in a new graphical frame
+magit -t              # same, in a terminal frame in this tty
+magit /path/to/repo   # magit-status for that directory
+magit -c ~/src/foo    # new graphical frame for ~/src/foo
+#+END_SRC
+
+** Options
+
+| Option      | Meaning |
+|-------------+---------|
+| ~-c~        | Create a new graphical Emacs frame (~emacsclient -c~) |
+| ~-t~        | Open a text-only frame in the current terminal (~emacsclient -t~) |
+| ~directory~ | Repository directory (default: current working directory) |
+
+~-c~ and ~-t~ should not be combined. If both are given, the last one
+wins.
+
+Unknown flags print usage to stderr and exit 1.
+
+* Behavior
+
+1. Resolve the target directory to an absolute path. A missing or
+   unreadable directory fails before Emacs is contacted.
+2. Probe the Emacs server with ~emacsclient -e '(+ 1 1)'~. If that
+   fails: ~Error: No Emacs server running. Start Emacs first.~ (exit 1).
+3. Escape ~\~ and ~"~ in the path so it is safe inside the Elisp string
+   passed to ~emacsclient --eval~.
+4. In Emacs, find an existing ~magit-status-mode~ buffer whose
+   canonical ~default-directory~ matches the target (symlink-aware).
+   Matching is by full path, not the directory basename, so two repos
+   named ~service~ do not collide.
+5. If that buffer lives in a persp-mode perspective, switch to it.
+   Otherwise, if ~persp-switch-by-number~ is bound, switch to
+   perspective ~1~.
+6. Run ~(magit-status dir)~ and raise the selected frame with
+   ~select-frame-set-input-focus~.
+
+* Terminal notes
+
+~-t~ must keep stdout attached to the tty; the wrapper does not
+redirect it in that mode.
+
+If ~TERM~ is ~xterm-ghostty~, the wrapper sets ~TERM=xterm-256color~
+for the ~emacsclient -t~ call. Ghostty's terminfo is not always
+installed where Emacs can see it.
+
+* Related
+
+- Script: ~devtools/magit/magit~
+- Ansible install: ~devtools/setup-dev/ansible/magit.yml~
+- Emacs / Spacemacs setup: ~spacemacs/README.org~


### PR DESCRIPTION
## Summary
- Add `devtools/magit/README.org` for the `magit` emacsclient wrapper: prerequisites, Ansible and manual install, flags (`-c` / `-t` / directory), perspective reuse, and canonical-path matching.
- List the tool in `devtools/README.org` under Development Utilities and note Emacs as a prerequisite for this CLI.
- Add `devtools/magit/BUILD.bazel` with `org_lint_tests` so `make check` covers the new README.

The wrapper itself is unchanged.

## Test plan
- [x] `org-lint` on `devtools/magit/README.org` and `devtools/README.org`
- [x] `bazel test //devtools/magit:README_org_lint_test`
- [x] `./tools/org-lint/check-org-lint-tests.sh`
- [x] `make check` from repo root (308 tests pass, lint/semgrep clean)