### PR TITLE
feat(devcheck): detect, run, and report with documented CLI flags

### DIFF
--- a/devtools/devcheck/cmd/devcheck/BUILD.bazel
+++ b/devtools/devcheck/cmd/devcheck/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//devtools/devcheck/internal/config:go_default_library",
         "//devtools/devcheck/internal/detector:go_default_library",
+        "//devtools/devcheck/internal/runner:go_default_library",
         "@com_github_jaeyeom_go_cmdexec//:go_default_library",
     ],
 )

--- a/devtools/devcheck/cmd/devcheck/main.go
+++ b/devtools/devcheck/cmd/devcheck/main.go
@@ -1,436 +1,184 @@
-// Package main provides a CLI tool for DevCheck project detection and tool execution demo.
+// Command devcheck detects repository context, runs format/lint/test tools, and
+// reports results for humans and AI agents.
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
-	"time"
 
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/detector"
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/runner"
 	executor "github.com/jaeyeom/go-cmdexec"
 )
 
 func main() {
-	var (
-		dir        string
-		demoMode   bool
-		concurrent bool
-		maxWorkers int
-	)
+	os.Exit(realMain())
+}
 
-	// Parse command line flags
-	flag.BoolVar(&demoMode, "demo", false, "Run tool executor demo")
-	flag.BoolVar(&concurrent, "concurrent", true, "Use concurrent execution in demo mode")
-	flag.IntVar(&maxWorkers, "max-workers", 3, "Maximum concurrent workers in demo mode")
-	flag.Parse()
-
-	// Get the directory to analyze
-	if flag.NArg() > 0 {
-		dir = flag.Arg(0)
-	} else {
-		// Use the original working directory when invoked with bazel run
-		if wd := os.Getenv("BUILD_WORKING_DIRECTORY"); wd != "" {
-			dir = wd
-		} else {
-			// Fallback to current directory
-			var err error
-			dir, err = os.Getwd()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error getting current directory: %v\n", err)
-				os.Exit(1)
-			}
-		}
-	}
-
-	// Run appropriate mode
-	var err error
-	if demoMode {
-		err = runExecutorDemo(dir, os.Stdout, concurrent, maxWorkers)
-	} else {
-		err = detectAndPrint(dir, os.Stdout)
-	}
-
+func realMain() int {
+	signalExec := executor.NewWithSignalHandling()
+	ctx, err := signalExec.Start()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return 1
+	}
+	defer signalExec.Stop()
+	return run(ctx, os.Args[1:], os.Stdout, os.Stderr, signalExec)
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer, exec executor.Executor) int {
+	opts, err := parseArgs(args, stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+
+	dir, err := resolveDir(opts.path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	project, err := detector.NewProjectDetector().Detect(dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: failed to detect project configuration: %v\n", err)
+		return 1
+	}
+
+	report, err := runner.Run(ctx, project, opts.options, exec)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
+	if err := runner.Write(stdout, opts.options.OutputFormat, report); err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
+	if report.Failed() {
+		return 1
+	}
+	return 0
+}
+
+type cliOptions struct {
+	options runner.Options
+	path    string
+}
+
+func parseArgs(args []string, stderr io.Writer) (cliOptions, error) {
+	fs := flag.NewFlagSet("devcheck", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, "Usage: devcheck [OPTIONS] [PATH]\n\n")
+		fmt.Fprintf(stderr, "Detect the repository context and run format, lint, and test tools.\n\n")
+		fmt.Fprintf(stderr, "Options:\n")
+		fs.PrintDefaults()
+	}
+
+	var opts cliOptions
+	var format string
+	var filters filterFlag
+	fs.BoolVar(&opts.options.DryRun, "dry-run", false, "Show what would be done without executing")
+	fs.BoolVar(&opts.options.DryRun, "n", false, "Show what would be done without executing")
+	fs.BoolVar(&opts.options.Verbose, "verbose", false, "Verbose output for debugging")
+	fs.BoolVar(&opts.options.Verbose, "v", false, "Verbose output for debugging")
+	fs.StringVar(&format, "format", string(runner.FormatPrompt), "Output format (prompt, summary, json)")
+	fs.Var(&filters, "filter", "Run only specific tool types (format, lint, test); repeatable or comma-separated")
+	fs.BoolVar(&opts.options.ChangedOnly, "changed-only", false, "Run only on changed files (requires git)")
+	fs.BoolVar(&opts.options.ForceFallback, "force-fallback", false, "Skip Bazel/Make and use language-specific tools")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return cliOptions{}, flag.ErrHelp
+		}
+		return cliOptions{}, fmt.Errorf("parse flags: %w", err)
+	}
+
+	outputFormat, err := parseOutputFormat(format)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return cliOptions{}, err
+	}
+	opts.options.OutputFormat = outputFormat
+	opts.options.Filters = []config.ToolType(filters)
+	if fs.NArg() > 1 {
+		err := fmt.Errorf("unexpected extra arguments: %s", strings.Join(fs.Args()[1:], " "))
+		fmt.Fprintln(stderr, err)
+		return cliOptions{}, err
+	}
+	if fs.NArg() == 1 {
+		opts.path = fs.Arg(0)
+	}
+	return opts, nil
+}
+
+func parseOutputFormat(raw string) (runner.OutputFormat, error) {
+	switch runner.OutputFormat(raw) {
+	case runner.FormatPrompt, runner.FormatSummary, runner.FormatJSON:
+		return runner.OutputFormat(raw), nil
+	default:
+		return "", fmt.Errorf("invalid format %q (want prompt, summary, or json)", raw)
 	}
 }
 
