### PR TITLE
feat(prsync): close merged orphan tabs with --close-merged

### DIFF
--- a/devtools/prsync/README.org
+++ b/devtools/prsync/README.org
@@ -11,15 +11,17 @@ that agent a prompt to address unresolved review comments — or, with
 ~--rebase~, a rebase-in-place prompt even when there are no open comments.
 It can also run the join in reverse (~tabs --orphans~) to flag live-agent
 tabs whose PR already merged, so their worktrees and gate slots can be
-reclaimed. ~comment~ posts a conversation-level PR comment through ~gh~
+reclaimed — and, with ~--close-merged --go~, close those merged-bucket
+tabs itself. ~comment~ posts a conversation-level PR comment through ~gh~
 with no herdr tab and no concurrency gate.
 
-~scan~ and ~tabs~ are read-only on GitHub. ~comment~ writes a PR comment
-via ~gh~. ~dispatch~ is write-only on herdr (prompt injection). The tool
-shells out to the already-authenticated ~gh~ CLI and to herdr ≥ 0.8. It
-never embeds a GitHub token. Dispatch is serialized (one agent at a time)
-and dry-run by default; ~comment~ is also dry-run by default. All commands
-emit JSON on stdout.
+~scan~ and ~tabs --orphans~ are read-only on GitHub. ~comment~ writes a PR
+comment via ~gh~. ~dispatch~ is write-only on herdr (prompt injection).
+~tabs --orphans --close-merged --go~ is write-only on herdr (tab close).
+The tool shells out to the already-authenticated ~gh~ CLI and to herdr ≥
+0.8. It never embeds a GitHub token. Dispatch is serialized (one agent at
+a time) and dry-run by default; ~comment~ and ~tabs --close-merged~ are
+also dry-run by default. All commands emit JSON on stdout.
 
 Related tracker: [[https://github.com/jaeyeom/experimental/issues/211][#211]].
 
@@ -54,7 +56,7 @@ Optional: copy [[file:prsync.config.example][prsync.config.example]] to
 
 #+BEGIN_EXAMPLE
 prsync scan     [--config PATH] [--repo owner/repo ...] [--json]
-prsync tabs     --orphans [--config PATH] [--json] [--stdin]
+prsync tabs     --orphans [--config PATH] [--json] [--stdin] [--close-merged] [--go]
 prsync dispatch [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--rebase] [--force] [--stdin]
 prsync comment  [--config PATH] [--pr owner/repo#N ...] [--all] [--go] [--stdin] --body TEXT
 prsync gate     [--config PATH]
@@ -67,17 +69,21 @@ prsync version
 | ~--repo owner/repo~ | scan | Repeatable; replaces ~repos~ entirely |
 | ~--json~ | scan, tabs | Accepted no-op (stdout is always JSON) |
 | ~--orphans~ | tabs | Required; report live-agent tabs with no open/draft PR |
+| ~--close-merged~ | tabs | Close ~merged~-bucket orphan tabs (default is dry-run) |
 | ~--stdin~ | tabs | Reuse open-PR↔tab matches from a scan document on stdin (else self-resolve) |
 | ~--pr owner/repo#N~ | dispatch, comment | Repeatable; limit candidates |
 | ~--all~ | dispatch, comment | Every PR in the scan document (default when no ~--pr~) |
-| ~--go~ | dispatch, comment | Live send (default is dry-run) |
+| ~--go~ | dispatch, comment, tabs | Live send / close (default is dry-run) |
 | ~--rebase~ | dispatch | Rebase-in-place prompt; skips the unaddressed-comment gate |
 | ~--force~ | dispatch | Re-dispatch even if dedupe state would skip |
 | ~--stdin~ | dispatch, comment | Read a scan document from stdin (FIFO or regular file). Default is self-scan. |
 | ~--body TEXT~ | comment | Comment body to post (required) |
 
-~--pr~ and ~--all~ together is an error (exit 2). ~--go~ always sends.
-~dry_run=false~ in the config also sends without ~--go~ (for cron).
+~--pr~ and ~--all~ together is an error (exit 2). ~--go~ on ~tabs~
+requires ~--close-merged~ (exit 2 otherwise). ~--go~ always sends (or,
+with ~--close-merged~, closes). ~dry_run=false~ in the config also
+sends / closes without ~--go~ (for cron); ~tabs~ still needs
+~--close-merged~ to close anything.
 
 ~dispatch~ and ~comment~ read a scan document from stdin only when
 ~--stdin~ is set and stdin is a FIFO or regular file (a pipe or
@@ -285,10 +291,45 @@ prsync tabs --orphans --config ./prsync.config
 }
 #+END_SRC
 
-Report-only, like ~scan~: closing a tab (~herdr tab close~) stays a
-separate, explicitly-confirmed step — never automatic. The report sees
-only the local herdr socket, so a ticket whose tab lives on another
-machine is never mislabeled here.
+~--close-merged~ closes only the ~merged~ bucket, driven by ~prsync~'s
+own classification rather than a hand-copied ~tab_id~. Dry-run by
+default (same as ~dispatch~ / ~comment~); ~--go~ actually closes.
+~no_pr~ tabs are never touched — they may hold unpushed work. At close
+time each candidate is re-verified (its PR is still merged or closed)
+so a race cannot close a tab that grew a new open PR. The report and
+the close both see only the local herdr socket, so a ticket whose tab
+lives on another machine is never mislabeled or closed here.
+
+#+BEGIN_SRC bash
+prsync tabs --orphans --close-merged --config ./prsync.config
+prsync tabs --orphans --close-merged --go --config ./prsync.config
+#+END_SRC
+
+#+BEGIN_SRC json
+{
+  "generated_at": "2026-01-01T09:00:00Z",
+  "dry_run": true,
+  "results": [
+    {
+      "tab_id": "w2:tA",
+      "workspace_id": "w2",
+      "ticket": "AP-1306",
+      "action": "would_close",
+      "pr": {
+        "repo": "acme/widgets",
+        "number": 32347,
+        "url": "https://github.com/acme/widgets/pull/32347",
+        "state": "merged",
+        "merged_at": "2026-08-18T22:19:28Z"
+      }
+    }
+  ]
+}
+#+END_SRC
+
+Live ~action~ values: ~closed~, ~skipped_not_merged~,
+~skipped_not_found~. Dry-run emits ~would_close~ for each merged-bucket
+tab it would close.
 
 Piping a ~scan~ document in with ~--stdin~ reuses its open-PR↔tab matches,
 so tabs that already have an open PR are skipped without a ~gh search~:
@@ -428,6 +469,8 @@ prsync dispatch --config ./prsync.config          # review rendered_prompt
 prsync dispatch --config ./prsync.config --go     # pane_id + --wait --until idle --until done
 prsync comment --config ./prsync.config --body "please retry"      # review rendered_prompt
 prsync comment --config ./prsync.config --body "please retry" --go
+prsync tabs --orphans --close-merged --config ./prsync.config      # review would_close
+prsync tabs --orphans --close-merged --go --config ./prsync.config
 prsync gate --config ./prsync.config
 #+END_SRC
 
@@ -447,6 +490,9 @@ This procedure is README-only; CI uses fixture binaries, not live herdr.
   Auth is the operator's existing ~gh~ login plus the local herdr socket.
 - ~comment --go~ posts the given body as a GitHub PR comment. Dry-run
   first; there is no extra confirmation beyond ~--go~.
+- ~tabs --orphans --close-merged --go~ runs ~herdr tab close~ on each
+  tab still in the ~merged~ bucket. Dry-run first; ~no_pr~ and
+  ~has_open_pr~ tabs are never candidates.
 - Review comment bodies are interpolated into the dispatch prompt as text.
   ~prsync~ does not execute them. The *agent* may follow malicious review
   text — this is inherent to the product. Do not treat the prompt as

--- a/devtools/prsync/internal/cli/cli_tabs_test.go
+++ b/devtools/prsync/internal/cli/cli_tabs_test.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -77,6 +81,116 @@ func TestTabsOrphansStdinReuseSkipsMatchedTab(t *testing.T) {
 	}
 	if len(doc.OrphanTabs) != 0 {
 		t.Fatalf("orphan_tabs = %+v, want empty (tab already has an open PR in the scan)", doc.OrphanTabs)
+	}
+}
+
+func TestTabsGoRequiresCloseMerged(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"tabs", "--orphans", "--go"}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitUsage {
+		t.Fatalf("exit = %d, want %d, stderr=%q", code, ExitUsage, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--go requires --close-merged") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestTabsCloseMergedDryRun(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	sentinel := filepath.Join(t.TempDir(), "close")
+	t.Setenv("HERDR_FAKE_TAB_CLOSE_SENTINEL", sentinel)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"tabs", "--orphans", "--close-merged", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var doc scan.CloseDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if !doc.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if len(doc.Results) != 1 {
+		t.Fatalf("results = %+v, want 1", doc.Results)
+	}
+	got := doc.Results[0]
+	if got.TabID != "w2:tC" || got.Ticket != "PROJ-123" || got.Action != scan.ActionWouldClose {
+		t.Fatalf("result = %+v", got)
+	}
+	if _, err := os.Stat(sentinel); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("herdr tab close was invoked on dry-run: %v", err)
+	}
+}
+
+func TestTabsCloseMergedGoCloses(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	sentinel := filepath.Join(t.TempDir(), "close")
+	t.Setenv("HERDR_FAKE_TAB_CLOSE_SENTINEL", sentinel)
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"tabs", "--orphans", "--close-merged", "--go", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var doc scan.CloseDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if doc.DryRun {
+		t.Fatal("dry_run = true, want false")
+	}
+	if len(doc.Results) != 1 || doc.Results[0].Action != scan.ActionClosed || doc.Results[0].TabID != "w2:tC" {
+		t.Fatalf("results = %+v, want closed w2:tC", doc.Results)
+	}
+	body, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("herdr tab close was not invoked: %v", err)
+	}
+	if !strings.Contains(string(body), "w2:tC") {
+		t.Fatalf("close args = %q, want w2:tC", body)
+	}
+}
+
+func TestTabsCloseMergedGoSkippedNotFound(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	t.Setenv("HERDR_FAKE_TAB_CLOSE", "not_found")
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"tabs", "--orphans", "--close-merged", "--go", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitOK {
+		t.Fatalf("exit = %d, stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	var doc scan.CloseDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if len(doc.Results) != 1 || doc.Results[0].Action != scan.ActionSkippedNotFound {
+		t.Fatalf("results = %+v, want skipped_not_found", doc.Results)
+	}
+}
+
+func TestTabsCloseMergedGoFailureExit3(t *testing.T) {
+	ghBin, herdrBin := fixtureBins(t)
+	t.Setenv("HERDR_FAKE_TAB_CLOSE", "fail")
+	cfgPath := writeScanConfig(t, "gh_bin="+ghBin+"\nherdr_bin="+herdrBin+"\nauthor=alice\n")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), []string{"tabs", "--orphans", "--close-merged", "--go", "--config", cfgPath}, &stdout, &stderr, executor.NewBasicExecutor())
+	if code != ExitPrecondition {
+		t.Fatalf("exit = %d, want %d, stderr=%q stdout=%q", code, ExitPrecondition, stderr.String(), stdout.String())
+	}
+	var doc scan.CloseDocument
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("json: %v\n%s", err, stdout.String())
+	}
+	if len(doc.Results) != 1 || doc.Results[0].Action != scan.ActionFailed {
+		t.Fatalf("results = %+v, want failed", doc.Results)
 	}
 }
 

