### PR TITLE
fix(devcheck): include hidden configs and fix path matching

### DIFF
--- a/devtools/devcheck/internal/detector/detector.go
+++ b/devtools/devcheck/internal/detector/detector.go
@@ -3,6 +3,7 @@ package detector
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -108,44 +109,8 @@ func (d *ProjectDetector) performInitialScan(absPath string) (*ScanResult, error
 }
 
 func (d *ProjectDetector) detectGitRepository(absPath string) bool {
-	gitScanOptions := d.createGitScanOptions()
-	gitScanner := NewScanner(gitScanOptions)
-	gitScanResult, _ := gitScanner.Scan(absPath)
-
-	if gitScanResult == nil {
-		return false
-	}
-
-	return d.checkForGitIndicators(gitScanResult)
-}
-
-func (d *ProjectDetector) createGitScanOptions() ScanOptions {
-	gitScanOptions := DefaultScanOptions()
-	gitScanOptions.IncludeHidden = true
-	gitScanOptions.MaxDepth = 2
-
-	// Remove .git from ignore patterns
-	newIgnorePatterns := make([]string, 0, len(gitScanOptions.IgnorePatterns))
-	for _, pattern := range gitScanOptions.IgnorePatterns {
-		if pattern != ".git" {
-			newIgnorePatterns = append(newIgnorePatterns, pattern)
-		}
-	}
-	gitScanOptions.IgnorePatterns = newIgnorePatterns
-
-	return gitScanOptions
-}
-
-func (d *ProjectDetector) checkForGitIndicators(gitScanResult *ScanResult) bool {
-	// Check for .git directory
-	for _, dir := range gitScanResult.Directories {
-		if dir == ".git" {
-			return true
-		}
-	}
-
-	// Check for .git files (worktrees)
-	return gitScanResult.HasPattern(".git/*") || gitScanResult.HasFile(".git")
+	_, err := os.Stat(filepath.Join(absPath, ".git"))
+	return err == nil
 }
 
 func (d *ProjectDetector) aggregateTools(languages []config.Language, buildSystem config.BuildSystem, absPath string) map[config.ToolType][]string {

--- a/devtools/devcheck/internal/detector/detector_test.go
+++ b/devtools/devcheck/internal/detector/detector_test.go
@@ -196,6 +196,58 @@ func TestProjectDetector_SupportedBuildSystems(t *testing.T) {
 	}
 }
 