-// detectAndPrint runs project detection on the given directory and prints results to the writer.
-func detectAndPrint(dir string, w io.Writer) error {
-	// Create project detector
-	projectDetector := detector.NewProjectDetector()
-
-	// Run detection
-	projectConfig, err := projectDetector.Detect(dir)
-	if err != nil {
-		return fmt.Errorf("failed to detect project configuration: %w", err)
-	}
-
-	// Print results
-	fmt.Fprintf(w, "🔍 DevCheck Project Detection Results\n")
-	fmt.Fprintf(w, "=====================================\n\n")
-
-	// Path information
-	absPath, _ := filepath.Abs(dir)
-	fmt.Fprintf(w, "Path: %s\n", absPath)
-
-	// Languages
-	if len(projectConfig.Languages) > 0 {
-		var languages []string
-		for _, lang := range projectConfig.Languages {
-			languages = append(languages, string(lang))
-		}
-		sort.Strings(languages)
-		fmt.Fprintf(w, "Languages: %s\n", strings.Join(languages, ", "))
-	} else {
-		fmt.Fprintf(w, "Languages: none detected\n")
-	}
-
-	// Build system
-	fmt.Fprintf(w, "Build System: %s\n", projectConfig.BuildSystem)
-
-	// Git repository
-	if projectConfig.HasGit {
-		fmt.Fprintf(w, "Git Repository: yes\n")
-	} else {
-		fmt.Fprintf(w, "Git Repository: no\n")
-	}
-
-	// Tools
-	if len(projectConfig.Tools) > 0 {
-		fmt.Fprintf(w, "\nTools:\n")
-
-		// Sort tool types for consistent output
-		var toolTypes []string
-		for toolType := range projectConfig.Tools {
-			toolTypes = append(toolTypes, string(toolType))
-		}
-		sort.Strings(toolTypes)
-
-		for _, toolTypeStr := range toolTypes {
-			tools := projectConfig.Tools[config.ToolType(toolTypeStr)]
-			if len(tools) > 0 {
-				// Show only the first (highest priority) tool for simplicity
-				fmt.Fprintf(w, "  %s: %s\n", toolTypeStr, tools[0])
+func resolveDir(path string) (string, error) {
+	if path == "" {
+		if wd := os.Getenv("BUILD_WORKING_DIRECTORY"); wd != "" {
+			path = wd
+		} else {
+			wd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("get current directory: %w", err)
 			}
-		}
-	} else {
-		fmt.Fprintf(w, "\nTools: none detected\n")
-	}
-
-	// Configuration files
-	if len(projectConfig.ConfigFiles) > 0 {
-		fmt.Fprintf(w, "\nConfiguration Files:\n")
-
-		// Sort config files for consistent output
-		var tools []string
-		for tool := range projectConfig.ConfigFiles {
-			tools = append(tools, tool)
-		}
-		sort.Strings(tools)
-
-		for _, tool := range tools {
-			fmt.Fprintf(w, "  %s: %s\n", tool, projectConfig.ConfigFiles[tool])
+			path = wd
 		}
 	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	return abs, nil
+}
 
-	// Detection time
-	fmt.Fprintf(w, "\nDetection completed at: %s\n", projectConfig.DetectionTime.Format("2006-01-02 15:04:05"))
+type filterFlag []config.ToolType
 
+func (f *filterFlag) String() string {
+	parts := make([]string, len(*f))
+	for i, toolType := range *f {
+		parts[i] = string(toolType)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (f *filterFlag) Set(value string) error {
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		toolType, err := parseToolType(part)
+		if err != nil {
+			return err
+		}
+		*f = append(*f, toolType)
+	}
 	return nil
 }
 
-// runExecutorDemo demonstrates the tool executor framework capabilities.
-func runExecutorDemo(dir string, w io.Writer, concurrent bool, maxWorkers int) error {
-	printDemoHeader(w)
-
-	projectConfig, err := detectProject(dir, w)
-	if err != nil {
-		return err
+func parseToolType(raw string) (config.ToolType, error) {
+	switch config.ToolType(raw) {
+	case config.ToolTypeFormat, config.ToolTypeLint, config.ToolTypeTest:
+		return config.ToolType(raw), nil
+	default:
+		return "", fmt.Errorf("invalid filter %q (want format, lint, or test)", raw)
 	}
-
-	demoConfigs, err := prepareDemoConfigs(projectConfig, dir, executor.NewBasicExecutor())
-	if err != nil {
-		return err
-	}
-
-	if len(demoConfigs) == 0 {
-		fmt.Fprintf(w, "\nNo demo tools available to run.\n")
-		return nil
-	}
-
-	return executeDemoConfigs(demoConfigs, w, concurrent, maxWorkers)
-}
-
-func printDemoHeader(w io.Writer) {
-	fmt.Fprintf(w, "🚀 DevCheck Tool Executor Demo\n")
-	fmt.Fprintf(w, "==============================\n\n")
-}
-
-func detectProject(dir string, w io.Writer) (*config.ProjectConfig, error) {
-	projectDetector := detector.NewProjectDetector()
-	projectConfig, err := projectDetector.Detect(dir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to detect project: %w", err)
-	}
-
-	absPath, _ := filepath.Abs(dir)
-	fmt.Fprintf(w, "Path: %s\n", absPath)
-
-	showDetectedTools(w, projectConfig)
-	return projectConfig, nil
-}
-
-func showDetectedTools(w io.Writer, projectConfig *config.ProjectConfig) {
-	fmt.Fprintf(w, "\nDetected Tools:\n")
-	if len(projectConfig.Tools) > 0 {
-		for toolType, tools := range projectConfig.Tools {
-			if len(tools) > 0 {
-				fmt.Fprintf(w, "  %s: %s\n", toolType, tools[0])
-			}
-		}
-	}
-}
-
-func prepareDemoConfigs(projectConfig *config.ProjectConfig, dir string, exec executor.Executor) ([]executor.ToolConfig, error) {
-	var demoConfigs []executor.ToolConfig
-
-	// Add Bazel support
-	if projectConfig.BuildSystem == "bazel" && exec.IsAvailable("bazel") {
-		demoConfigs = append(demoConfigs, createBazelConfig(dir))
-	}
-
-	langConfigs := addLanguageSpecificTools(projectConfig, dir, exec)
-	demoConfigs = append(demoConfigs, langConfigs...)
-
-	// Add git status
-	if projectConfig.HasGit && exec.IsAvailable("git") {
-		demoConfigs = append(demoConfigs, createGitConfig(dir))
-	}
-
-	return demoConfigs, nil
-}
-
-func createBazelConfig(dir string) executor.ToolConfig {
-	return executor.ToolConfig{
-		Command:        "bazel",
-		Args:           []string{"info", "workspace"},
-		WorkingDir:     dir,
-		Timeout:        15 * time.Second,
-		CommandBuilder: &executor.ShellCommandBuilder{},
-	}
-}
-
-func createGitConfig(dir string) executor.ToolConfig {
-	return executor.ToolConfig{
-		Command:    "git",
-		Args:       []string{"status", "--short"},
-		WorkingDir: dir,
-	}
-}
-
-func addLanguageSpecificTools(projectConfig *config.ProjectConfig, dir string, basicExec executor.Executor) []executor.ToolConfig {
-	var configs []executor.ToolConfig
-
-	for _, lang := range projectConfig.Languages {
-		switch lang {
-		case config.LanguageGo:
-			configs = append(configs, addGoTools(projectConfig, dir, basicExec)...)
-		case config.LanguagePython:
-			configs = append(configs, addPythonTools(projectConfig, dir, basicExec)...)
-		}
-	}
-
-	return configs
-}
-
-func addGoTools(projectConfig *config.ProjectConfig, dir string, basicExec executor.Executor) []executor.ToolConfig {
-	var configs []executor.ToolConfig
-
-	if basicExec.IsAvailable("go") && hasDetectedTool(projectConfig, "go") {
-		configs = append(configs, executor.ToolConfig{
-			Command:    "go",
-			Args:       []string{"list", "./..."},
-			WorkingDir: dir,
-		})
-	}
-
-	if basicExec.IsAvailable("golangci-lint") && hasDetectedTool(projectConfig, "golangci-lint") {
-		configs = append(configs, executor.ToolConfig{
-			Command:    "golangci-lint",
-			Args:       []string{"run", "--timeout=30s", "./..."},
-			WorkingDir: dir,
-			Timeout:    45 * time.Second,
-		})
-	}
-
-	return configs
-}
-
-func hasDetectedTool(projectConfig *config.ProjectConfig, command string) bool {
-	if projectConfig == nil {
-		return false
-	}
-	for _, tools := range projectConfig.Tools {
-		for _, tool := range tools {
-			fields := strings.Fields(tool)
-			if len(fields) > 0 && fields[0] == command {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func addPythonTools(projectConfig *config.ProjectConfig, dir string, basicExec executor.Executor) []executor.ToolConfig {
-	var configs []executor.ToolConfig
-
-	if basicExec.IsAvailable("ruff") && hasDetectedTool(projectConfig, "ruff") && projectConfig.ConfigFiles["ruff"] != "" {
-		configs = append(configs, executor.ToolConfig{
-			Command:    "ruff",
-			Args:       []string{"check", "--statistics"},
-			WorkingDir: dir,
-			Timeout:    10 * time.Second,
-		})
-	}
-
-	return configs
-}
-
-func executeDemoConfigs(demoConfigs []executor.ToolConfig, w io.Writer, concurrent bool, maxWorkers int) error {
-	signalExecutor := executor.NewWithSignalHandling()
-	ctx, err := signalExecutor.Start()
-	if err != nil {
-		return fmt.Errorf("failed to start signal handler: %w", err)
-	}
-	defer signalExecutor.Stop()
-
-	if concurrent {
-		fmt.Fprintf(w, "\nRunning %d tools concurrently (max %d workers)...\n\n", len(demoConfigs), maxWorkers)
-		return runConcurrentDemo(ctx, w, signalExecutor, demoConfigs, maxWorkers)
-	}
-
-	fmt.Fprintf(w, "\nRunning %d tools sequentially...\n\n", len(demoConfigs))
-	return runSequentialDemo(ctx, w, signalExecutor, demoConfigs)
-}
-
-// runSequentialDemo runs tools one by one.
-func runSequentialDemo(ctx context.Context, w io.Writer, exec executor.Executor, configs []executor.ToolConfig) error {
-	startTime := time.Now()
-	successCount := 0
-
-	for i, cfg := range configs {
-		fmt.Fprintf(w, "[%d/%d] Running: %s %s\n", i+1, len(configs), cfg.Command, strings.Join(cfg.Args, " "))
-
-		cmdStart := time.Now()
-		result, err := exec.Execute(ctx, cfg)
-		duration := time.Since(cmdStart)
-
-		switch {
-		case err != nil:
-			fmt.Fprintf(w, "  ❌ ERROR: %v\n", err)
-		case result.ExitCode != 0:
-			fmt.Fprintf(w, "  ❌ FAILED (exit code %d)\n", result.ExitCode)
-			if result.Stderr != "" {
-				fmt.Fprintf(w, "  stderr: %s\n", strings.TrimSpace(result.Stderr))
-			}
-		default:
-			successCount++
-			fmt.Fprintf(w, "  ✅ SUCCESS (%v)\n", duration.Round(time.Millisecond))
-			if result.Output != "" {
-				fmt.Fprintf(w, "  output: %s\n", strings.TrimSpace(result.Output))
-			}
-		}
-		fmt.Fprintln(w)
-	}
-
-	totalDuration := time.Since(startTime)
-	fmt.Fprintf(w, "Summary: %d/%d tools passed (total time: %v)\n",
-		successCount, len(configs), totalDuration.Round(time.Millisecond))
-
-	return demoResultError(successCount, len(configs))
-}
-
-// runConcurrentDemo runs tools concurrently.
-func runConcurrentDemo(ctx context.Context, w io.Writer, exec executor.Executor, configs []executor.ToolConfig, maxWorkers int) error {
-	startTime := time.Now()
-
-	// Create concurrent executor
-	concurrentExec := executor.NewConcurrentExecutor(exec)
-	concurrentExec.SetMaxConcurrency(maxWorkers)
-
-	// Execute all tools concurrently
-	results, err := concurrentExec.ExecuteAll(ctx, configs)
-	if err != nil {
-		return fmt.Errorf("concurrent execution failed: %w", err)
-	}
-
-	// Process and display results
-	successCount := 0
-	fmt.Fprintf(w, "┌─────────────────────────────────┬─────────┬──────────┬───────────┐\n")
-	fmt.Fprintf(w, "│ Tool                            │ Status  │ Duration │ Exit Code │\n")
-	fmt.Fprintf(w, "├─────────────────────────────────┼─────────┼──────────┼───────────┤\n")
-
-	for _, res := range results {
-		cmd := res.Config.Command
-		if len(res.Config.Args) > 0 {
-			cmd = fmt.Sprintf("%s %s", cmd, strings.Join(res.Config.Args, " "))
-		}
-		if len(cmd) > 32 {
-			cmd = cmd[:29] + "..."
-		}
-
-		status := "✅ PASS"
-		exitCode := "0"
-		duration := "N/A"
-
-		if res.Error != nil {
-			status = "❌ ERROR"
-			exitCode = "N/A"
-		} else if res.Result != nil {
-			duration = res.Result.Duration().Round(time.Millisecond).String()
-			if res.Result.ExitCode != 0 {
-				status = "❌ FAIL"
-				exitCode = fmt.Sprintf("%d", res.Result.ExitCode)
-			} else {
-				successCount++
-			}
-		}
-
-		fmt.Fprintf(w, "│ %-31s │ %-7s │ %-8s │ %-9s │\n", cmd, status, duration, exitCode)
-	}
-
-	fmt.Fprintf(w, "└─────────────────────────────────┴─────────┴──────────┴───────────┘\n")
-
-	// Show error details for failed commands
-	for _, res := range results {
-		if res.Error != nil {
-			cmd := res.Config.Command
-			if len(res.Config.Args) > 0 {
-				cmd = fmt.Sprintf("%s %s", cmd, strings.Join(res.Config.Args, " "))
-			}
-			fmt.Fprintf(w, "\n❌ %s failed: %v\n", cmd, res.Error)
-		}
-	}
-
-	totalDuration := time.Since(startTime)
-	fmt.Fprintf(w, "\nSummary: %d/%d tools passed (total time: %v with concurrency)\n",
-		successCount, len(configs), totalDuration.Round(time.Millisecond))
-
-	return demoResultError(successCount, len(configs))
-}
-
-func demoResultError(successCount, total int) error {
-	if successCount < total {
-		return fmt.Errorf("%d/%d tools failed", total-successCount, total)
-	}
-	return nil
 }

--- a/devtools/devcheck/cmd/devcheck/main_test.go
+++ b/devtools/devcheck/cmd/devcheck/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,858 +14,229 @@ import (
 	executor "github.com/jaeyeom/go-cmdexec"
 )
 
-func TestDetectAndPrint(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "devcheck_cli_test")
-	if err != nil {
-		t.Fatal(err)
+func TestHelpListsDocumentedFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-h"}, &stdout, &stderr, executor.NewMockExecutor())
+	if code != 0 {
+		t.Fatalf("help exit = %d, want 0", code)
 	}
-	defer os.RemoveAll(tempDir)
-
-	tests := []struct {
-		name           string
-		files          []string
-		expectedOutput []string
-	}{
-		{
-			name:  "go project with bazel",
-			files: []string{"go.mod", "main.go", "MODULE.bazel"},
-			expectedOutput: []string{
-				"Languages: go",
-				"Build System: bazel",
-				"Tools:",
-				"  format: bazel run",
-				"  lint: bazel run",
-				"  test: bazel test",
-			},
-		},
-		{
-			name:  "python project",
-			files: []string{"pyproject.toml", "main.py", "requirements.txt"},
-			expectedOutput: []string{
-				"Languages: python",
-				"Build System: none",
-				"Tools:",
-				"  format: ruff format",
-				"  lint: ruff check",
-			},
-		},
-		{
-			name:  "mixed project with make",
-			files: []string{"go.mod", "main.go", "requirements.txt", "main.py", "Makefile"},
-			expectedOutput: []string{
-				"Languages: go, python",
-				"Build System: make",
-				"Tools:",
-				"  format: make format",
-				"  lint: make lint",
-				"  test: make test",
-			},
-		},
+	out := stdout.String() + stderr.String()
+	for _, name := range []string{
+		"-dry-run", "-n", "-verbose", "-v", "-filter", "-format", "-changed-only", "-force-fallback",
+	} {
+		if !strings.Contains(out, name) {
+			t.Errorf("help missing %s\n%s", name, out)
+		}
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create test directory
-			testDir := filepath.Join(tempDir, tt.name)
-			err := os.MkdirAll(testDir, 0o755)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Create test files
-			for _, file := range tt.files {
-				filePath := filepath.Join(testDir, file)
-				err := os.WriteFile(filePath, []byte("test content"), 0o600)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			// Capture output
-			var buf bytes.Buffer
-			err = detectAndPrint(testDir, &buf)
-			if err != nil {
-				t.Errorf("detectAndPrint() error = %v", err)
-				return
-			}
-
-			output := buf.String()
-
-			// Check that expected strings are in the output
-			for _, expected := range tt.expectedOutput {
-				if !strings.Contains(output, expected) {
-					t.Errorf("Expected output to contain %q, but got:\n%s", expected, output)
-				}
-			}
-		})
+	if strings.Contains(out, "-demo") {
+		t.Errorf("help still advertises -demo\n%s", out)
 	}
 }
 
-func TestDetectAndPrintInvalidPath(t *testing.T) {
-	var buf bytes.Buffer
-	err := detectAndPrint("/path/that/does/not/exist", &buf)
-	if err == nil {
-		t.Error("Expected error for non-existent path")
+func TestDryRunPrintsCommandsAndExitsZero(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "main.go", "MODULE.bazel")
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("bazel", true)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-n", dir}, &stdout, &stderr, mock)
+	if code != 0 {
+		t.Fatalf("dry-run exit = %d, stderr=%s", code, stderr.String())
 	}
-}
-
-func TestDetectAndPrintCurrentDirectory(t *testing.T) {
-	// Test that we can run detection on current directory without error
-	// Get current working directory for testing
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
+	if len(mock.CallHistory) != 0 {
+		t.Fatalf("dry-run executed %d commands", len(mock.CallHistory))
 	}
-
-	var buf bytes.Buffer
-	err = detectAndPrint(wd, &buf)
-	if err != nil {
-		t.Errorf("detectAndPrint() on current directory error = %v", err)
-	}
-
-	output := buf.String()
-	if output == "" {
-		t.Error("Expected some output for current directory")
-	}
-
-	// Should contain basic structure
-	if !strings.Contains(output, "Path:") {
-		t.Error("Expected output to contain 'Path:'")
-	}
-}
-
-// Test output formatting functions.
-func TestPrintDemoHeader(t *testing.T) {
-	var buf bytes.Buffer
-	printDemoHeader(&buf)
-	output := buf.String()
-
-	expectedStrings := []string{
-		"DevCheck Tool Executor Demo",
-		"==============================",
-	}
-
-	for _, expected := range expectedStrings {
-		if !strings.Contains(output, expected) {
-			t.Errorf("Expected output to contain %q, got:\n%s", expected, output)
+	out := stdout.String()
+	for _, want := range []string{
+		"bazel run //tools:format",
+		"bazel run //tools:lint",
+		"bazel test //...",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run missing %q\n%s", want, out)
 		}
 	}
 }
 
-func TestShowDetectedTools(t *testing.T) {
-	tests := []struct {
-		name           string
-		projectConfig  *config.ProjectConfig
-		expectedOutput []string
-	}{
-		{
-			name: "project with tools",
-			projectConfig: &config.ProjectConfig{
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeFormat: {"gofmt"},
-					config.ToolTypeLint:   {"golangci-lint"},
-				},
-			},
-			expectedOutput: []string{
-				"Detected Tools:",
-				"format: gofmt",
-				"lint: golangci-lint",
-			},
-		},
-		{
-			name: "project with no tools",
-			projectConfig: &config.ProjectConfig{
-				Tools: map[config.ToolType][]string{},
-			},
-			expectedOutput: []string{
-				"Detected Tools:",
-			},
-		},
+func TestFilterFormatRunsOnlyFormatters(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "main.go")
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("gofumpt", true)
+	mock.SetAvailableCommand("golangci-lint", true)
+	mock.SetAvailableCommand("go", true)
+	mock.ExpectCommand("gofumpt").
+		WillReturn(&executor.ExecutionResult{
+			Command: "gofumpt", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-filter=format", dir}, &stdout, &stderr, mock)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			showDetectedTools(&buf, tt.projectConfig)
-			output := buf.String()
-
-			for _, expected := range tt.expectedOutput {
-				if !strings.Contains(output, expected) {
-					t.Errorf("Expected output to contain %q, got:\n%s", expected, output)
-				}
-			}
-		})
+	commands := executedCommands(mock)
+	if len(commands) != 1 || commands[0] != "gofumpt" {
+		t.Fatalf("executed %v, want [gofumpt]", commands)
 	}
 }
 
-// Test configuration builder functions.
-func TestCreateBazelConfig(t *testing.T) {
-	dir := "/test/dir"
-	cfg := createBazelConfig(dir)
+func TestFormatJSONIsValidAndIncludesToolsAndIssues(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "main.go")
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("golangci-lint", true)
+	mock.ExpectCommand("golangci-lint").
+		WillReturn(&executor.ExecutionResult{
+			Command: "golangci-lint", ExitCode: 1, Output: golangciLintJSON,
+			StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
 
-	if cfg.Command != "bazel" {
-		t.Errorf("Expected command 'bazel', got %q", cfg.Command)
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-filter=lint", "-format=json", dir}, &stdout, &stderr, mock)
+	if code == 0 {
+		t.Fatal("lint failure exit = 0, want non-zero")
 	}
-
-	expectedArgs := []string{"info", "workspace"}
-	if len(cfg.Args) != len(expectedArgs) {
-		t.Fatalf("Expected %d args, got %d", len(expectedArgs), len(cfg.Args))
+	var payload struct {
+		Tools  []map[string]any `json:"tools"`
+		Issues []config.Issue   `json:"issues"`
 	}
-	for i, arg := range expectedArgs {
-		if cfg.Args[i] != arg {
-			t.Errorf("Expected arg[%d] = %q, got %q", i, arg, cfg.Args[i])
-		}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
 	}
-
-	if cfg.WorkingDir != dir {
-		t.Errorf("Expected WorkingDir %q, got %q", dir, cfg.WorkingDir)
+	if len(payload.Tools) == 0 {
+		t.Fatal("JSON tools is empty")
 	}
-
-	if cfg.Timeout != 15*time.Second {
-		t.Errorf("Expected timeout 15s, got %v", cfg.Timeout)
-	}
-}
-
-func TestCreateGitConfig(t *testing.T) {
-	dir := "/test/dir"
-	cfg := createGitConfig(dir)
-
-	if cfg.Command != "git" {
-		t.Errorf("Expected command 'git', got %q", cfg.Command)
-	}
-
-	expectedArgs := []string{"status", "--short"}
-	if len(cfg.Args) != len(expectedArgs) {
-		t.Fatalf("Expected %d args, got %d", len(expectedArgs), len(cfg.Args))
-	}
-	for i, arg := range expectedArgs {
-		if cfg.Args[i] != arg {
-			t.Errorf("Expected arg[%d] = %q, got %q", i, arg, cfg.Args[i])
-		}
-	}
-
-	if cfg.WorkingDir != dir {
-		t.Errorf("Expected WorkingDir %q, got %q", dir, cfg.WorkingDir)
+	if len(payload.Issues) != 1 || payload.Issues[0].FilePath != "broken.go" {
+		t.Fatalf("JSON issues = %+v, want broken.go", payload.Issues)
 	}
 }
 
-func TestAddGoTools(t *testing.T) {
-	detectedGoTools := map[config.ToolType][]string{
-		config.ToolTypeLint: {"golangci-lint"},
-		config.ToolTypeTest: {"go test"},
+func TestLintFixtureExitsNonZeroAndNamesFile(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "broken.go")
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("golangci-lint", true)
+	mock.ExpectCommand("golangci-lint").
+		WillReturn(&executor.ExecutionResult{
+			Command: "golangci-lint", ExitCode: 1, Output: golangciLintJSON,
+			StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-filter=lint", dir}, &stdout, &stderr, mock)
+	if code == 0 {
+		t.Fatal("lint fixture exit = 0, want non-zero")
 	}
-	tests := []struct {
-		name              string
-		tools             map[config.ToolType][]string
-		availableCommands map[string]bool
-		expectedCommands  []string
-		expectedArgs      [][]string
-	}{
-		{
-			name:  "all go tools available",
-			tools: detectedGoTools,
-			availableCommands: map[string]bool{
-				"go":            true,
-				"golangci-lint": true,
-			},
-			expectedCommands: []string{"go", "golangci-lint"},
-			expectedArgs: [][]string{
-				{"list", "./..."},
-				{"run", "--timeout=30s", "./..."},
-			},
-		},
-		{
-			name:  "only go available",
-			tools: detectedGoTools,
-			availableCommands: map[string]bool{
-				"go": true,
-			},
-			expectedCommands: []string{"go"},
-			expectedArgs:     [][]string{{"list", "./..."}},
-		},
-		{
-			name:              "no go tools available",
-			tools:             detectedGoTools,
-			availableCommands: map[string]bool{},
-			expectedCommands:  []string{},
-		},
-		{
-			name: "available binaries not in detected tools",
-			tools: map[config.ToolType][]string{
-				config.ToolTypeFormat: {"gofumpt"},
-			},
-			availableCommands: map[string]bool{
-				"go":            true,
-				"golangci-lint": true,
-			},
-			expectedCommands: []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockExec := executor.NewMockExecutor()
-			for cmd, available := range tt.availableCommands {
-				mockExec.SetAvailableCommand(cmd, available)
-			}
-
-			projectConfig := &config.ProjectConfig{
-				Languages: []config.Language{config.LanguageGo},
-				Tools:     tt.tools,
-			}
-			configs := addGoTools(projectConfig, "/test/dir", mockExec)
-
-			if len(configs) != len(tt.expectedCommands) {
-				t.Fatalf("Expected %d configs, got %d", len(tt.expectedCommands), len(configs))
-			}
-
-			for i, expectedCmd := range tt.expectedCommands {
-				if configs[i].Command != expectedCmd {
-					t.Errorf("Expected command[%d] = %q, got %q", i, expectedCmd, configs[i].Command)
-				}
-				if configs[i].WorkingDir != "/test/dir" {
-					t.Errorf("Expected WorkingDir '/test/dir', got %q", configs[i].WorkingDir)
-				}
-			}
-			assertGoPackagePath(t, configs, tt.expectedArgs)
-		})
+	if !strings.Contains(stdout.String(), "broken.go") {
+		t.Errorf("prompt missing broken.go\n%s", stdout.String())
 	}
 }
 
-func assertGoPackagePath(t *testing.T, configs []executor.ToolConfig, expectedArgs [][]string) {
+func TestChangedOnlyWithoutGitErrors(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "main.go")
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("gofumpt", true)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-changed-only", "-filter=format", dir}, &stdout, &stderr, mock)
+	if code == 0 {
+		t.Fatal("exit = 0, want non-zero without git")
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()+stdout.String()), "git") {
+		t.Errorf("error should mention git: %s%s", stdout.String(), stderr.String())
+	}
+}
+
+func TestInvalidFilter(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-filter=docs"}, &stdout, &stderr, executor.NewMockExecutor())
+	if code == 0 {
+		t.Fatal("invalid filter exit = 0")
+	}
+}
+
+func TestInvalidFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-format=xml"}, &stdout, &stderr, executor.NewMockExecutor())
+	if code == 0 {
+		t.Fatal("invalid format exit = 0")
+	}
+}
+
+func TestFilterRepeatableAndCommaSeparated(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "main.go")
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("gofumpt", true)
+	mock.SetAvailableCommand("golangci-lint", true)
+	mock.SetDefaultBehavior(&executor.ExecutionResult{
+		Command: "ok", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now(),
+	}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-filter=format,lint", dir}, &stdout, &stderr, mock)
+	if code != 0 {
+		t.Fatalf("comma filter exit = %d, stderr=%s", code, stderr.String())
+	}
+	got := executedCommands(mock)
+	if !contains(got, "gofumpt") || !contains(got, "golangci-lint") || contains(got, "go") {
+		t.Errorf("executed %v, want gofumpt and golangci-lint only", got)
+	}
+
+	mock2 := executor.NewMockExecutor()
+	mock2.SetAvailableCommand("gofumpt", true)
+	mock2.SetAvailableCommand("golangci-lint", true)
+	mock2.SetDefaultBehavior(&executor.ExecutionResult{
+		Command: "ok", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now(),
+	}, nil)
+	stdout.Reset()
+	stderr.Reset()
+	code = run(context.Background(), []string{"-filter=format", "-filter=lint", dir}, &stdout, &stderr, mock2)
+	if code != 0 {
+		t.Fatalf("repeatable filter exit = %d, stderr=%s", code, stderr.String())
+	}
+	got = executedCommands(mock2)
+	if !contains(got, "gofumpt") || !contains(got, "golangci-lint") {
+		t.Errorf("repeatable executed %v", got)
+	}
+}
+
+const golangciLintJSON = `{
+  "Issues": [
+    {
+      "FromLinter": "gosec",
+      "Text": "Potential file inclusion via variable",
+      "Severity": "error",
+      "Pos": {"Filename": "broken.go", "Line": 3, "Column": 10}
+    }
+  ]
+}`
+
+func fixtureDir(t *testing.T, files ...string) string {
 	t.Helper()
-	for i, cfg := range configs {
-		for _, arg := range cfg.Args {
-			if strings.Contains(arg, "devtools/devcheck") {
-				t.Errorf("command %s arg %q is hardcoded to this repository", cfg.Command, arg)
-			}
+	dir := t.TempDir()
+	for _, file := range files {
+		path := filepath.Join(dir, file)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
 		}
-		if i < len(expectedArgs) {
-			if !equalStrings(cfg.Args, expectedArgs[i]) {
-				t.Errorf("command %s args = %q, want %q", cfg.Command, cfg.Args, expectedArgs[i])
-			}
+		if err := os.WriteFile(path, []byte("module fixture\n"), 0o600); err != nil {
+			t.Fatal(err)
 		}
 	}
+	return dir
 }
 
-func equalStrings(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
+func executedCommands(mock *executor.MockExecutor) []string {
+	var commands []string
+	for _, call := range mock.GetCallHistory() {
+		commands = append(commands, call.Config.Command)
 	}
-	for i := range got {
-		if got[i] != want[i] {
-			return false
+	return commands
+}
+
+func contains(got []string, want string) bool {
+	for _, g := range got {
+		if g == want {
+			return true
 		}
 	}
-	return true
-}
-
-func TestAddPythonTools(t *testing.T) {
-	tests := []struct {
-		name              string
-		projectConfig     *config.ProjectConfig
-		availableCommands map[string]bool
-		expectedCommands  []string
-	}{
-		{
-			name: "ruff available with config",
-			projectConfig: &config.ProjectConfig{
-				ConfigFiles: map[string]string{
-					"ruff": "pyproject.toml",
-				},
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeLint: {"ruff check"},
-				},
-			},
-			availableCommands: map[string]bool{
-				"ruff": true,
-			},
-			expectedCommands: []string{"ruff"},
-		},
-		{
-			name: "ruff available with config but not in detected tools",
-			projectConfig: &config.ProjectConfig{
-				ConfigFiles: map[string]string{
-					"ruff": "pyproject.toml",
-				},
-			},
-			availableCommands: map[string]bool{
-				"ruff": true,
-			},
-			expectedCommands: []string{},
-		},
-		{
-			name: "ruff available but no config",
-			projectConfig: &config.ProjectConfig{
-				ConfigFiles: map[string]string{},
-			},
-			availableCommands: map[string]bool{
-				"ruff": true,
-			},
-			expectedCommands: []string{},
-		},
-		{
-			name: "ruff not available",
-			projectConfig: &config.ProjectConfig{
-				ConfigFiles: map[string]string{
-					"ruff": "pyproject.toml",
-				},
-			},
-			availableCommands: map[string]bool{},
-			expectedCommands:  []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockExec := executor.NewMockExecutor()
-			for cmd, available := range tt.availableCommands {
-				mockExec.SetAvailableCommand(cmd, available)
-			}
-
-			configs := addPythonTools(tt.projectConfig, "/test/dir", mockExec)
-
-			if len(configs) != len(tt.expectedCommands) {
-				t.Fatalf("Expected %d configs, got %d", len(tt.expectedCommands), len(configs))
-			}
-
-			for i, expectedCmd := range tt.expectedCommands {
-				if configs[i].Command != expectedCmd {
-					t.Errorf("Expected command[%d] = %q, got %q", i, expectedCmd, configs[i].Command)
-				}
-			}
-		})
-	}
-}
-
-func TestAddLanguageSpecificTools(t *testing.T) {
-	tests := []struct {
-		name              string
-		languages         []config.Language
-		availableCommands map[string]bool
-		expectedCommands  []string
-	}{
-		{
-			name:      "go project",
-			languages: []config.Language{config.LanguageGo},
-			availableCommands: map[string]bool{
-				"go": true,
-			},
-			expectedCommands: []string{"go"},
-		},
-		{
-			name:      "python project",
-			languages: []config.Language{config.LanguagePython},
-			availableCommands: map[string]bool{
-				"ruff": true,
-			},
-			expectedCommands: []string{},
-		},
-		{
-			name:      "multi-language project",
-			languages: []config.Language{config.LanguageGo, config.LanguagePython},
-			availableCommands: map[string]bool{
-				"go": true,
-			},
-			expectedCommands: []string{"go"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockExec := executor.NewMockExecutor()
-			for cmd, available := range tt.availableCommands {
-				mockExec.SetAvailableCommand(cmd, available)
-			}
-
-			projectConfig := &config.ProjectConfig{
-				Languages:   tt.languages,
-				ConfigFiles: map[string]string{},
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeTest: {"go test"},
-				},
-			}
-
-			configs := addLanguageSpecificTools(projectConfig, "/test/dir", mockExec)
-
-			if len(configs) != len(tt.expectedCommands) {
-				t.Fatalf("Expected %d configs, got %d", len(tt.expectedCommands), len(configs))
-			}
-
-			for i, expectedCmd := range tt.expectedCommands {
-				if configs[i].Command != expectedCmd {
-					t.Errorf("Expected command[%d] = %q, got %q", i, expectedCmd, configs[i].Command)
-				}
-			}
-		})
-	}
-}
-
-func TestPrepareDemoConfigs(t *testing.T) {
-	tests := []struct {
-		name              string
-		projectConfig     *config.ProjectConfig
-		availableCommands map[string]bool
-		expectedCommands  []string
-	}{
-		{
-			name: "bazel project with git",
-			projectConfig: &config.ProjectConfig{
-				BuildSystem: "bazel",
-				HasGit:      true,
-				Languages:   []config.Language{},
-			},
-			availableCommands: map[string]bool{
-				"bazel": true,
-				"git":   true,
-			},
-			expectedCommands: []string{"bazel", "git"},
-		},
-		{
-			name: "go project with git",
-			projectConfig: &config.ProjectConfig{
-				BuildSystem: "none",
-				HasGit:      true,
-				Languages:   []config.Language{config.LanguageGo},
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeTest: {"go test"},
-				},
-			},
-			availableCommands: map[string]bool{
-				"go":  true,
-				"git": true,
-			},
-			expectedCommands: []string{"go", "git"},
-		},
-		{
-			name: "project without git",
-			projectConfig: &config.ProjectConfig{
-				BuildSystem: "none",
-				HasGit:      false,
-				Languages:   []config.Language{config.LanguageGo},
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeTest: {"go test"},
-				},
-			},
-			availableCommands: map[string]bool{
-				"go": true,
-			},
-			expectedCommands: []string{"go"},
-		},
-		{
-			name: "no available tools",
-			projectConfig: &config.ProjectConfig{
-				BuildSystem: "bazel",
-				HasGit:      true,
-				Languages:   []config.Language{config.LanguageGo},
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeTest: {"go test"},
-				},
-			},
-			availableCommands: map[string]bool{},
-			expectedCommands:  []string{},
-		},
-		{
-			name: "detected go tools omitted when binaries missing",
-			projectConfig: &config.ProjectConfig{
-				BuildSystem: "none",
-				HasGit:      false,
-				Languages:   []config.Language{config.LanguageGo},
-				Tools: map[config.ToolType][]string{
-					config.ToolTypeLint: {"golangci-lint"},
-					config.ToolTypeTest: {"go test"},
-				},
-			},
-			availableCommands: map[string]bool{
-				"git": true,
-			},
-			expectedCommands: []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockExec := executor.NewMockExecutor()
-			for cmd, available := range tt.availableCommands {
-				mockExec.SetAvailableCommand(cmd, available)
-			}
-
-			configs, err := prepareDemoConfigs(tt.projectConfig, "/test/dir", mockExec)
-			if err != nil {
-				t.Fatalf("prepareDemoConfigs failed: %v", err)
-			}
-
-			if len(configs) != len(tt.expectedCommands) {
-				t.Fatalf("Expected %d configs, got %d (%v)", len(tt.expectedCommands), len(configs), commandNames(configs))
-			}
-
-			for i, expectedCmd := range tt.expectedCommands {
-				if configs[i].Command != expectedCmd {
-					t.Errorf("Expected command[%d] = %q, got %q", i, expectedCmd, configs[i].Command)
-				}
-				if configs[i].WorkingDir != "/test/dir" {
-					t.Errorf("Expected WorkingDir '/test/dir', got %q", configs[i].WorkingDir)
-				}
-			}
-			for _, cfg := range configs {
-				for _, arg := range cfg.Args {
-					if strings.Contains(arg, "devtools/devcheck") {
-						t.Errorf("command %s arg %q is hardcoded to this repository", cfg.Command, arg)
-					}
-				}
-			}
-		})
-	}
-}
-
-func commandNames(configs []executor.ToolConfig) []string {
-	names := make([]string, len(configs))
-	for i, cfg := range configs {
-		names[i] = cfg.Command
-	}
-	return names
-}
-
-// Test sequential demo execution.
-func TestRunSequentialDemo(t *testing.T) {
-	tests := []struct {
-		name            string
-		configs         []executor.ToolConfig
-		mockResults     []*executor.ExecutionResult
-		mockErrors      []error
-		expectedSuccess int
-		wantErr         bool
-		expectedOutput  []string
-	}{
-		{
-			name: "all tools succeed",
-			configs: []executor.ToolConfig{
-				{Command: "tool1", Args: []string{"arg1"}},
-				{Command: "tool2", Args: []string{"arg2"}},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "tool1", ExitCode: 0, Output: "success1", StartTime: time.Now(), EndTime: time.Now()},
-				{Command: "tool2", ExitCode: 0, Output: "success2", StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil, nil},
-			expectedSuccess: 2,
-			expectedOutput:  []string{"SUCCESS", "tool1", "tool2", "2/2"},
-		},
-		{
-			name: "one tool fails",
-			configs: []executor.ToolConfig{
-				{Command: "tool1"},
-				{Command: "tool2"},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "tool1", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now()},
-				{Command: "tool2", ExitCode: 1, Stderr: "error message", StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil, nil},
-			expectedSuccess: 1,
-			wantErr:         true,
-			expectedOutput:  []string{"SUCCESS", "FAILED", "exit code 1", "1/2"},
-		},
-		{
-			name: "execution error",
-			configs: []executor.ToolConfig{
-				{Command: "tool1"},
-			},
-			mockResults: []*executor.ExecutionResult{
-				nil,
-			},
-			mockErrors:      []error{fmt.Errorf("execution failed")},
-			expectedSuccess: 0,
-			wantErr:         true,
-			expectedOutput:  []string{"ERROR", "execution failed", "0/1"},
-		},
-		{
-			name: "mixed results",
-			configs: []executor.ToolConfig{
-				{Command: "tool1"},
-				{Command: "tool2"},
-				{Command: "tool3"},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "tool1", ExitCode: 0, Output: "ok", StartTime: time.Now(), EndTime: time.Now()},
-				nil,
-				{Command: "tool3", ExitCode: 1, Stderr: "failed", StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil, fmt.Errorf("error"), nil},
-			expectedSuccess: 1,
-			wantErr:         true,
-			expectedOutput:  []string{"SUCCESS", "ERROR", "FAILED", "1/3"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockExec := executor.NewMockExecutor()
-
-			// Set up expectations
-			for i, cfg := range tt.configs {
-				mockExec.ExpectCommand(cfg.Command).
-					WillReturn(tt.mockResults[i], tt.mockErrors[i]).
-					Once().
-					Build()
-			}
-
-			var buf bytes.Buffer
-			ctx := context.Background()
-
-			err := runSequentialDemo(ctx, &buf, mockExec, tt.configs)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("runSequentialDemo() error = nil, want failure")
-				}
-			} else if err != nil {
-				t.Fatalf("runSequentialDemo() unexpected error: %v", err)
-			}
-
-			output := buf.String()
-
-			// Verify expected outputs
-			for _, expected := range tt.expectedOutput {
-				if !strings.Contains(output, expected) {
-					t.Errorf("Expected output to contain %q, got:\n%s", expected, output)
-				}
-			}
-		})
-	}
-}
-
-// Test concurrent demo execution.
-func TestRunConcurrentDemo(t *testing.T) {
-	tests := []struct {
-		name            string
-		configs         []executor.ToolConfig
-		mockResults     []*executor.ExecutionResult
-		mockErrors      []error
-		maxWorkers      int
-		expectedSuccess int
-		wantErr         bool
-		expectedOutput  []string
-	}{
-		{
-			name: "all tools succeed",
-			configs: []executor.ToolConfig{
-				{Command: "tool1", Args: []string{"arg1"}},
-				{Command: "tool2", Args: []string{"arg2"}},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "tool1", ExitCode: 0, Output: "success1", StartTime: time.Now(), EndTime: time.Now()},
-				{Command: "tool2", ExitCode: 0, Output: "success2", StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil, nil},
-			maxWorkers:      2,
-			expectedSuccess: 2,
-			expectedOutput:  []string{"PASS", "tool1", "tool2", "2/2"},
-		},
-		{
-			name: "one tool fails",
-			configs: []executor.ToolConfig{
-				{Command: "tool1"},
-				{Command: "tool2"},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "tool1", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now()},
-				{Command: "tool2", ExitCode: 1, Stderr: "error", StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil, nil},
-			maxWorkers:      2,
-			expectedSuccess: 1,
-			wantErr:         true,
-			expectedOutput:  []string{"PASS", "FAIL", "1/2"},
-		},
-		{
-			name: "execution error",
-			configs: []executor.ToolConfig{
-				{Command: "tool1"},
-			},
-			mockResults: []*executor.ExecutionResult{
-				nil,
-			},
-			mockErrors:      []error{fmt.Errorf("execution failed")},
-			maxWorkers:      1,
-			expectedSuccess: 0,
-			wantErr:         true,
-			expectedOutput:  []string{"ERROR", "execution failed", "0/1"},
-		},
-		{
-			name: "command at 31 chars not truncated",
-			configs: []executor.ToolConfig{
-				{Command: "cmd", Args: []string{"with", "args", "exactly", "31"}},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "cmd", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil},
-			maxWorkers:      1,
-			expectedSuccess: 1,
-			expectedOutput:  []string{"PASS", "cmd with args exactly 31", "1/1"},
-		},
-		{
-			name: "command at 32 chars overflows column",
-			configs: []executor.ToolConfig{
-				// This command is exactly 32 chars: "cmd with args exactly thirtytwo"
-				{Command: "cmd", Args: []string{"with", "args", "exactly", "thirtytwo"}},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "cmd", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil},
-			maxWorkers:      1,
-			expectedSuccess: 1,
-			// Note: This will overflow the 31-char column width (bug in implementation)
-			expectedOutput: []string{"PASS", "cmd with args exactly thirtytwo", "1/1"},
-		},
-		{
-			name: "command over 32 chars gets truncated",
-			configs: []executor.ToolConfig{
-				{Command: "very-long-command-name-that-exceeds", Args: []string{"the", "thirty-two", "character", "limit"}},
-			},
-			mockResults: []*executor.ExecutionResult{
-				{Command: "very-long-command-name-that-exceeds", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now()},
-			},
-			mockErrors:      []error{nil},
-			maxWorkers:      1,
-			expectedSuccess: 1,
-			expectedOutput:  []string{"PASS", "very-long-command-name-that-e...", "1/1"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockExec := executor.NewMockExecutor()
-
-			// Set up expectations
-			for i, cfg := range tt.configs {
-				mockExec.ExpectCommand(cfg.Command).
-					WillReturn(tt.mockResults[i], tt.mockErrors[i]).
-					Once().
-					Build()
-			}
-
-			var buf bytes.Buffer
-			ctx := context.Background()
-
-			err := runConcurrentDemo(ctx, &buf, mockExec, tt.configs, tt.maxWorkers)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("runConcurrentDemo() error = nil, want failure")
-				}
-			} else if err != nil {
-				t.Fatalf("runConcurrentDemo() unexpected error: %v", err)
-			}
-
-			output := buf.String()
-
-			// Verify expected outputs
-			for _, expected := range tt.expectedOutput {
-				if !strings.Contains(output, expected) {
-					t.Errorf("Expected output to contain %q, got:\n%s", expected, output)
-				}
-			}
-		})
-	}
+	return false
 }

--- a/devtools/devcheck/internal/runner/BUILD.bazel
+++ b/devtools/devcheck/internal/runner/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "format.go",
+        "parse.go",
+        "plan.go",
+        "run.go",
+    ],
+    importpath = "github.com/jaeyeom/experimental/devtools/devcheck/internal/runner",
+    visibility = ["//devtools/devcheck:__subpackages__"],
+    deps = [
+        "//devtools/devcheck/internal/config:go_default_library",
+        "@com_github_jaeyeom_go_cmdexec//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "format_test.go",
+        "parse_test.go",
+        "plan_test.go",
+        "run_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//devtools/devcheck/internal/config:go_default_library",
+        "@com_github_jaeyeom_go_cmdexec//:go_default_library",
+    ],
+)

--- a/devtools/devcheck/internal/runner/format.go
+++ b/devtools/devcheck/internal/runner/format.go
@@ -1,0 +1,354 @@
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+)
+
+type jsonDocument struct {
+	RootPath    string             `json:"rootPath"`
+	BuildSystem config.BuildSystem `json:"buildSystem"`
+	Languages   []config.Language  `json:"languages"`
+	Tools       []jsonTool         `json:"tools"`
+	Issues      []config.Issue     `json:"issues"`
+	Failed      bool               `json:"failed"`
+	DryRun      bool               `json:"dryRun"`
+}
+
+type jsonTool struct {
+	Type      config.ToolType `json:"type"`
+	Command   string          `json:"command"`
+	Args      []string        `json:"args"`
+	Status    string          `json:"status"`
+	ExitCode  *int            `json:"exitCode,omitempty"`
+	Duration  string          `json:"duration,omitempty"`
+	RawOutput string          `json:"rawOutput,omitempty"`
+}
+
+// Write renders a report in the requested format.
+func Write(w io.Writer, format OutputFormat, report *Report) error {
+	if report == nil {
+		return fmt.Errorf("report is required")
+	}
+	switch format {
+	case FormatPrompt, "":
+		return writePrompt(w, report)
+	case FormatSummary:
+		return writeSummary(w, report)
+	case FormatJSON:
+		return writeJSON(w, report)
+	default:
+		return fmt.Errorf("unknown output format %q (want prompt, summary, or json)", format)
+	}
+}
+
+func writePrompt(w io.Writer, report *Report) error {
+	if err := writePromptHeader(w, report); err != nil {
+		return err
+	}
+	if err := writePromptTools(w, report); err != nil {
+		return err
+	}
+	if err := writePromptIssues(w, report); err != nil {
+		return err
+	}
+	if err := writePromptNextSteps(w, report); err != nil {
+		return err
+	}
+	return writePromptStatus(w, report)
+}
+
+func writePromptHeader(w io.Writer, report *Report) error {
+	if _, err := fmt.Fprintln(w, "🔧 DevCheck Report"); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, "Repository Analysis:"); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	project := report.Project
+	build := "none"
+	if project != nil && project.BuildSystem != "" {
+		build = string(project.BuildSystem)
+	}
+	if _, err := fmt.Fprintf(w, "- Build System: %s\n", build); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "- Languages: %s\n", languageList(project)); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "- Strategy: %s\n\n", strategyLine(project, report)); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+func writePromptTools(w io.Writer, report *Report) error {
+	heading := "Tools Executed:"
+	if report.DryRun {
+		heading = "Tools that would run:"
+	}
+	if _, err := fmt.Fprintln(w, heading); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if len(report.Tools) == 0 {
+		if _, err := fmt.Fprintln(w, "none"); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+		return nil
+	}
+	for _, tool := range report.Tools {
+		if _, err := fmt.Fprintf(w, "%s %s - %s\n", toolMark(tool), tool.Tool.Display(), toolSummary(tool)); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+		if tool.RawOutput != "" {
+			if _, err := fmt.Fprintf(w, "   output: %s\n", truncate(tool.RawOutput, 400)); err != nil {
+				return fmt.Errorf("write report: %w", err)
+			}
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+func writePromptIssues(w io.Writer, report *Report) error {
+	if _, err := fmt.Fprintln(w, "Issues Found:"); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if len(report.Issues) == 0 {
+		if _, err := fmt.Fprintln(w, "none"); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+		return nil
+	}
+	for _, issue := range report.Issues {
+		if _, err := fmt.Fprintf(w, "📍 %s\n", formatIssue(issue)); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+func writePromptNextSteps(w io.Writer, report *Report) error {
+	if _, err := fmt.Fprintln(w, "Next Steps for AI Agent:"); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	steps := nextSteps(report)
+	for i, step := range steps {
+		if _, err := fmt.Fprintf(w, "%d. %s\n", i+1, step); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+func writePromptStatus(w io.Writer, report *Report) error {
+	status := "Status: ✅ All checks passed"
+	if report.DryRun {
+		status = "Status: dry-run (commands were not executed)"
+	} else if report.Failed() {
+		status = fmt.Sprintf("Status: 🚨 Requires attention (%d issue", len(report.Issues))
+		if len(report.Issues) != 1 {
+			status += "s"
+		}
+		status += ")"
+	}
+	if _, err := fmt.Fprintln(w, status); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+func writeSummary(w io.Writer, report *Report) error {
+	passed, failed := 0, 0
+	for _, tool := range report.Tools {
+		if toolFailed(tool) {
+			failed++
+			continue
+		}
+		passed++
+	}
+	if _, err := fmt.Fprintf(w, "DevCheck: %d passed, %d failed\n", passed, failed); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	for _, tool := range report.Tools {
+		mark := "ok"
+		if tool.DryRun {
+			mark = "dry-run"
+		} else if toolFailed(tool) {
+			mark = "FAIL"
+		}
+		if _, err := fmt.Fprintf(w, "  %s %s\n", mark, tool.Tool.Display()); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeJSON(w io.Writer, report *Report) error {
+	doc := jsonDocument{
+		Issues: report.Issues,
+		Failed: report.Failed(),
+		DryRun: report.DryRun,
+	}
+	if report.Project != nil {
+		doc.RootPath = report.Project.RootPath
+		doc.BuildSystem = report.Project.BuildSystem
+		doc.Languages = report.Project.Languages
+	}
+	if doc.Issues == nil {
+		doc.Issues = []config.Issue{}
+	}
+	for _, tool := range report.Tools {
+		doc.Tools = append(doc.Tools, toJSONTool(tool))
+	}
+	if doc.Tools == nil {
+		doc.Tools = []jsonTool{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return fmt.Errorf("encode JSON report: %w", err)
+	}
+	return nil
+}
+
+func toJSONTool(tool ToolResult) jsonTool {
+	item := jsonTool{
+		Type:      tool.Tool.Type,
+		Command:   tool.Tool.Config.Command,
+		Args:      tool.Tool.Config.Args,
+		Status:    jsonStatus(tool),
+		RawOutput: tool.RawOutput,
+	}
+	if tool.Result != nil {
+		code := tool.Result.ExitCode
+		item.ExitCode = &code
+		item.Duration = tool.Result.Duration().String()
+	}
+	return item
+}
+
+func jsonStatus(tool ToolResult) string {
+	switch {
+	case tool.DryRun:
+		return "dry-run"
+	case tool.Error != nil:
+		return "error"
+	case tool.Result != nil && tool.Result.ExitCode != 0:
+		return "failed"
+	default:
+		return "passed"
+	}
+}
+
+func languageList(project *config.ProjectConfig) string {
+	if project == nil || len(project.Languages) == 0 {
+		return "none detected"
+	}
+	names := make([]string, len(project.Languages))
+	for i, lang := range project.Languages {
+		names[i] = string(lang)
+	}
+	return strings.Join(names, ", ")
+}
+
+func strategyLine(project *config.ProjectConfig, report *Report) string {
+	if report.DryRun {
+		return "Dry-run; commands were not executed"
+	}
+	if project == nil {
+		return "Language-specific tools"
+	}
+	switch project.BuildSystem {
+	case config.BuildSystemBazel:
+		return "Using bazel-based tools for consistency"
+	case config.BuildSystemMake:
+		return "Using make-based tools for consistency"
+	default:
+		return "Using language-specific tools"
+	}
+}
+
+func toolMark(tool ToolResult) string {
+	switch {
+	case tool.DryRun:
+		return "⏳"
+	case toolFailed(tool):
+		return "❌"
+	default:
+		return "✅"
+	}
+}
+
+func toolSummary(tool ToolResult) string {
+	switch {
+	case tool.DryRun:
+		return "would run"
+	case tool.Error != nil:
+		return tool.Error.Error()
+	case len(tool.Issues) == 1:
+		return "Found 1 issue requiring attention"
+	case len(tool.Issues) > 1:
+		return fmt.Sprintf("Found %d issues requiring attention", len(tool.Issues))
+	case tool.Result != nil && tool.Result.ExitCode != 0:
+		return fmt.Sprintf("exit code %d", tool.Result.ExitCode)
+	default:
+		return "succeeded"
+	}
+}
+
+func formatIssue(issue config.Issue) string {
+	loc := issue.FilePath
+	if issue.Line > 0 {
+		loc = fmt.Sprintf("%s:%d", loc, issue.Line)
+		if issue.Column > 0 {
+			loc = fmt.Sprintf("%s:%d", loc, issue.Column)
+		}
+	}
+	code := issue.Code
+	if code == "" {
+		code = issue.ToolName
+	}
+	return fmt.Sprintf("%s - %s: %s", loc, code, issue.Message)
+}
+
+func nextSteps(report *Report) []string {
+	if report.DryRun {
+		return []string{"Re-run without --dry-run to execute the selected tools"}
+	}
+	if !report.Failed() {
+		return []string{"No action required"}
+	}
+	var steps []string
+	for _, issue := range report.Issues {
+		steps = append(steps, fmt.Sprintf("Fix %s in %s", issue.Code, issue.String()))
+	}
+	if len(steps) == 0 {
+		steps = append(steps, "Inspect failed tool output and fix the reported problems")
+	}
+	steps = append(steps, "Re-run devcheck after fixing to confirm the issues are resolved")
+	return steps
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/devtools/devcheck/internal/runner/format_test.go
+++ b/devtools/devcheck/internal/runner/format_test.go
@@ -1,0 +1,158 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestWrite_PromptIncludesIssueLocationAndNextSteps(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatPrompt, lintFailureReport()); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"DevCheck Report",
+		"Build System: make",
+		"Languages: go",
+		"broken.go:3",
+		"gosec",
+		"Next Steps",
+		"Requires attention",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("prompt missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestWrite_JSONIncludesToolsAndIssues(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatJSON, lintFailureReport()); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	var payload jsonReport
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if len(payload.Tools) == 0 {
+		t.Fatal("JSON tools is empty")
+	}
+	if len(payload.Issues) != 1 {
+		t.Fatalf("JSON issues = %d, want 1", len(payload.Issues))
+	}
+	if payload.Issues[0].FilePath != "broken.go" {
+		t.Errorf("issue filePath = %q, want broken.go", payload.Issues[0].FilePath)
+	}
+	if !payload.Failed {
+		t.Error("JSON failed = false, want true")
+	}
+}
+
+func TestWrite_SummaryListsCommands(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatSummary, lintFailureReport()); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "golangci-lint") {
+		t.Errorf("summary missing command\n%s", out)
+	}
+	if !strings.Contains(out, "failed") && !strings.Contains(out, "FAIL") {
+		t.Errorf("summary missing failure status\n%s", out)
+	}
+}
+
+func TestWrite_DryRunPrintsCommands(t *testing.T) {
+	report := &Report{
+		Project: &config.ProjectConfig{
+			BuildSystem: config.BuildSystemBazel,
+			Languages:   []config.Language{config.LanguageGo},
+		},
+		DryRun: true,
+		Tools: []ToolResult{
+			{
+				Tool: PlannedTool{
+					Type: config.ToolTypeFormat,
+					Config: executor.ToolConfig{
+						Command: "bazel",
+						Args:    []string{"run", "//tools:format"},
+					},
+				},
+				DryRun: true,
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatPrompt, report); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "bazel run //tools:format") {
+		t.Errorf("dry-run prompt missing command\n%s", buf.String())
+	}
+}
+
+func TestWrite_UnknownFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := Write(&buf, OutputFormat("xml"), lintFailureReport())
+	if err == nil {
+		t.Fatal("Write() error = nil, want unknown format")
+	}
+}
+
+func lintFailureReport() *Report {
+	return &Report{
+		Project: &config.ProjectConfig{
+			RootPath:    "/repo",
+			BuildSystem: config.BuildSystemMake,
+			Languages:   []config.Language{config.LanguageGo},
+		},
+		Tools: []ToolResult{
+			{
+				Tool: PlannedTool{
+					Type: config.ToolTypeLint,
+					Config: executor.ToolConfig{
+						Command: "golangci-lint",
+						Args:    []string{"run", "--output.json.path=stdout"},
+					},
+				},
+				Result: &executor.ExecutionResult{
+					Command:   "golangci-lint",
+					ExitCode:  1,
+					StartTime: time.Now(),
+					EndTime:   time.Now(),
+				},
+				Issues: []config.Issue{{
+					FilePath: "broken.go",
+					Line:     3,
+					Column:   10,
+					Severity: config.SeverityError,
+					Message:  "Potential file inclusion via variable",
+					Code:     "gosec",
+					ToolName: "golangci-lint",
+				}},
+			},
+		},
+		Issues: []config.Issue{{
+			FilePath: "broken.go",
+			Line:     3,
+			Column:   10,
+			Severity: config.SeverityError,
+			Message:  "Potential file inclusion via variable",
+			Code:     "gosec",
+			ToolName: "golangci-lint",
+		}},
+	}
+}
+
+type jsonReport struct {
+	Tools  []json.RawMessage `json:"tools"`
+	Issues []config.Issue    `json:"issues"`
+	Failed bool              `json:"failed"`
+}

--- a/devtools/devcheck/internal/runner/parse.go
+++ b/devtools/devcheck/internal/runner/parse.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+)
+
+// External tool schemas keep the vendor field names.
+type golangciReport struct {
+	Issues []golangciIssue `json:"Issues"` //nolint:tagliatelle // golangci-lint schema
+}
+
+type golangciIssue struct {
+	FromLinter string      `json:"FromLinter"` //nolint:tagliatelle // golangci-lint schema
+	Text       string      `json:"Text"`       //nolint:tagliatelle // golangci-lint schema
+	Severity   string      `json:"Severity"`   //nolint:tagliatelle // golangci-lint schema
+	Pos        golangciPos `json:"Pos"`        //nolint:tagliatelle // golangci-lint schema
+}
+
+type golangciPos struct {
+	Filename string `json:"Filename"` //nolint:tagliatelle // golangci-lint schema
+	Line     int    `json:"Line"`     //nolint:tagliatelle // golangci-lint schema
+	Column   int    `json:"Column"`   //nolint:tagliatelle // golangci-lint schema
+}
+
+type ruffIssue struct {
+	Code        string    `json:"code"`
+	Message     string    `json:"message"`
+	Filename    string    `json:"filename"`
+	Location    ruffPoint `json:"location"`
+	EndLocation ruffPoint `json:"end_location"` //nolint:tagliatelle // ruff schema
+}
+
+type ruffPoint struct {
+	Row    int `json:"row"`
+	Column int `json:"column"`
+}
+
+// ParseIssues converts tool stdout/stderr into structured issues when possible.
+func ParseIssues(command, stdout, stderr string) []config.Issue {
+	payload := firstNonEmpty(stdout, stderr)
+	switch command {
+	case "golangci-lint":
+		return parseGolangci(payload)
+	case "ruff":
+		return parseRuff(payload)
+	default:
+		return nil
+	}
+}
+
+func parseGolangci(payload string) []config.Issue {
+	var report golangciReport
+	if err := json.Unmarshal([]byte(payload), &report); err != nil {
+		return nil
+	}
+	issues := make([]config.Issue, 0, len(report.Issues))
+	for _, item := range report.Issues {
+		issues = append(issues, config.Issue{
+			FilePath: item.Pos.Filename,
+			Line:     item.Pos.Line,
+			Column:   item.Pos.Column,
+			Severity: parseSeverity(item.Severity),
+			Message:  item.Text,
+			Code:     item.FromLinter,
+			ToolName: "golangci-lint",
+		})
+	}
+	return issues
+}
+
+func parseRuff(payload string) []config.Issue {
+	var items []ruffIssue
+	if err := json.Unmarshal([]byte(payload), &items); err != nil {
+		return nil
+	}
+	issues := make([]config.Issue, 0, len(items))
+	for _, item := range items {
+		issues = append(issues, config.Issue{
+			FilePath:  item.Filename,
+			Line:      item.Location.Row,
+			Column:    item.Location.Column,
+			EndLine:   item.EndLocation.Row,
+			EndColumn: item.EndLocation.Column,
+			Severity:  config.SeverityError,
+			Message:   item.Message,
+			Code:      item.Code,
+			ToolName:  "ruff",
+		})
+	}
+	return issues
+}
+
+func parseSeverity(raw string) config.Severity {
+	switch strings.ToLower(raw) {
+	case string(config.SeverityWarning):
+		return config.SeverityWarning
+	case string(config.SeverityInfo):
+		return config.SeverityInfo
+	case string(config.SeverityHint):
+		return config.SeverityHint
+	default:
+		return config.SeverityError
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/devtools/devcheck/internal/runner/parse_test.go
+++ b/devtools/devcheck/internal/runner/parse_test.go
@@ -1,0 +1,114 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+)
+
+const golangciLintFixture = `{
+  "Issues": [
+    {
+      "FromLinter": "gosec",
+      "Text": "Potential file inclusion via variable",
+      "Severity": "error",
+      "Pos": {
+        "Filename": "broken.go",
+        "Offset": 120,
+        "Line": 3,
+        "Column": 10
+      }
+    }
+  ]
+}`
+
+const ruffFixture = `[
+  {
+    "code": "F401",
+    "message": "os imported but unused",
+    "filename": "unused.py",
+    "location": {"row": 1, "column": 8},
+    "end_location": {"row": 1, "column": 11}
+  }
+]`
+
+func TestParseIssues_GolangciLintJSON(t *testing.T) {
+	issues := ParseIssues("golangci-lint", golangciLintFixture, "")
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	got := issues[0]
+	if got.FilePath != "broken.go" {
+		t.Errorf("FilePath = %q, want broken.go", got.FilePath)
+	}
+	if got.Line != 3 || got.Column != 10 {
+		t.Errorf("pos = %d:%d, want 3:10", got.Line, got.Column)
+	}
+	if got.Code != "gosec" {
+		t.Errorf("Code = %q, want gosec", got.Code)
+	}
+	if got.ToolName != "golangci-lint" {
+		t.Errorf("ToolName = %q, want golangci-lint", got.ToolName)
+	}
+	if got.Severity != config.SeverityError {
+		t.Errorf("Severity = %q, want error", got.Severity)
+	}
+	if got.Message == "" {
+		t.Error("Message is empty")
+	}
+}
+
+func TestParseIssues_RuffJSON(t *testing.T) {
+	issues := ParseIssues("ruff", ruffFixture, "")
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(issues))
+	}
+	got := issues[0]
+	if got.FilePath != "unused.py" {
+		t.Errorf("FilePath = %q, want unused.py", got.FilePath)
+	}
+	if got.Line != 1 || got.Column != 8 {
+		t.Errorf("pos = %d:%d, want 1:8", got.Line, got.Column)
+	}
+	if got.EndLine != 1 || got.EndColumn != 11 {
+		t.Errorf("end = %d:%d, want 1:11", got.EndLine, got.EndColumn)
+	}
+	if got.Code != "F401" {
+		t.Errorf("Code = %q, want F401", got.Code)
+	}
+	if got.ToolName != "ruff" {
+		t.Errorf("ToolName = %q, want ruff", got.ToolName)
+	}
+}
+
+func TestParseIssues_UnknownToolReturnsNone(t *testing.T) {
+	issues := ParseIssues("make", "some raw lint output\nfile.go:1: boom\n", "stderr")
+	if len(issues) != 0 {
+		t.Fatalf("issues = %v, want none for unknown tools", issues)
+	}
+}
+
+func TestParseIssues_EmptyOutput(t *testing.T) {
+	if issues := ParseIssues("golangci-lint", "", ""); len(issues) != 0 {
+		t.Errorf("empty golangci-lint output produced %d issues", len(issues))
+	}
+	if issues := ParseIssues("ruff", "[]", ""); len(issues) != 0 {
+		t.Errorf("empty ruff output produced %d issues", len(issues))
+	}
+}
+
+func TestParseIssues_InvalidJSONReturnsNone(t *testing.T) {
+	if issues := ParseIssues("golangci-lint", "not json", "also not json"); len(issues) != 0 {
+		t.Errorf("invalid JSON produced %d issues", len(issues))
+	}
+}
+
+func TestParseIssues_UsesStderrWhenStdoutEmpty(t *testing.T) {
+	issues := ParseIssues("ruff", "", ruffFixture)
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d, want 1 from stderr", len(issues))
+	}
+	if issues[0].FilePath != "unused.py" {
+		t.Errorf("FilePath = %q, want unused.py", issues[0].FilePath)
+	}
+}

--- a/devtools/devcheck/internal/runner/plan.go
+++ b/devtools/devcheck/internal/runner/plan.go
@@ -1,0 +1,327 @@
+// Package runner plans, executes, and reports DevCheck tool runs.
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+var errNoMatchingFiles = errors.New("no matching changed files")
+
+// Options controls which tools are selected and how they are run.
+type Options struct {
+	DryRun        bool
+	Verbose       bool
+	Filters       []config.ToolType
+	OutputFormat  OutputFormat
+	ChangedOnly   bool
+	ForceFallback bool
+	ChangedFiles  []string
+}
+
+// OutputFormat is the CLI report format.
+type OutputFormat string
+
+const (
+	// FormatPrompt is the default LLM-oriented report.
+	FormatPrompt OutputFormat = "prompt"
+	// FormatSummary is a short human-readable report.
+	FormatSummary OutputFormat = "summary"
+	// FormatJSON is machine-readable JSON.
+	FormatJSON OutputFormat = "json"
+)
+
+// PlannedTool is a detected tool mapped to a structured executor config.
+type PlannedTool struct {
+	Type   config.ToolType
+	Config executor.ToolConfig
+}
+
+// Display returns the command line that will be executed.
+func (t PlannedTool) Display() string {
+	if len(t.Config.Args) == 0 {
+		return t.Config.Command
+	}
+	return t.Config.Command + " " + strings.Join(t.Config.Args, " ")
+}
+
+// Plan selects one available tool per requested type and maps it to ToolConfig.
+func Plan(project *config.ProjectConfig, opts Options, exec executor.Executor) ([]PlannedTool, error) {
+	if project == nil {
+		return nil, fmt.Errorf("project config is required")
+	}
+	types := selectedTypes(project, opts.Filters)
+	planned := make([]PlannedTool, 0, len(types))
+	for _, toolType := range types {
+		tool, err := selectTool(project, toolType, opts, exec)
+		if errors.Is(err, errNoMatchingFiles) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		planned = append(planned, tool)
+	}
+	return planned, nil
+}
+
+func selectedTypes(project *config.ProjectConfig, filters []config.ToolType) []config.ToolType {
+	order := []config.ToolType{config.ToolTypeFormat, config.ToolTypeLint, config.ToolTypeTest}
+	if len(filters) == 0 {
+		var types []config.ToolType
+		for _, toolType := range order {
+			if len(project.Tools[toolType]) > 0 {
+				types = append(types, toolType)
+			}
+		}
+		return types
+	}
+	wanted := make(map[config.ToolType]struct{}, len(filters))
+	for _, f := range filters {
+		wanted[f] = struct{}{}
+	}
+	var types []config.ToolType
+	for _, toolType := range order {
+		if _, ok := wanted[toolType]; ok {
+			types = append(types, toolType)
+		}
+	}
+	return types
+}
+
+func selectTool(project *config.ProjectConfig, toolType config.ToolType, opts Options, exec executor.Executor) (PlannedTool, error) {
+	candidates := project.Tools[toolType]
+	var tried []string
+	skippedForFiles := false
+	for _, spec := range candidates {
+		command, args := splitSpec(spec)
+		if opts.ForceFallback && isBuildSystemCommand(command) {
+			continue
+		}
+		tried = append(tried, spec)
+		if exec != nil && !exec.IsAvailable(command) {
+			continue
+		}
+		if skipForChangedFiles(command, opts) {
+			skippedForFiles = true
+			continue
+		}
+		cfg := buildConfig(command, args, toolType, project.RootPath, opts.ChangedFiles)
+		return PlannedTool{Type: toolType, Config: cfg}, nil
+	}
+	if skippedForFiles {
+		return PlannedTool{}, errNoMatchingFiles
+	}
+	if len(tried) == 0 {
+		tried = candidates
+	}
+	return PlannedTool{}, fmt.Errorf("missing required %s tool (tried: %s)", toolType, strings.Join(tried, ", "))
+}
+
+func skipForChangedFiles(command string, opts Options) bool {
+	if !opts.ChangedOnly || !acceptsFileArgs(command) {
+		return false
+	}
+	return len(filterFilesForCommand(command, opts.ChangedFiles)) == 0
+}
+
+func splitSpec(spec string) (string, []string) {
+	fields := strings.Fields(spec)
+	if len(fields) == 0 {
+		return spec, nil
+	}
+	return fields[0], append([]string(nil), fields[1:]...)
+}
+
+func isBuildSystemCommand(command string) bool {
+	return command == "bazel" || command == "make"
+}
+
+func buildConfig(command string, args []string, toolType config.ToolType, workDir string, changedFiles []string) executor.ToolConfig {
+	args = enhanceArgs(command, args, toolType, changedFiles)
+	cfg := executor.ToolConfig{
+		Command:    command,
+		Args:       args,
+		WorkingDir: workDir,
+		Timeout:    timeoutFor(command, toolType),
+	}
+	if command == "bazel" {
+		cfg.CommandBuilder = &executor.ShellCommandBuilder{}
+	}
+	return cfg
+}
+
+func enhanceArgs(command string, args []string, toolType config.ToolType, changedFiles []string) []string {
+	switch command {
+	case "golangci-lint":
+		args = ensureGolangciArgs(args)
+	case "ruff":
+		args = ensureRuffArgs(args)
+	case "gofumpt", "gofmt":
+		args = defaultArgs(args, "-w", ".")
+	case "go":
+		args = ensureGoTestArgs(args)
+	case "black":
+		args = defaultArgs(args, ".")
+	case "prettier":
+		args = defaultArgs(args, "--write", ".")
+	case "eslint":
+		args = defaultArgs(args, ".")
+	}
+	return appendChangedFiles(command, args, toolType, changedFiles)
+}
+
+func ensureGolangciArgs(args []string) []string {
+	if !hasArg(args, "run") {
+		args = append([]string{"run"}, args...)
+	}
+	if !hasArgPrefix(args, "--timeout") {
+		args = append(args, "--timeout=30s")
+	}
+	if !hasArgPrefix(args, "--output.json.path") {
+		args = append(args, "--output.json.path=stdout")
+	}
+	return args
+}
+
+func ensureRuffArgs(args []string) []string {
+	if !hasArg(args, "check") {
+		return args
+	}
+	if hasArgPrefix(args, "--output-format") {
+		return args
+	}
+	return append(args, "--output-format", "json")
+}
+
+func ensureGoTestArgs(args []string) []string {
+	if !hasArg(args, "test") {
+		return args
+	}
+	if len(args) == 1 {
+		return append(args, "./...")
+	}
+	return args
+}
+
+func defaultArgs(args []string, defaults ...string) []string {
+	if len(args) > 0 {
+		return args
+	}
+	return append([]string(nil), defaults...)
+}
+
+func appendChangedFiles(command string, args []string, _ config.ToolType, changedFiles []string) []string {
+	if len(changedFiles) == 0 || !acceptsFileArgs(command) {
+		return args
+	}
+	files := filterFilesForCommand(command, changedFiles)
+	if len(files) == 0 {
+		return args
+	}
+	if command == "gofumpt" || command == "gofmt" {
+		args = replaceDotPath(args, files)
+		return args
+	}
+	return append(args, files...)
+}
+
+func replaceDotPath(args, files []string) []string {
+	out := make([]string, 0, len(args)+len(files))
+	replaced := false
+	for _, arg := range args {
+		if arg == "." {
+			out = append(out, files...)
+			replaced = true
+			continue
+		}
+		out = append(out, arg)
+	}
+	if !replaced {
+		out = append(out, files...)
+	}
+	return out
+}
+
+func acceptsFileArgs(command string) bool {
+	switch command {
+	case "gofumpt", "gofmt", "golangci-lint", "ruff", "black", "flake8", "prettier", "eslint", "pytest":
+		return true
+	default:
+		return false
+	}
+}
+
+func filterFilesForCommand(command string, files []string) []string {
+	var out []string
+	for _, file := range files {
+		if fileMatchesCommand(command, file) {
+			out = append(out, file)
+		}
+	}
+	return out
+}
+
+func fileMatchesCommand(command, file string) bool {
+	switch command {
+	case "gofumpt", "gofmt", "golangci-lint":
+		return strings.HasSuffix(file, ".go")
+	case "ruff", "black", "flake8", "pytest":
+		return strings.HasSuffix(file, ".py")
+	case "prettier", "eslint":
+		return hasAnySuffix(file, ".js", ".jsx", ".ts", ".tsx")
+	default:
+		return true
+	}
+}
+
+func hasAnySuffix(file string, suffixes ...string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(file, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasArgPrefix(args []string, prefix string) bool {
+	for _, arg := range args {
+		if arg == prefix || strings.HasPrefix(arg, prefix+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func timeoutFor(command string, toolType config.ToolType) time.Duration {
+	if command == "bazel" {
+		if toolType == config.ToolTypeTest {
+			return 10 * time.Minute
+		}
+		return 5 * time.Minute
+	}
+	if command == "make" && toolType == config.ToolTypeTest {
+		return 5 * time.Minute
+	}
+	if command == "golangci-lint" {
+		return 45 * time.Second
+	}
+	if toolType == config.ToolTypeTest {
+		return 3 * time.Minute
+	}
+	return 30 * time.Second
+}

--- a/devtools/devcheck/internal/runner/plan_test.go
+++ b/devtools/devcheck/internal/runner/plan_test.go
@@ -1,0 +1,274 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestPlan_MapsDetectedToolsToStructuredConfigs(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath:    "/repo",
+		BuildSystem: config.BuildSystemBazel,
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"bazel run //tools:format", "gofumpt"},
+			config.ToolTypeLint:   {"bazel run //tools:lint", "golangci-lint"},
+			config.ToolTypeTest:   {"bazel test //...", "go test"},
+		},
+	}
+	exec := availableExec(t, "bazel")
+
+	planned, err := Plan(project, Options{}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(planned) != 3 {
+		t.Fatalf("planned tools = %d, want 3", len(planned))
+	}
+
+	assertTool(t, planned[0], config.ToolTypeFormat, "bazel", []string{"run", "//tools:format"})
+	assertTool(t, planned[1], config.ToolTypeLint, "bazel", []string{"run", "//tools:lint"})
+	assertTool(t, planned[2], config.ToolTypeTest, "bazel", []string{"test", "//..."})
+
+	for _, tool := range planned {
+		if tool.Config.WorkingDir != "/repo" {
+			t.Errorf("%s WorkingDir = %q, want /repo", tool.Type, tool.Config.WorkingDir)
+		}
+		if tool.Config.Timeout <= 0 {
+			t.Errorf("%s Timeout = %v, want > 0", tool.Type, tool.Config.Timeout)
+		}
+		if tool.Config.CommandBuilder == nil {
+			t.Errorf("%s CommandBuilder is nil, want shell builder for bazel", tool.Type)
+		}
+	}
+}
+
+func TestPlan_ForceFallbackSkipsBuildSystemTools(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath:    "/repo",
+		BuildSystem: config.BuildSystemMake,
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"make format", "gofumpt", "gofmt"},
+			config.ToolTypeLint:   {"make lint", "golangci-lint"},
+		},
+	}
+	exec := availableExec(t, "make", "gofumpt", "gofmt", "golangci-lint")
+
+	planned, err := Plan(project, Options{ForceFallback: true}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(planned) != 2 {
+		t.Fatalf("planned tools = %d, want 2: %v", len(planned), displayAll(planned))
+	}
+	assertTool(t, planned[0], config.ToolTypeFormat, "gofumpt", []string{"-w", "."})
+	assertTool(t, planned[1], config.ToolTypeLint, "golangci-lint", nil)
+	if !containsAll(planned[1].Config.Args, "run") {
+		t.Errorf("golangci-lint args = %v, want to include run", planned[1].Config.Args)
+	}
+}
+
+func TestPlan_FilterRunsOnlySelectedTypes(t *testing.T) {
+	project := bazelGoProject()
+	exec := availableExec(t, "bazel")
+
+	planned, err := Plan(project, Options{Filters: []config.ToolType{config.ToolTypeFormat}}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(planned) != 1 {
+		t.Fatalf("planned tools = %d, want 1", len(planned))
+	}
+	if planned[0].Type != config.ToolTypeFormat {
+		t.Errorf("type = %s, want format", planned[0].Type)
+	}
+}
+
+func TestPlan_FallsBackWhenPreferredBinaryMissing(t *testing.T) {
+	project := bazelGoProject()
+	exec := availableExec(t, "gofumpt", "golangci-lint", "go")
+
+	planned, err := Plan(project, Options{}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	assertTool(t, planned[0], config.ToolTypeFormat, "gofumpt", []string{"-w", "."})
+	if planned[1].Config.Command != "golangci-lint" {
+		t.Errorf("lint command = %q, want golangci-lint", planned[1].Config.Command)
+	}
+	assertTool(t, planned[2], config.ToolTypeTest, "go", []string{"test", "./..."})
+}
+
+func TestPlan_MissingRequiredTool(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeLint: {"golangci-lint"},
+		},
+	}
+	exec := availableExec(t)
+
+	_, err := Plan(project, Options{Filters: []config.ToolType{config.ToolTypeLint}}, exec)
+	if err == nil {
+		t.Fatal("Plan() error = nil, want missing required tool")
+	}
+	if !strings.Contains(err.Error(), "golangci-lint") {
+		t.Errorf("error %q, want to name golangci-lint", err)
+	}
+}
+
+func TestPlan_EnhancesParserFriendlyArgs(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeLint: {"golangci-lint", "ruff check"},
+		},
+	}
+	exec := availableExec(t, "golangci-lint")
+
+	planned, err := Plan(project, Options{}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(planned) != 1 {
+		t.Fatalf("planned = %d, want 1", len(planned))
+	}
+	args := strings.Join(planned[0].Config.Args, " ")
+	if !strings.Contains(args, "run") {
+		t.Errorf("args %q, want run", args)
+	}
+	if !strings.Contains(args, "--output.json.path") {
+		t.Errorf("args %q, want golangci-lint JSON output flag", args)
+	}
+}
+
+func TestPlan_EnhancesRuffCheckJSON(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeLint: {"ruff check"},
+		},
+	}
+	exec := availableExec(t, "ruff")
+
+	planned, err := Plan(project, Options{}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if !containsAll(planned[0].Config.Args, "check", "--output-format", "json") &&
+		!containsAll(planned[0].Config.Args, "check", "--output-format=json") {
+		t.Errorf("ruff args = %v, want check plus JSON output format", planned[0].Config.Args)
+	}
+}
+
+func TestPlan_ChangedOnlySkipsToolsWithoutMatchingFiles(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"gofumpt"},
+			config.ToolTypeLint:   {"ruff check"},
+		},
+	}
+	exec := availableExec(t, "gofumpt", "ruff")
+
+	planned, err := Plan(project, Options{
+		ChangedOnly:  true,
+		ChangedFiles: []string{"unused.py", "README.md"},
+	}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(planned) != 1 {
+		t.Fatalf("planned = %v, want only ruff", displayAll(planned))
+	}
+	if planned[0].Config.Command != "ruff" {
+		t.Errorf("command = %q, want ruff", planned[0].Config.Command)
+	}
+	if !containsAll(planned[0].Config.Args, "unused.py") {
+		t.Errorf("args = %v, want unused.py", planned[0].Config.Args)
+	}
+}
+
+func TestPlan_TimeoutPositive(t *testing.T) {
+	project := bazelGoProject()
+	exec := availableExec(t, "bazel")
+	planned, err := Plan(project, Options{}, exec)
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	for _, tool := range planned {
+		if tool.Config.Timeout < time.Second {
+			t.Errorf("%s timeout %v is too short", tool.Type, tool.Config.Timeout)
+		}
+	}
+}
+
+func bazelGoProject() *config.ProjectConfig {
+	return &config.ProjectConfig{
+		RootPath:    "/repo",
+		BuildSystem: config.BuildSystemBazel,
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"bazel run //tools:format", "gofumpt", "gofmt"},
+			config.ToolTypeLint:   {"bazel run //tools:lint", "golangci-lint"},
+			config.ToolTypeTest:   {"bazel test //...", "go test"},
+		},
+	}
+}
+
+func availableExec(t *testing.T, commands ...string) executor.Executor {
+	t.Helper()
+	mock := executor.NewMockExecutor()
+	for _, cmd := range commands {
+		mock.SetAvailableCommand(cmd, true)
+	}
+	return mock
+}
+
+func assertTool(t *testing.T, tool PlannedTool, toolType config.ToolType, command string, args []string) {
+	t.Helper()
+	if tool.Type != toolType {
+		t.Errorf("type = %s, want %s", tool.Type, toolType)
+	}
+	if tool.Config.Command != command {
+		t.Errorf("%s command = %q, want %q", toolType, tool.Config.Command, command)
+	}
+	if args != nil && !equalStrings(tool.Config.Args, args) {
+		t.Errorf("%s args = %v, want %v", toolType, tool.Config.Args, args)
+	}
+}
+
+func displayAll(tools []PlannedTool) []string {
+	out := make([]string, len(tools))
+	for i, tool := range tools {
+		out[i] = tool.Display()
+	}
+	return out
+}
+
+func containsAll(got []string, want ...string) bool {
+	set := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		set[g] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/devtools/devcheck/internal/runner/run.go
+++ b/devtools/devcheck/internal/runner/run.go
@@ -1,0 +1,177 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+// Report is the result of planning and optionally executing tools.
+type Report struct {
+	Project *config.ProjectConfig
+	Tools   []ToolResult
+	Issues  []config.Issue
+	DryRun  bool
+}
+
+// ToolResult is the outcome of one planned tool.
+type ToolResult struct {
+	Tool      PlannedTool
+	Result    *executor.ExecutionResult
+	Error     error
+	Issues    []config.Issue
+	RawOutput string
+	DryRun    bool
+}
+
+// Failed reports whether any executed tool failed. Dry-run never fails.
+func (r *Report) Failed() bool {
+	if r == nil || r.DryRun {
+		return false
+	}
+	for _, tool := range r.Tools {
+		if toolFailed(tool) {
+			return true
+		}
+	}
+	return false
+}
+
+func toolFailed(tool ToolResult) bool {
+	if tool.Error != nil {
+		return true
+	}
+	return tool.Result != nil && tool.Result.ExitCode != 0
+}
+
+// Run plans tools and executes them unless DryRun is set.
+func Run(ctx context.Context, project *config.ProjectConfig, opts Options, exec executor.Executor) (*Report, error) {
+	if project == nil {
+		return nil, fmt.Errorf("project config is required")
+	}
+	if opts.ChangedOnly {
+		files, err := changedFiles(ctx, project, exec)
+		if err != nil {
+			return nil, err
+		}
+		opts.ChangedFiles = files
+	}
+
+	planned, err := Plan(project, opts, exec)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &Report{Project: project, DryRun: opts.DryRun}
+	if opts.DryRun {
+		for _, tool := range planned {
+			report.Tools = append(report.Tools, ToolResult{Tool: tool, DryRun: true})
+		}
+		return report, nil
+	}
+
+	results, err := executeAll(ctx, exec, planned)
+	if err != nil {
+		return nil, err
+	}
+	for i, tool := range planned {
+		item := decorateResult(tool, results[i], opts.Verbose)
+		report.Tools = append(report.Tools, item)
+		report.Issues = append(report.Issues, item.Issues...)
+	}
+	return report, nil
+}
+
+func changedFiles(ctx context.Context, project *config.ProjectConfig, exec executor.Executor) ([]string, error) {
+	if !project.HasGit {
+		return nil, fmt.Errorf("--changed-only requires a git repository")
+	}
+	if exec != nil && !exec.IsAvailable("git") {
+		return nil, fmt.Errorf("--changed-only requires git")
+	}
+	diff, err := gitOutput(ctx, exec, project.RootPath, "diff", "--name-only", "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("list changed files: %w", err)
+	}
+	untracked, err := gitOutput(ctx, exec, project.RootPath, "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, fmt.Errorf("list untracked files: %w", err)
+	}
+	return uniqueLines(diff, untracked), nil
+}
+
+func gitOutput(ctx context.Context, exec executor.Executor, workDir string, args ...string) (string, error) {
+	result, err := exec.Execute(ctx, executor.ToolConfig{
+		Command:    "git",
+		Args:       args,
+		WorkingDir: workDir,
+	})
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	if result.ExitCode != 0 {
+		return "", fmt.Errorf("git %s: exit %d: %s", strings.Join(args, " "), result.ExitCode, strings.TrimSpace(result.Stderr))
+	}
+	return result.Output, nil
+}
+
+func uniqueLines(chunks ...string) []string {
+	seen := make(map[string]struct{})
+	var files []string
+	for _, chunk := range chunks {
+		for _, line := range strings.Split(chunk, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if _, ok := seen[line]; ok {
+				continue
+			}
+			seen[line] = struct{}{}
+			files = append(files, line)
+		}
+	}
+	return files
+}
+
+func executeAll(ctx context.Context, exec executor.Executor, planned []PlannedTool) ([]executor.ConcurrentResult, error) {
+	configs := make([]executor.ToolConfig, len(planned))
+	for i, tool := range planned {
+		configs[i] = tool.Config
+	}
+	concurrent := executor.NewConcurrentExecutor(exec)
+	concurrent.SetMaxConcurrency(3)
+	results, err := concurrent.ExecuteAll(ctx, configs)
+	if err != nil {
+		return nil, fmt.Errorf("execute tools: %w", err)
+	}
+	return results, nil
+}
+
+func decorateResult(tool PlannedTool, cr executor.ConcurrentResult, verbose bool) ToolResult {
+	item := ToolResult{Tool: tool, Result: cr.Result, Error: cr.Error}
+	if cr.Result == nil {
+		return item
+	}
+	item.Issues = ParseIssues(tool.Config.Command, cr.Result.Output, cr.Result.Stderr)
+	if len(item.Issues) == 0 && (verbose || cr.Result.ExitCode != 0) {
+		item.RawOutput = combinedOutput(cr.Result)
+	}
+	return item
+}
+
+func combinedOutput(result *executor.ExecutionResult) string {
+	out := strings.TrimSpace(result.Output)
+	errOut := strings.TrimSpace(result.Stderr)
+	switch {
+	case out != "" && errOut != "":
+		return out + "\n" + errOut
+	case errOut != "":
+		return errOut
+	default:
+		return out
+	}
+}

--- a/devtools/devcheck/internal/runner/run_test.go
+++ b/devtools/devcheck/internal/runner/run_test.go
@@ -1,0 +1,195 @@
+package runner
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+	executor "github.com/jaeyeom/go-cmdexec"
+)
+
+func TestRun_DryRunDoesNotExecute(t *testing.T) {
+	project := bazelGoProject()
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("bazel", true)
+	mock.DefaultResult = &executor.ExecutionResult{
+		Command:   "bazel",
+		ExitCode:  0,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}
+
+	report, err := Run(context.Background(), project, Options{DryRun: true}, mock)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(mock.CallHistory) != 0 {
+		t.Fatalf("dry-run executed %d commands, want 0", len(mock.CallHistory))
+	}
+	if len(report.Tools) != 3 {
+		t.Fatalf("tools = %d, want 3", len(report.Tools))
+	}
+	for _, tool := range report.Tools {
+		if !tool.DryRun {
+			t.Errorf("%s DryRun = false, want true", tool.Tool.Type)
+		}
+		if !strings.Contains(tool.Tool.Display(), "bazel") {
+			t.Errorf("display %q, want bazel command", tool.Tool.Display())
+		}
+	}
+	if report.Failed() {
+		t.Error("dry-run report should not fail")
+	}
+}
+
+func TestRun_RecordsSuccessAndFailure(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"gofumpt"},
+			config.ToolTypeLint:   {"golangci-lint"},
+		},
+	}
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("gofumpt", true)
+	mock.SetAvailableCommand("golangci-lint", true)
+	mock.ExpectCommand("gofumpt").
+		WillReturn(&executor.ExecutionResult{
+			Command: "gofumpt", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+	mock.ExpectCommand("golangci-lint").
+		WillReturn(&executor.ExecutionResult{
+			Command:   "golangci-lint",
+			ExitCode:  1,
+			Output:    golangciLintFixture,
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+		}, nil).Once().Build()
+
+	report, err := Run(context.Background(), project, Options{}, mock)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !report.Failed() {
+		t.Fatal("Failed() = false, want true on lint failure")
+	}
+	if len(report.Issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(report.Issues))
+	}
+	if report.Issues[0].FilePath != "broken.go" {
+		t.Errorf("issue file = %q, want broken.go", report.Issues[0].FilePath)
+	}
+}
+
+func TestRun_ChangedOnlyRequiresGit(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		HasGit:   false,
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"gofumpt"},
+		},
+	}
+	mock := availableExec(t, "gofumpt").(*executor.MockExecutor)
+
+	_, err := Run(context.Background(), project, Options{ChangedOnly: true}, mock)
+	if err == nil {
+		t.Fatal("Run() error = nil, want git repo required")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "git") {
+		t.Errorf("error %q, want to mention git", err)
+	}
+}
+
+func TestRun_ChangedOnlyAppendsMatchingFiles(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		HasGit:   true,
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"gofumpt"},
+		},
+	}
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("gofumpt", true)
+	mock.SetAvailableCommand("git", true)
+	mock.ExpectCommand("git").
+		WillReturn(&executor.ExecutionResult{
+			Command: "git", ExitCode: 0, Output: "main.go\nREADME.md\n",
+			StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+	mock.ExpectCommand("git").
+		WillReturn(&executor.ExecutionResult{
+			Command: "git", ExitCode: 0, Output: "",
+			StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+	mock.ExpectCommand("gofumpt").
+		WillReturn(&executor.ExecutionResult{
+			Command: "gofumpt", ExitCode: 0, StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+
+	report, err := Run(context.Background(), project, Options{ChangedOnly: true}, mock)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(report.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1", len(report.Tools))
+	}
+	if !containsAll(report.Tools[0].Tool.Config.Args, "main.go") {
+		t.Errorf("args = %v, want main.go", report.Tools[0].Tool.Config.Args)
+	}
+	if containsAll(report.Tools[0].Tool.Config.Args, "README.md") {
+		t.Errorf("args = %v, README.md should not be passed to gofumpt", report.Tools[0].Tool.Config.Args)
+	}
+}
+
+func TestRun_AttachesRawOutputWhenUnparsed(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeLint: {"make lint"},
+		},
+	}
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("make", true)
+	mock.ExpectCommand("make").
+		WillReturn(&executor.ExecutionResult{
+			Command: "make", ExitCode: 1, Output: "lint failed on foo.go",
+			Stderr: "error details", StartTime: time.Now(), EndTime: time.Now(),
+		}, nil).Once().Build()
+
+	report, err := Run(context.Background(), project, Options{}, mock)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(report.Issues) != 0 {
+		t.Errorf("parsed issues = %d, want 0 for make", len(report.Issues))
+	}
+	if !strings.Contains(report.Tools[0].RawOutput, "lint failed on foo.go") {
+		t.Errorf("RawOutput = %q, want make stdout", report.Tools[0].RawOutput)
+	}
+}
+
+func TestRun_ExecutionErrorFailsReport(t *testing.T) {
+	project := &config.ProjectConfig{
+		RootPath: "/repo",
+		Tools: map[config.ToolType][]string{
+			config.ToolTypeFormat: {"gofumpt"},
+		},
+	}
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("gofumpt", true)
+	mock.ExpectCommand("gofumpt").
+		WillReturn(nil, context.DeadlineExceeded).Once().Build()
+
+	report, err := Run(context.Background(), project, Options{}, mock)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !report.Failed() {
+		t.Fatal("Failed() = false, want true on execution error")
+	}
+	if report.Tools[0].Error == nil {
+		t.Fatal("tool error is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Replace detection-only default mode and `-demo` with a real `devcheck` CLI: detect tools, map them to `go-cmdexec` `ToolConfig`s, run them, and emit agent-usable reports.
- Add the documented flags: `--dry-run`/`-n`, `--verbose`/`-v`, `--filter`, `--format=prompt|summary|json`, `--changed-only`, `--force-fallback`.
- Parse golangci-lint and ruff JSON into `config.Issue`; attach raw output for other tools. Exit 0 only on success or dry-run.

Resolves #261

## Demo

Recorded against this repo. `main` only prints detection by default; `-demo` runs a handful of probe commands. This PR drops `-demo` and makes `--dry-run` preview the real format/lint/test commands.

### Before (`main`)

`devcheck .`

```
🔍 DevCheck Project Detection Results
=====================================

Path: /home/jaehyun/go/src/github.com/jaeyeom/experimental
Languages: go, javascript, python, typescript
Build System: bazel
Git Repository: yes

Tools:
  format: bazel run //tools:format
  lint: bazel run //tools:lint
  test: bazel test //...

Configuration Files:
  golangci-lint: .golangci.yml
  ruff: pyproject.toml
  typescript: tsconfig.json

Detection completed at: 2026-08-28 09:34:47
```

`devcheck -demo .`

```
🚀 DevCheck Tool Executor Demo
==============================

Path: /home/jaehyun/go/src/github.com/jaeyeom/experimental

Detected Tools:
  test: bazel test //...
  format: bazel run //tools:format
  lint: bazel run //tools:lint

Running 5 tools concurrently (max 3 workers)...

┌─────────────────────────────────┬─────────┬──────────┬───────────┐
│ Tool                            │ Status  │ Duration │ Exit Code │
├─────────────────────────────────┼─────────┼──────────┼───────────┤
│ bazel info workspace            │ ✅ PASS  │ 779ms    │ 0         │
│ go list ./...                   │ ✅ PASS  │ 77ms     │ 0         │
│ golangci-lint run --timeout=3... │ ✅ PASS  │ 439ms    │ 0         │
│ ruff check --statistics         │ ✅ PASS  │ 8ms      │ 0         │
│ git status --short              │ ✅ PASS  │ 8ms      │ 0         │
└─────────────────────────────────┴─────────┴──────────┴───────────┘

Summary: 5/5 tools passed (total time: 779ms with concurrency)
```

### After (this PR)

`devcheck --dry-run .`

```
🔧 DevCheck Report

Repository Analysis:
- Build System: bazel
- Languages: javascript, go, python, typescript
- Strategy: Dry-run; commands were not executed

Tools that would run:
⏳ bazel run //tools:format - would run
⏳ bazel run //tools:lint - would run
⏳ bazel test //... - would run

Issues Found:
none
Next Steps for AI Agent:
1. Re-run without --dry-run to execute the selected tools

Status: dry-run (commands were not executed)
```

`devcheck --filter=format --dry-run .`

```
🔧 DevCheck Report

Repository Analysis:
- Build System: bazel
- Languages: go, python, typescript, javascript
- Strategy: Dry-run; commands were not executed

Tools that would run:
⏳ bazel run //tools:format - would run

Issues Found:
none
Next Steps for AI Agent:
1. Re-run without --dry-run to execute the selected tools

Status: dry-run (commands were not executed)
```

## Test plan
- [x] `devcheck --dry-run` on this repo prints `bazel run //tools:format`, `bazel run //tools:lint`, `bazel test //...` and exits 0
- [x] `devcheck --filter=format` plans/runs only formatters
- [x] `devcheck --format=json` is valid JSON with `tools` and `issues`
- [x] Fixture lint failure exits non-zero and names `broken.go` in prompt output
- [x] `flag` help lists the documented flags; `-demo` is gone
- [x] `make check` is green (309 tests pass, lint/semgrep clean)