--- a/devtools/prsync/internal/cli/tabs.go
+++ b/devtools/prsync/internal/cli/tabs.go
@@ -20,10 +20,12 @@ import (
 
 func newTabsCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 	var (
-		configPath string
-		orphans    bool
-		jsonFlag   bool
-		readStdin  bool
+		configPath  string
+		orphans     bool
+		jsonFlag    bool
+		readStdin   bool
+		closeMerged bool
+		goLive      bool
 	)
 	cmd := &cobra.Command{
 		Use:   "tabs",
@@ -34,37 +36,59 @@ func newTabsCmd(stdout io.Writer, exec executor.Executor) *cobra.Command {
 			if !orphans {
 				return &ExitError{Code: ExitUsage, Err: errors.New("tabs requires --orphans")}
 			}
-			return runTabsOrphans(cmd.Context(), stdout, exec, configPath, readStdin)
+			if goLive && !closeMerged {
+				return &ExitError{Code: ExitUsage, Err: errors.New("--go requires --close-merged")}
+			}
+			return runTabsOrphans(cmd.Context(), stdout, exec, configPath, readStdin, closeMerged, goLive)
 		},
 	}
 	cmd.Flags().StringVar(&configPath, "config", "", "config file path")
 	cmd.Flags().BoolVar(&orphans, "orphans", false, "report live-agent tabs with no open/draft PR")
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "accepted, no-op (stdout is always JSON)")
 	cmd.Flags().BoolVar(&readStdin, "stdin", false, "reuse open-PR matches from a scan document on stdin")