+func TestProjectDetector_DetectRecordsGolangciConfig(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "golangci_config_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for _, file := range []string{"go.mod", "main.go", ".golangci.yml"} {
+		if err := os.WriteFile(filepath.Join(tempDir, file), []byte("test content"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := NewProjectDetector().Detect(tempDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+
+	got, ok := result.ConfigFiles["golangci-lint"]
+	if !ok {
+		t.Fatalf("Detect() ConfigFiles = %v, want golangci-lint config recorded", result.ConfigFiles)
+	}
+	if got != ".golangci.yml" {
+		t.Errorf("Detect() ConfigFiles[golangci-lint] = %q, want %q", got, ".golangci.yml")
+	}
+}
+
+func TestProjectDetector_DetectGitWorktreeFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "git_worktree_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for _, file := range []string{"go.mod", "main.go"} {
+		if err := os.WriteFile(filepath.Join(tempDir, file), []byte("test content"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, ".git"), []byte("gitdir: /path/to/main/.git/worktrees/feature"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := NewProjectDetector().Detect(tempDir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if !result.HasGit {
+		t.Error("Detect() HasGit = false, want true for a .git worktree file")
+	}
+}
+
 func TestProjectDetector_DetectWithLocationPriority(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "location_priority_test")
 	if err != nil {

--- a/devtools/devcheck/internal/detector/patterns.go
+++ b/devtools/devcheck/internal/detector/patterns.go
@@ -155,11 +155,15 @@ func (pm *PatternMatcher) MatchBuildSystemWithLocation(files []string) config.Bu
 	// Group files by directory depth
 	filesByDepth := make(map[int][]string)
 	minDepth := -1
+	maxDepth := -1
 
 	for _, file := range files {
 		depth := strings.Count(file, string(filepath.Separator))
 		if minDepth == -1 || depth < minDepth {
 			minDepth = depth
+		}
+		if depth > maxDepth {
+			maxDepth = depth
 		}
 		filesByDepth[depth] = append(filesByDepth[depth], file)
 	}
@@ -170,7 +174,7 @@ func (pm *PatternMatcher) MatchBuildSystemWithLocation(files []string) config.Bu
 	}
 
 	// Check each depth level, starting from the shallowest (root)
-	for depth := minDepth; depth <= len(filesByDepth)+minDepth; depth++ {
+	for depth := minDepth; depth <= maxDepth; depth++ {
 		filesAtDepth, exists := filesByDepth[depth]
 		if !exists {
 			continue

--- a/devtools/devcheck/internal/detector/patterns_test.go
+++ b/devtools/devcheck/internal/detector/patterns_test.go
@@ -197,6 +197,11 @@ func TestPatternMatcher_MatchBuildSystemWithLocation(t *testing.T) {
 			files:    []string{"examples/MODULE.bazel", "tests/Makefile", "main.go"},
 			expected: config.BuildSystemBazel,
 		},
+		{
+			name:     "sparse tree with makefile at depth 10",
+			files:    []string{"README.md", "a/b/c/d/e/f/g/h/i/j/Makefile"},
+			expected: config.BuildSystemMake,
+		},
 	}
 
 	for _, tt := range tests {

--- a/devtools/devcheck/internal/detector/scanner.go
+++ b/devtools/devcheck/internal/detector/scanner.go
@@ -42,7 +42,7 @@ func DefaultScanOptions() ScanOptions {
 			"*.tmp",
 			"*.temp",
 		},
-		IncludeHidden: false,
+		IncludeHidden: true,
 	}
 }
 
@@ -189,7 +189,11 @@ func (s *Scanner) isValidSymlinkTarget(entryAbsPath, absRoot string, result *Sca
 		return false
 	}
 
-	return strings.HasPrefix(cleanTarget, absRoot)
+	rel, err := filepath.Rel(absRoot, cleanTarget)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (s *Scanner) processEntry(entry os.DirEntry, entryRelPath, absRoot string, depth int, result *ScanResult) {

--- a/devtools/devcheck/internal/detector/scanner_test.go
+++ b/devtools/devcheck/internal/detector/scanner_test.go
@@ -32,11 +32,11 @@ func TestScanner_Scan(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name:          "hidden files excluded by default",
-			files:         []string{"main.go", ".gitignore", ".hidden/secret.txt"},
-			directories:   []string{".hidden"},
+			name:          "hidden files included except ignored dirs",
+			files:         []string{"main.go", ".golangci.yml", ".gitignore", ".git/HEAD", ".idea/workspace.xml"},
+			directories:   []string{".git", ".idea"},
 			options:       DefaultScanOptions(),
-			expectedFiles: []string{"main.go"},
+			expectedFiles: []string{"main.go", ".golangci.yml", ".gitignore"},
 			expectedDirs:  []string{},
 			expectError:   false,
 		},
@@ -443,8 +443,8 @@ func TestDefaultScanOptions(t *testing.T) {
 		t.Error("Expected FollowSymlinks to be false")
 	}
 
-	if options.IncludeHidden {
-		t.Error("Expected IncludeHidden to be false")
+	if !options.IncludeHidden {
+		t.Error("Expected IncludeHidden to be true")
 	}
 
 	// Check that common ignore patterns are included
@@ -460,6 +460,43 @@ func TestDefaultScanOptions(t *testing.T) {
 		if !found {
 			t.Errorf("Expected ignore pattern %s not found", pattern)
 		}
+	}
+}
+
+func TestScanner_isValidSymlinkTarget_rejectsPrefixSibling(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "symlink_prefix_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	absRoot, err := filepath.Abs(filepath.Join(tempDir, "proj"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evilDir := absRoot + "evil"
+	if err := os.MkdirAll(absRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(evilDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(evilDir, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(absRoot, "link")
+	if err := os.Symlink(evilDir, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	scanner := NewScanner(ScanOptions{
+		MaxDepth:       5,
+		FollowSymlinks: true,
+	})
+	result := &ScanResult{}
+	if scanner.isValidSymlinkTarget(linkPath, absRoot, result) {
+		t.Errorf("isValidSymlinkTarget(%q, %q) = true, want false for target %q", linkPath, absRoot, evilDir)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Include hidden files in the default detector scan so tool configs like `.golangci.yml` are found (`.git` / `.idea` remain ignored).
- Iterate build-system location matching to the actual max depth so sparse trees (e.g. a Makefile at depth 10) are not skipped.
- Detect git worktrees with `os.Stat` on `.git` (file or directory).
- Contain symlink targets with `filepath.Rel` so `absRoot + "evil"` is not treated as inside `absRoot`.

Resolves #262

## Demo

Ran `go run ./devtools/devcheck/cmd/devcheck` against this repository.

### Hidden config files

This repo has `.golangci.yml` at the root. Default scan skipped dotfiles, so `Detect()` never recorded the golangci-lint config.

**Before** (`origin/main`):

```
🔍 DevCheck Project Detection Results
=====================================

Path: /home/jaehyun/go/src/github.com/jaeyeom/experimental
Languages: go, javascript, python, typescript
Build System: bazel
Git Repository: yes

Tools:
  format: bazel run //tools:format
  lint: bazel run //tools:lint
  test: bazel test //...

Configuration Files:
  ruff: pyproject.toml
  typescript: tsconfig.json
```

**After** (this PR):

```
🔍 DevCheck Project Detection Results
=====================================

Path: /home/jaehyun/go/src/github.com/jaeyeom/experimental
Languages: go, javascript, python, typescript
Build System: bazel
Git Repository: yes

Tools:
  format: bazel run //tools:format
  lint: bazel run //tools:lint
  test: bazel test //...

Configuration Files:
  golangci-lint: .golangci.yml
  ruff: pyproject.toml
  typescript: tsconfig.json
```

`.golangci.yml` is the only new config file; `ruff` and `typescript` were already visible because `pyproject.toml` and `tsconfig.json` are not hidden.

### Sparse build-system matching

This repo has `MODULE.bazel` and `Makefile` at the root, so location matching already returns `bazel` at depth 0. The bug shows up when occupied depths are sparse. Same matcher, a root file plus a Makefile at depth 10:

| | `MatchBuildSystemWithLocation(["README.md", "a/b/c/d/e/f/g/h/i/j/Makefile"])` |
|---|---|
| **Before** | `none` |
| **After** | `make` |

### Symlink containment

Using this repo's absolute path as `absRoot`:

```
absRoot = /home/jaehyun/go/src/github.com/jaeyeom/experimental
evil    = /home/jaehyun/go/src/github.com/jaeyeom/experimentalevil
```

| Check | Before | After |
|---|---|---|
| `strings.HasPrefix(evil, absRoot)` | `true` (treated as inside) | still `true`, but no longer used |
| `filepath.Rel(absRoot, evil)` | unused | `../experimentalevil` |
| `isValidSymlinkTarget` for a symlink to `absRoot+"evil"` | `true` | `false` |

### Git worktree file

This checkout is a normal `.git` directory, so both versions report `Git Repository: yes`. A `.git` *file* (linked worktree) also sets `HasGit=true` on both; detection now uses `os.Stat` instead of a second scan plus a dead `HasPattern(".git/*")` fallback.

## Test plan
- [x] `TestProjectDetector_DetectRecordsGolangciConfig`
- [x] `TestPatternMatcher_MatchBuildSystemWithLocation/sparse_tree_with_makefile_at_depth_10`
- [x] `TestProjectDetector_DetectGitWorktreeFile`
- [x] `TestScanner_isValidSymlinkTarget_rejectsPrefixSibling`
- [x] `make check` from repo root (308 tests pass, lint/semgrep clean)