+	cmd.Flags().BoolVar(&closeMerged, "close-merged", false, "close merged-bucket orphan tabs (default is dry-run)")
+	cmd.Flags().BoolVar(&goLive, "go", false, "actually close tabs (default is dry-run)")
 	return cmd
 }
 
-func runTabsOrphans(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, readStdin bool) error {
+func runTabsOrphans(ctx context.Context, stdout io.Writer, exec executor.Executor, configPath string, readStdin, closeMerged, goLive bool) error {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
+	}
+	if goLive {
+		cfg.DryRun = false
 	}
 	openTabs, err := openTabsFromStdin(readStdin)
 	if err != nil {
 		return err
 	}
+	client := herdr.NewClient(exec, cfg.HerdrBin)
 	deps := scan.OrphanDeps{
 		GH:    gh.NewClient(exec, cfg.GHBin),
-		Herdr: herdr.NewClient(exec, cfg.HerdrBin),
+		Herdr: client,
 	}
 	doc, err := scan.Orphans(ctx, deps, cfg, openTabs, time.Now())
-	if scan.OrphansStarted(doc) {
-		if werr := writeOrphanJSON(stdout, doc); werr != nil {
-			return werr
-		}
-	}
 	if err != nil {
+		if scan.OrphansStarted(doc) {
+			if werr := writeOrphanJSON(stdout, doc); werr != nil {
+				return werr
+			}
+		}
 		return gateError(err, cfg)
+	}
+	if !closeMerged {
+		return writeOrphanJSON(stdout, doc)
+	}
+	out, closeErr := scan.CloseMerged(ctx, scan.CloseDeps{
+		GH:    deps.GH,
+		Herdr: client,
+	}, cfg, doc.Author, doc.OrphanTabs, time.Now())
+	if werr := writeCloseJSON(stdout, out); werr != nil {
+		return werr
+	}
+	if closeErr != nil {
+		return gateError(closeErr, cfg)
 	}
 	return nil
 }
@@ -84,6 +108,17 @@ func openTabsFromStdin(readStdin bool) (map[string]struct{}, error) {
 }
 
 func writeOrphanJSON(w io.Writer, doc scan.OrphanDocument) error {
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode tabs: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", out); err != nil {
+		return fmt.Errorf("write tabs: %w", err)
+	}
+	return nil
+}
+
+func writeCloseJSON(w io.Writer, doc scan.CloseDocument) error {
 	out, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode tabs: %w", err)

--- a/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
+++ b/devtools/prsync/internal/cli/testdata/fixtures/herdr-fake.sh
@@ -15,6 +15,23 @@ case "${1-} ${2-}" in
     cat "${DIR}/herdr-tab-list.json"
     exit 0
     ;;
+  "tab close")
+    if [ -n "${HERDR_FAKE_TAB_CLOSE_SENTINEL-}" ]; then
+      printf '%s\n' "$*" > "$HERDR_FAKE_TAB_CLOSE_SENTINEL"
+    fi
+    case "${HERDR_FAKE_TAB_CLOSE-}" in
+      not_found)
+        printf '%s\n' "{\"error\":{\"code\":\"tab_not_found\",\"message\":\"tab ${3-} not found\"},\"id\":\"cli:tab:close\"}"
+        exit 1
+        ;;
+      fail)
+        printf '%s\n' "herdr-fake: tab close failed" >&2
+        exit 1
+        ;;
+    esac
+    printf '%s\n' '{"result":{"closed":true}}'
+    exit 0
+    ;;
   "agent list")
     if [ -n "${HERDR_FAKE_STATUS_FILE-}" ] || [ -n "${HERDR_FAKE_AGENT_STATUS-}" ] || [ -n "${HERDR_FAKE_TAB_ID-}" ] || [ -n "${HERDR_FAKE_PANE_ID-}" ]; then
       status=${HERDR_FAKE_AGENT_STATUS:-idle}

--- a/devtools/prsync/internal/herdr/client.go
+++ b/devtools/prsync/internal/herdr/client.go
@@ -82,6 +82,21 @@ func (c *Client) TabList(ctx context.Context) ([]Tab, error) {
 	return *env.Result.Tabs, nil
 }
 
+// TabClose runs `herdr tab close <tabID>`. A missing tab is ErrTabNotFound.
+func (c *Client) TabClose(ctx context.Context, tabID string) error {
+	_, err := c.output(ctx, defaultCallTimeout, "tab", "close", tabID)
+	if err == nil {
+		return nil
+	}
+	var proc *ProcError
+	if errors.As(err, &proc) {
+		if code := promptErrorCode(proc.Stderr, proc.Stdout); code == "tab_not_found" {
+			return fmt.Errorf("%w: %s", ErrTabNotFound, proc.Error())
+		}
+	}
+	return err
+}
+
 // AgentList runs `herdr agent list` and returns .result.agents.
 func (c *Client) AgentList(ctx context.Context) ([]Agent, error) {
 	raw, err := c.output(ctx, defaultCallTimeout, "agent", "list")

--- a/devtools/prsync/internal/herdr/client_test.go
+++ b/devtools/prsync/internal/herdr/client_test.go
@@ -153,6 +153,50 @@ func TestTabList(t *testing.T) {
 	})
 }
 
+func TestTabClose(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "tab", "close", "w2:tC").
+			WillSucceed(`{"result":{"closed":true}}`, 0).Build()
+		if err := NewClient(mock, testHerdrBin).TabClose(context.Background(), "w2:tC"); err != nil {
+			t.Fatalf("TabClose() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("tab_not_found", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "tab", "close", "w2:tMissing").WillReturn(&executor.ExecutionResult{
+			Output:   `{"error":{"code":"tab_not_found","message":"tab w2:tMissing not found"},"id":"cli:tab:close"}`,
+			ExitCode: 1,
+		}, nil).Build()
+		err := NewClient(mock, testHerdrBin).TabClose(context.Background(), "w2:tMissing")
+		if !errors.Is(err, ErrTabNotFound) {
+			t.Fatalf("TabClose() error = %v, want ErrTabNotFound", err)
+		}
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		t.Parallel()
+		mock := newHerdrMock()
+		mock.ExpectCommandWithArgs(testHerdrBin, "tab", "close", "w2:tC").WillReturn(&executor.ExecutionResult{
+			Stderr:   "herdr: boom",
+			ExitCode: 1,
+		}, nil).Build()
+		err := NewClient(mock, testHerdrBin).TabClose(context.Background(), "w2:tC")
+		var proc *ProcError
+		if !errors.As(err, &proc) {
+			t.Fatalf("TabClose() error = %v, want ProcError", err)
+		}
+		if proc.ExitCode != 1 {
+			t.Fatalf("exit = %d, want 1", proc.ExitCode)
+		}
+	})
+}
+
 func TestAgentList(t *testing.T) {
 	t.Parallel()
 

--- a/devtools/prsync/internal/herdr/types.go
+++ b/devtools/prsync/internal/herdr/types.go
@@ -15,6 +15,9 @@ var ErrUnsupported = errors.New("herdr version unsupported")
 // ErrDegraded is returned when a herdr success envelope is missing an expected field.
 var ErrDegraded = errors.New("herdr response missing expected fields")
 
+// ErrTabNotFound is returned when `herdr tab close` reports the tab is gone.
+var ErrTabNotFound = errors.New("herdr tab not found")
+
 // ProcError is a non-zero process exit from herdr.
 type ProcError struct {
 	ExitCode int

--- a/devtools/prsync/internal/scan/BUILD.bazel
+++ b/devtools/prsync/internal/scan/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bucket.go",
         "ci.go",
+        "close.go",
         "identifier.go",
         "match.go",
         "orphan.go",
@@ -25,6 +26,7 @@ go_test(
     srcs = [
         "bucket_test.go",
         "ci_test.go",
+        "close_test.go",
         "identifier_test.go",
         "match_test.go",
         "orphan_test.go",

--- a/devtools/prsync/internal/scan/close.go
+++ b/devtools/prsync/internal/scan/close.go
@@ -1,0 +1,176 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+)
+
+// Close actions in a --close-merged result.
+const (
+	ActionWouldClose       = "would_close"
+	ActionClosed           = "closed"
+	ActionSkippedNotMerged = "skipped_not_merged"
+	ActionSkippedNotFound  = "skipped_not_found"
+	ActionFailed           = "failed"
+)
+
+// ErrCloseFailed is returned when a live tab close fails (exit 3).
+var ErrCloseFailed = errors.New("close merged failed")
+
+// TabCloser is the herdr surface --close-merged uses.
+type TabCloser interface {
+	TabList(ctx context.Context) ([]herdr.Tab, error)
+	TabClose(ctx context.Context, tabID string) error
+}
+
+// CloseDeps is the injected GitHub and herdr adapters for --close-merged.
+type CloseDeps struct {
+	GH    OrphanGH
+	Herdr TabCloser
+}
+
+// CloseDocument is the outbound `tabs --orphans --close-merged` JSON document.
+type CloseDocument struct {
+	GeneratedAt string      `json:"generated_at"` //nolint:tagliatelle // brief outbound contract
+	DryRun      bool        `json:"dry_run"`      //nolint:tagliatelle // brief outbound contract
+	Results     []CloseItem `json:"results"`
+}
+
+// CloseItem is one tab's close outcome.
+type CloseItem struct {
+	TabID       string    `json:"tab_id"`                 //nolint:tagliatelle // brief outbound contract
+	WorkspaceID string    `json:"workspace_id,omitempty"` //nolint:tagliatelle // brief outbound contract
+	Ticket      string    `json:"ticket,omitempty"`
+	Action      string    `json:"action"`
+	Detail      string    `json:"detail,omitempty"`
+	PR          *OrphanPR `json:"pr,omitempty"`
+}
+
+// CloseMerged closes tabs classified as merged orphans. Dry-run never calls
+// herdr or GitHub. Live send re-verifies each candidate's PR is still
+// merged/closed immediately before close so a newly opened PR cannot be
+// closed by a stale classification. no_pr tabs are never candidates.
+func CloseMerged(ctx context.Context, deps CloseDeps, cfg config.Config, author string, orphans []OrphanTab, now time.Time) (CloseDocument, error) {
+	doc := CloseDocument{
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		DryRun:      cfg.DryRun,
+		Results:     []CloseItem{},
+	}
+	var merged []OrphanTab
+	for _, tab := range orphans {
+		if tab.Bucket == BucketMerged {
+			merged = append(merged, tab)
+		}
+	}
+	if cfg.DryRun {
+		for _, tab := range merged {
+			doc.Results = append(doc.Results, wouldCloseItem(tab))
+		}
+		return doc, nil
+	}
+	if len(merged) == 0 {
+		return doc, nil
+	}
+	present, err := presentTabs(ctx, deps.Herdr)
+	if err != nil {
+		return doc, err
+	}
+	for _, tab := range merged {
+		if err := ctx.Err(); err != nil {
+			item := baseCloseItem(tab)
+			item.Action = ActionFailed
+			item.Detail = err.Error()
+			doc.Results = append(doc.Results, item)
+			return doc, fmt.Errorf("close merged: %w", err)
+		}
+		item, err := closeOne(ctx, deps, cfg, author, present, tab)
+		doc.Results = append(doc.Results, item)
+		if err != nil {
+			return doc, err
+		}
+	}
+	return doc, nil
+}
+
+func wouldCloseItem(tab OrphanTab) CloseItem {
+	item := baseCloseItem(tab)
+	item.Action = ActionWouldClose
+	return item
+}
+
+func baseCloseItem(tab OrphanTab) CloseItem {
+	return CloseItem{
+		TabID:       tab.TabID,
+		WorkspaceID: tab.WorkspaceID,
+		Ticket:      tab.Ticket,
+		PR:          tab.PR,
+	}
+}
+
+func presentTabs(ctx context.Context, h TabCloser) (map[string]struct{}, error) {
+	tabs, err := h.TabList(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tab list: %w", err)
+	}
+	present := make(map[string]struct{}, len(tabs))
+	for _, tab := range tabs {
+		present[tab.TabID] = struct{}{}
+	}
+	return present, nil
+}
+
+func closeOne(ctx context.Context, deps CloseDeps, cfg config.Config, author string, present map[string]struct{}, tab OrphanTab) (CloseItem, error) {
+	item := baseCloseItem(tab)
+	if _, ok := present[tab.TabID]; !ok {
+		item.Action = ActionSkippedNotFound
+		return item, nil
+	}
+	still, pr, err := stillMerged(ctx, deps.GH, cfg, author, tab.Ticket)
+	if err != nil {
+		item.Action = ActionFailed
+		item.Detail = err.Error()
+		return item, fmt.Errorf("%w: %w", ErrCloseFailed, err)
+	}
+	if !still {
+		item.Action = ActionSkippedNotMerged
+		if pr != nil {
+			item.PR = pr
+		}
+		return item, nil
+	}
+	if pr != nil {
+		item.PR = pr
+	}
+	if err := deps.Herdr.TabClose(ctx, tab.TabID); err != nil {
+		if errors.Is(err, herdr.ErrTabNotFound) {
+			item.Action = ActionSkippedNotFound
+			return item, nil
+		}
+		item.Action = ActionFailed
+		item.Detail = err.Error()
+		return item, fmt.Errorf("%w: %w", ErrCloseFailed, err)
+	}
+	item.Action = ActionClosed
+	return item, nil
+}
+
+func stillMerged(ctx context.Context, client OrphanGH, cfg config.Config, author, ticket string) (bool, *OrphanPR, error) {
+	items, err := client.SearchAuthoredPRs(ctx, author, ticket)
+	if err != nil {
+		return false, nil, fmt.Errorf("search prs %s: %w", ticket, err)
+	}
+	candidates := filterByTicket(items, ticket, cfg.TitleIDPattern)
+	if hasOpenPR(candidates) {
+		return false, nil, nil
+	}
+	resolving := pickResolving(candidates)
+	if resolving == nil {
+		return false, nil, nil
+	}
+	return true, toOrphanPR(*resolving), nil
+}

--- a/devtools/prsync/internal/scan/close_test.go
+++ b/devtools/prsync/internal/scan/close_test.go
@@ -1,0 +1,285 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/config"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/gh"
+	"github.com/jaeyeom/experimental/devtools/prsync/internal/herdr"
+)
+
+func mergedOrphan(tabID, ticket string) OrphanTab {
+	mergedAt := "2026-08-18T22:19:28Z"
+	return OrphanTab{
+		TabID:       tabID,
+		WorkspaceID: "w2",
+		Label:       ticket,
+		Ticket:      ticket,
+		AgentStatus: "idle",
+		Bucket:      BucketMerged,
+		PR: &OrphanPR{
+			Repo: "acme/x", Number: 32347, URL: "https://gh/acme/x/pull/32347",
+			State: "merged", MergedAt: &mergedAt,
+		},
+	}
+}
+
+func noPROrphan(tabID, ticket string) OrphanTab {
+	return OrphanTab{
+		TabID:       tabID,
+		WorkspaceID: "w2",
+		Label:       ticket,
+		Ticket:      ticket,
+		AgentStatus: "idle",
+		Bucket:      BucketNoPR,
+	}
+}
+
+func TestCloseMergedDryRunWouldCloseMergedOnly(t *testing.T) {
+	t.Parallel()
+
+	h := &closeHerdr{}
+	g := &orphanGH{}
+	got, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, orphanCfg(), "alice", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+		noPROrphan("w2:tB", "AP-1287"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if !got.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if got.GeneratedAt != "2026-01-01T09:00:00Z" {
+		t.Fatalf("generated_at = %q", got.GeneratedAt)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %+v, want 1 merged tab", got.Results)
+	}
+	item := got.Results[0]
+	if item.TabID != "w2:tA" || item.Ticket != "AP-1306" || item.Action != ActionWouldClose {
+		t.Fatalf("item = %+v", item)
+	}
+	if len(h.closed) != 0 {
+		t.Fatalf("TabClose called on dry-run: %v", h.closed)
+	}
+	if len(g.queried) != 0 {
+		t.Fatalf("GitHub re-verify on dry-run: %v", g.queried)
+	}
+	if h.listed {
+		t.Fatal("TabList called on dry-run")
+	}
+}
+
+func TestCloseMergedLiveClosesMerged(t *testing.T) {
+	t.Parallel()
+
+	cfg := orphanCfg()
+	cfg.DryRun = false
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{
+			Number: 32347, Title: "[AP-1306] Fix", State: "merged",
+			ClosedAt: "2026-08-18T22:19:28Z", Repository: gh.SearchRepository{NameWithOwner: "acme/x"},
+		}},
+	}}
+	h := &closeHerdr{tabs: []herdr.Tab{liveTab("w2:tA", "w2", "AP-1306")}}
+	got, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, cfg, "alice", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+		noPROrphan("w2:tB", "AP-1287"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if got.DryRun {
+		t.Fatal("dry_run = true, want false")
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results = %+v, want 1", got.Results)
+	}
+	item := got.Results[0]
+	if item.TabID != "w2:tA" || item.Action != ActionClosed {
+		t.Fatalf("item = %+v, want closed w2:tA", item)
+	}
+	if len(h.closed) != 1 || h.closed[0] != "w2:tA" {
+		t.Fatalf("closed = %v, want [w2:tA]", h.closed)
+	}
+}
+
+func TestCloseMergedLiveSkipsNotMerged(t *testing.T) {
+	t.Parallel()
+
+	cfg := orphanCfg()
+	cfg.DryRun = false
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{
+			Number: 500, Title: "[AP-1306] reopened", State: "open",
+			Repository: gh.SearchRepository{NameWithOwner: "acme/x"},
+		}},
+	}}
+	h := &closeHerdr{tabs: []herdr.Tab{liveTab("w2:tA", "w2", "AP-1306")}}
+	got, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, cfg, "alice", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionSkippedNotMerged {
+		t.Fatalf("results = %+v, want skipped_not_merged", got.Results)
+	}
+	if len(h.closed) != 0 {
+		t.Fatalf("TabClose called: %v", h.closed)
+	}
+}
+
+func TestCloseMergedLiveSkipsNotFound(t *testing.T) {
+	t.Parallel()
+
+	cfg := orphanCfg()
+	cfg.DryRun = false
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{
+			Number: 32347, Title: "[AP-1306] Fix", State: "merged",
+			Repository: gh.SearchRepository{NameWithOwner: "acme/x"},
+		}},
+	}}
+	h := &closeHerdr{} // tab list empty
+	got, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, cfg, "alice", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionSkippedNotFound {
+		t.Fatalf("results = %+v, want skipped_not_found", got.Results)
+	}
+	if len(h.closed) != 0 {
+		t.Fatalf("TabClose called: %v", h.closed)
+	}
+}
+
+func TestCloseMergedLiveTabCloseNotFound(t *testing.T) {
+	t.Parallel()
+
+	cfg := orphanCfg()
+	cfg.DryRun = false
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{
+			Number: 32347, Title: "[AP-1306] Fix", State: "merged",
+			Repository: gh.SearchRepository{NameWithOwner: "acme/x"},
+		}},
+	}}
+	h := &closeHerdr{
+		tabs:     []herdr.Tab{liveTab("w2:tA", "w2", "AP-1306")},
+		closeErr: herdr.ErrTabNotFound,
+	}
+	got, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, cfg, "alice", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Action != ActionSkippedNotFound {
+		t.Fatalf("results = %+v, want skipped_not_found", got.Results)
+	}
+}
+
+func TestCloseMergedLiveFailureStopsBatch(t *testing.T) {
+	t.Parallel()
+
+	cfg := orphanCfg()
+	cfg.DryRun = false
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{Number: 1, Title: "[AP-1306] a", State: "merged", Repository: gh.SearchRepository{NameWithOwner: "acme/x"}}},
+		"AP-1400": {{Number: 2, Title: "[AP-1400] b", State: "merged", Repository: gh.SearchRepository{NameWithOwner: "acme/x"}}},
+	}}
+	h := &closeHerdr{
+		tabs: []herdr.Tab{
+			liveTab("w2:tA", "w2", "AP-1306"),
+			liveTab("w2:tC", "w2", "AP-1400"),
+		},
+		closeErr: errors.New("boom"),
+	}
+	got, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, cfg, "alice", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+		mergedOrphan("w2:tC", "AP-1400"),
+	}, fixtureNow)
+	if !errors.Is(err, ErrCloseFailed) {
+		t.Fatalf("error = %v, want ErrCloseFailed", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (stop on failure)", len(got.Results))
+	}
+	if got.Results[0].Action != ActionFailed {
+		t.Fatalf("result = %+v, want failed", got.Results[0])
+	}
+	if len(h.closed) != 1 {
+		t.Fatalf("closed = %v, want 1", h.closed)
+	}
+}
+
+func TestCloseMergedLiveReverifyUsesResolvedAuthor(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.DryRun = false
+	g := &orphanGH{search: map[string][]gh.PRSearchItem{
+		"AP-1306": {{
+			Number: 32347, Title: "[AP-1306] Fix", State: "merged",
+			Repository: gh.SearchRepository{NameWithOwner: "acme/x"},
+		}},
+	}}
+	h := &closeHerdr{tabs: []herdr.Tab{liveTab("w2:tA", "w2", "AP-1306")}}
+	_, err := CloseMerged(context.Background(), CloseDeps{GH: g, Herdr: h}, cfg, "bob", []OrphanTab{
+		mergedOrphan("w2:tA", "AP-1306"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if g.searchedAuthor != "bob" {
+		t.Fatalf("searched as %q, want bob", g.searchedAuthor)
+	}
+}
+
+func TestCloseMergedEmptyResults(t *testing.T) {
+	t.Parallel()
+
+	h := &closeHerdr{}
+	got, err := CloseMerged(context.Background(), CloseDeps{Herdr: h}, orphanCfg(), "alice", []OrphanTab{
+		noPROrphan("w2:tB", "AP-1287"),
+	}, fixtureNow)
+	if err != nil {
+		t.Fatalf("CloseMerged() unexpected error: %v", err)
+	}
+	if got.Results == nil {
+		t.Fatal("results = nil, want empty slice")
+	}
+	if len(got.Results) != 0 {
+		t.Fatalf("results = %+v, want empty", got.Results)
+	}
+	if h.listed {
+		t.Fatal("TabList called with no merged candidates")
+	}
+}
+
+type closeHerdr struct {
+	tabs     []herdr.Tab
+	closed   []string
+	closeErr error
+	listErr  error
+	listed   bool
+}
+
+func (h *closeHerdr) TabList(context.Context) ([]herdr.Tab, error) {
+	h.listed = true
+	if h.listErr != nil {
+		return nil, h.listErr
+	}
+	return h.tabs, nil
+}
+
+func (h *closeHerdr) TabClose(_ context.Context, tabID string) error {
+	h.closed = append(h.closed, tabID)
+	return h.closeErr
+}


### PR DESCRIPTION
## Summary
- Add `prsync tabs --orphans --close-merged` to close merged-bucket orphan tabs from the tool's own classification, so operators never hand-copy a `tab_id` into `herdr tab close`.
- Dry-run by default (`would_close`); `--go` actually closes. Only the `merged` bucket is a candidate; `no_pr` tabs are never touched.
- Live close re-verifies each PR is still merged/closed, then maps `herdr tab close` outcomes to `closed` / `skipped_not_merged` / `skipped_not_found`.

Resolves #273

## Test plan
- [x] `TabClose` maps `tab_not_found` to `ErrTabNotFound`
- [x] `CloseMerged` dry-run `would_close`; live `closed`; skips `not_merged` and `not_found`; failure stops the batch
- [x] `--go` without `--close-merged` is usage; CLI dry-run does not invoke `herdr tab close`
- [x] `make check` is green (308 tests pass, lint/semgrep clean)