### PR TITLE
fix(devcheck): probe real tools instead of assumed commands

### DIFF
--- a/devtools/devcheck/cmd/devcheck/main_test.go
+++ b/devtools/devcheck/cmd/devcheck/main_test.go
@@ -34,6 +34,7 @@ func TestHelpListsDocumentedFlags(t *testing.T) {
 }
 
 func TestDryRunPrintsCommandsAndExitsZero(t *testing.T) {
+	withBinsOnPath(t, "make")
 	dir := fixtureDir(t, "go.mod", "main.go", "MODULE.bazel", "Makefile")
 	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("format:\nlint:\ntest:\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -70,6 +71,7 @@ func TestDryRunPrintsCommandsAndExitsZero(t *testing.T) {
 }
 
 func TestDryRunUsesBazelWhenFormatAndLintTargetsExist(t *testing.T) {
+	withBinsOnPath(t, "bazel", "make")
 	dir := fixtureDir(t, "go.mod", "main.go", "MODULE.bazel", "Makefile", "tools/BUILD.bazel")
 	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("format:\nlint:\ntest:\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -100,6 +102,7 @@ func TestDryRunUsesBazelWhenFormatAndLintTargetsExist(t *testing.T) {
 }
 
 func TestFilterFormatRunsOnlyFormatters(t *testing.T) {
+	withBinsOnPath(t, "gofumpt", "golangci-lint", "go")
 	dir := fixtureDir(t, "go.mod", "main.go")
 	mock := executor.NewMockExecutor()
 	mock.SetAvailableCommand("gofumpt", true)
@@ -122,6 +125,7 @@ func TestFilterFormatRunsOnlyFormatters(t *testing.T) {
 }
 
 func TestFormatJSONIsValidAndIncludesToolsAndIssues(t *testing.T) {
+	withBinsOnPath(t, "golangci-lint")
 	dir := fixtureDir(t, "go.mod", "main.go")
 	mock := executor.NewMockExecutor()
 	mock.SetAvailableCommand("golangci-lint", true)
@@ -152,6 +156,7 @@ func TestFormatJSONIsValidAndIncludesToolsAndIssues(t *testing.T) {
 }
 
 func TestLintFixtureExitsNonZeroAndNamesFile(t *testing.T) {
+	withBinsOnPath(t, "golangci-lint")
 	dir := fixtureDir(t, "go.mod", "broken.go")
 	mock := executor.NewMockExecutor()
 	mock.SetAvailableCommand("golangci-lint", true)
@@ -172,6 +177,7 @@ func TestLintFixtureExitsNonZeroAndNamesFile(t *testing.T) {
 }
 
 func TestChangedOnlyWithoutGitErrors(t *testing.T) {
+	withBinsOnPath(t, "gofumpt")
 	dir := fixtureDir(t, "go.mod", "main.go")
 	mock := executor.NewMockExecutor()
 	mock.SetAvailableCommand("gofumpt", true)
@@ -203,6 +209,7 @@ func TestInvalidFormat(t *testing.T) {
 }
 
 func TestFilterRepeatableAndCommaSeparated(t *testing.T) {
+	withBinsOnPath(t, "gofumpt", "golangci-lint")
 	dir := fixtureDir(t, "go.mod", "main.go")
 	mock := executor.NewMockExecutor()
 	mock.SetAvailableCommand("gofumpt", true)
@@ -249,6 +256,21 @@ const golangciLintJSON = `{
     }
   ]
 }`
+
+func withBinsOnPath(t *testing.T, names ...string) {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range names {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+}
 
 func fixtureDir(t *testing.T, files ...string) string {
 	t.Helper()

--- a/devtools/devcheck/cmd/devcheck/main_test.go
+++ b/devtools/devcheck/cmd/devcheck/main_test.go
@@ -34,9 +34,12 @@ func TestHelpListsDocumentedFlags(t *testing.T) {
 }
 
 func TestDryRunPrintsCommandsAndExitsZero(t *testing.T) {
-	dir := fixtureDir(t, "go.mod", "main.go", "MODULE.bazel")
+	dir := fixtureDir(t, "go.mod", "main.go", "MODULE.bazel", "Makefile")
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("format:\nlint:\ntest:\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	mock := executor.NewMockExecutor()
-	mock.SetAvailableCommand("bazel", true)
+	mock.SetAvailableCommand("make", true)
 
 	var stdout, stderr bytes.Buffer
 	code := run(context.Background(), []string{"-n", dir}, &stdout, &stderr, mock)
@@ -45,6 +48,44 @@ func TestDryRunPrintsCommandsAndExitsZero(t *testing.T) {
 	}
 	if len(mock.CallHistory) != 0 {
 		t.Fatalf("dry-run executed %d commands", len(mock.CallHistory))
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"make format",
+		"make lint",
+		"make test",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run missing %q\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{
+		"bazel run //tools:format",
+		"bazel run //tools:lint",
+	} {
+		if strings.Contains(out, notWant) {
+			t.Errorf("dry-run unexpectedly listed %q\n%s", notWant, out)
+		}
+	}
+}
+
+func TestDryRunUsesBazelWhenFormatAndLintTargetsExist(t *testing.T) {
+	dir := fixtureDir(t, "go.mod", "main.go", "MODULE.bazel", "Makefile", "tools/BUILD.bazel")
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("format:\nlint:\ntest:\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tools/BUILD.bazel"), []byte(
+		"sh_binary(name = \"format\", srcs = [\"format.sh\"])\nsh_binary(name = \"lint\", srcs = [\"lint.sh\"])\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mock := executor.NewMockExecutor()
+	mock.SetAvailableCommand("bazel", true)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"-n", dir}, &stdout, &stderr, mock)
+	if code != 0 {
+		t.Fatalf("dry-run exit = %d, stderr=%s", code, stderr.String())
 	}
 	out := stdout.String()
 	for _, want := range []string{

--- a/devtools/devcheck/internal/detector/BUILD.bazel
+++ b/devtools/devcheck/internal/detector/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "detector.go",
         "language.go",
         "patterns.go",
+        "probe.go",
         "scanner.go",
         "unnecessary_interface_assertion_linter.go",
     ],

--- a/devtools/devcheck/internal/detector/detector.go
+++ b/devtools/devcheck/internal/detector/detector.go
@@ -86,7 +86,7 @@ func (d *ProjectDetector) Detect(rootPath string) (*config.ProjectConfig, error)
 	}
 
 	languages := d.patternMatcher.MatchLanguages(scanResult.Files)
-	buildSystem := d.patternMatcher.MatchBuildSystemWithLocation(scanResult.Files)
+	buildSystem := selectBuildSystem(absPath, d.patternMatcher.MatchBuildSystemsAtChosenDepth(scanResult.Files))
 	hasGit := d.detectGitRepository(absPath)
 
 	tools := d.aggregateTools(languages, buildSystem, absPath)
@@ -209,14 +209,22 @@ func (d *BazelDetector) GetBuildSystem() config.BuildSystem {
 }
 
 // GetTools returns the available tools for Bazel.
-func (d *BazelDetector) GetTools(_ string) map[config.ToolType][]string {
+func (d *BazelDetector) GetTools(rootPath string) map[config.ToolType][]string {
 	tools := make(map[config.ToolType][]string)
-
-	// Bazel provides unified commands for all operations
-	tools[config.ToolTypeFormat] = []string{"bazel run //tools:format", "bazel run //:format"}
-	tools[config.ToolTypeLint] = []string{"bazel run //tools:lint", "bazel run //:lint"}
-	tools[config.ToolTypeTest] = []string{"bazel test //..."}
-
+	var format, lint []string
+	for _, label := range bazelFormatLabels {
+		if bazelLabelExists(rootPath, label) {
+			format = append(format, "bazel run "+label)
+		}
+	}
+	for _, label := range bazelLintLabels {
+		if bazelLabelExists(rootPath, label) {
+			lint = append(lint, "bazel run "+label)
+		}
+	}
+	tools[config.ToolTypeFormat] = availableCommands(format...)
+	tools[config.ToolTypeLint] = availableCommands(lint...)
+	tools[config.ToolTypeTest] = availableCommands("bazel test //...")
 	return tools
 }
 
@@ -250,13 +258,20 @@ func (d *MakeDetector) GetBuildSystem() config.BuildSystem {
 }
 
 // GetTools returns the available tools for Make.
-func (d *MakeDetector) GetTools(_ string) map[config.ToolType][]string {
+func (d *MakeDetector) GetTools(rootPath string) map[config.ToolType][]string {
 	tools := make(map[config.ToolType][]string)
-
-	// Make provides targets for different operations
-	tools[config.ToolTypeFormat] = []string{"make format"}
-	tools[config.ToolTypeLint] = []string{"make lint"}
-	tools[config.ToolTypeTest] = []string{"make test"}
-
+	targets := []struct {
+		toolType config.ToolType
+		target   string
+	}{
+		{config.ToolTypeFormat, "format"},
+		{config.ToolTypeLint, "lint"},
+		{config.ToolTypeTest, "test"},
+	}
+	for _, item := range targets {
+		if makefileHasTarget(rootPath, item.target) {
+			tools[item.toolType] = availableCommands("make " + item.target)
+		}
+	}
 	return tools
 }

--- a/devtools/devcheck/internal/detector/detector_test.go
+++ b/devtools/devcheck/internal/detector/detector_test.go
@@ -46,7 +46,7 @@ func TestProjectDetector_Detect(t *testing.T) {
 		{
 			name:              "typescript project",
 			files:             []string{"tsconfig.json", "package.json", "src/main.ts"},
-			expectedLanguages: []config.Language{config.LanguageTypeScript, config.LanguageJavaScript},
+			expectedLanguages: []config.Language{config.LanguageTypeScript},
 			expectedBuild:     config.BuildSystemNone,
 			expectedHasGit:    false,
 		},
@@ -282,14 +282,14 @@ func TestProjectDetector_DetectWithLocationPriority(t *testing.T) {
 			description: "Should detect Make when Makefile is in root despite MODULE.bazel in subdirectory",
 		},
 		{
-			name: "both_in_subdirectories_bazel_priority",
+			name: "both_in_subdirectories_prefers_make_without_bazel_tools",
 			files: []string{
 				"main.go",
 				"src/MODULE.bazel",
 				"test/Makefile",
 			},
-			expected:    config.BuildSystemBazel,
-			description: "Should use priority order (Bazel > Make) when both are at same depth",
+			expected:    config.BuildSystemMake,
+			description: "Should prefer Make when Bazel and Make are at the same depth but Bazel format/lint targets are missing",
 		},
 		{
 			name: "make_shallow_bazel_deep",
@@ -341,5 +341,149 @@ func TestProjectDetector_DetectWithLocationPriority(t *testing.T) {
 					tt.description, tt.expected, result.BuildSystem)
 			}
 		})
+	}
+}
+
+func TestProjectDetector_DetectPrefersMakeWhenBazelFormatLintMissing(t *testing.T) {
+	withBinsOnPath(t, "make", "bazel")
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"go.mod":       "module example",
+		"main.go":      "package main",
+		"MODULE.bazel": "module(name = \"example\")",
+		"BUILD.bazel":  "alias(name = \"format\", actual = \"//tools/format:format\")\n",
+		"Makefile":     "format:\nlint:\ntest:\n",
+	})
+
+	result, err := NewProjectDetector().Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if result.BuildSystem != config.BuildSystemMake {
+		t.Errorf("BuildSystem = %v, want make when //tools:format and //tools:lint are missing", result.BuildSystem)
+	}
+	assertFirstTool(t, result, config.ToolTypeFormat, "make format")
+	assertFirstTool(t, result, config.ToolTypeLint, "make lint")
+	assertFirstTool(t, result, config.ToolTypeTest, "make test")
+}
+
+func TestProjectDetector_DetectUsesBazelWhenFormatAndLintTargetsExist(t *testing.T) {
+	withBinsOnPath(t, "make", "bazel")
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"go.mod":            "module example",
+		"main.go":           "package main",
+		"MODULE.bazel":      "module(name = \"example\")",
+		"Makefile":          "format:\nlint:\ntest:\n",
+		"tools/BUILD.bazel": "sh_binary(name = \"format\", srcs = [\"format.sh\"])\nsh_binary(name = \"lint\", srcs = [\"lint.sh\"])\n",
+	})
+
+	result, err := NewProjectDetector().Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if result.BuildSystem != config.BuildSystemBazel {
+		t.Errorf("BuildSystem = %v, want bazel when //tools:format and //tools:lint exist", result.BuildSystem)
+	}
+	assertFirstTool(t, result, config.ToolTypeFormat, "bazel run //tools:format")
+	assertFirstTool(t, result, config.ToolTypeLint, "bazel run //tools:lint")
+}
+
+func TestProjectDetector_DetectTSOnlyTreeDoesNotListJavaScript(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"tsconfig.json": `{"compilerOptions":{}}`,
+		"src/main.ts":   "export const x = 1;",
+		"package.json":  `{"name":"app","scripts":{"test":"jest"}}`,
+	})
+
+	result, err := NewProjectDetector().Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	for _, lang := range result.Languages {
+		if lang == config.LanguageJavaScript {
+			t.Fatalf("Languages = %v, want no javascript for a TS-only tree", result.Languages)
+		}
+	}
+	if !hasLanguage(result.Languages, config.LanguageTypeScript) {
+		t.Errorf("Languages = %v, want typescript", result.Languages)
+	}
+}
+
+func TestBazelDetector_GetToolsOnlyListsExistingTargets(t *testing.T) {
+	withBinsOnPath(t, "bazel")
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"BUILD.bazel": "alias(name = \"format\", actual = \":fmt\")\n",
+	})
+
+	tools := NewBazelDetector().GetTools(dir)
+	assertContainsTool(t, tools[config.ToolTypeFormat], "bazel run //:format")
+	assertNotContainsTool(t, tools[config.ToolTypeFormat], "bazel run //tools:format")
+	assertNotContainsTool(t, tools[config.ToolTypeLint], "bazel run //tools:lint")
+	assertNotContainsTool(t, tools[config.ToolTypeLint], "bazel run //:lint")
+}
+
+func TestMakeDetector_GetToolsOnlyListsExistingTargets(t *testing.T) {
+	withBinsOnPath(t, "make")
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"Makefile": "format:\ntest:\n",
+	})
+
+	tools := NewMakeDetector().GetTools(dir)
+	assertContainsTool(t, tools[config.ToolTypeFormat], "make format")
+	assertContainsTool(t, tools[config.ToolTypeTest], "make test")
+	assertNotContainsTool(t, tools[config.ToolTypeLint], "make lint")
+}
+
+func withBinsOnPath(t *testing.T, names ...string) {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range names {
+		writeExecutable(t, filepath.Join(binDir, name))
+	}
+	t.Setenv("PATH", binDir)
+}
+
+func writeTree(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func assertFirstTool(t *testing.T, result *config.ProjectConfig, toolType config.ToolType, want string) {
+	t.Helper()
+	got := result.Tools[toolType]
+	if len(got) == 0 || got[0] != want {
+		t.Errorf("Tools[%s] first = %v, want %q", toolType, got, want)
+	}
+}
+
+func assertContainsTool(t *testing.T, tools []string, want string) {
+	t.Helper()
+	for _, tool := range tools {
+		if tool == want {
+			return
+		}
+	}
+	t.Errorf("tools %v, want to contain %q", tools, want)
+}
+
+func assertNotContainsTool(t *testing.T, tools []string, want string) {
+	t.Helper()
+	for _, tool := range tools {
+		if tool == want {
+			t.Errorf("tools %v, want not to contain %q", tools, want)
+			return
+		}
 	}
 }

--- a/devtools/devcheck/internal/detector/language.go
+++ b/devtools/devcheck/internal/detector/language.go
@@ -61,18 +61,11 @@ func (d *GoDetector) GetConfigFiles(rootPath string) map[string]string {
 
 // GetTools returns the available tools for Go development.
 func (d *GoDetector) GetTools(_ string) map[config.ToolType][]string {
-	tools := make(map[config.ToolType][]string)
-
-	// Format tools
-	tools[config.ToolTypeFormat] = []string{"gofumpt", "gofmt"}
-
-	// Lint tools
-	tools[config.ToolTypeLint] = []string{"golangci-lint", "unnecessary-interface-assertion-linter"}
-
-	// Test tools
-	tools[config.ToolTypeTest] = []string{"go test"}
-
-	return tools
+	return map[config.ToolType][]string{
+		config.ToolTypeFormat: availableCommands("gofumpt", "gofmt"),
+		config.ToolTypeLint:   availableCommands("golangci-lint", "unnecessary-interface-assertion-linter"),
+		config.ToolTypeTest:   availableCommands("go test"),
+	}
 }
 
 // PythonDetector implements language detection for Python projects.
@@ -131,18 +124,11 @@ func (d *PythonDetector) GetConfigFiles(rootPath string) map[string]string {
 
 // GetTools returns the available tools for Python development.
 func (d *PythonDetector) GetTools(_ string) map[config.ToolType][]string {
-	tools := make(map[config.ToolType][]string)
-
-	// Format tools
-	tools[config.ToolTypeFormat] = []string{"ruff format", "black"}
-
-	// Lint tools
-	tools[config.ToolTypeLint] = []string{"ruff check", "flake8"}
-
-	// Test tools
-	tools[config.ToolTypeTest] = []string{"pytest", "python -m unittest"}
-
-	return tools
+	return map[config.ToolType][]string{
+		config.ToolTypeFormat: availableCommands("ruff format", "black"),
+		config.ToolTypeLint:   availableCommands("ruff check", "flake8"),
+		config.ToolTypeTest:   availableCommands("pytest", "python -m unittest"),
+	}
 }
 
 // TypeScriptDetector implements language detection for TypeScript projects.
@@ -206,24 +192,27 @@ func (d *TypeScriptDetector) GetConfigFiles(rootPath string) map[string]string {
 
 // GetTools returns the available tools for TypeScript development.
 func (d *TypeScriptDetector) GetTools(rootPath string) map[config.ToolType][]string {
-	tools := make(map[config.ToolType][]string)
-
-	// Check if package.json exists to determine npm vs other tools
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err == nil && result.HasFile("package.json") {
-		// Use npm scripts if package.json exists
-		tools[config.ToolTypeFormat] = []string{"npm run format", "prettier"}
-		tools[config.ToolTypeLint] = []string{"npm run lint", "eslint"}
-		tools[config.ToolTypeTest] = []string{"npm test", "npm run test"}
-	} else {
-		// Fallback to direct tool usage
-		tools[config.ToolTypeFormat] = []string{"prettier"}
-		tools[config.ToolTypeLint] = []string{"eslint"}
-		tools[config.ToolTypeTest] = []string{"jest", "mocha"}
+	var format, lint, test []string
+	scripts := loadNpmScripts(rootPath)
+	if _, ok := scripts["format"]; ok {
+		format = append(format, "npm run format")
 	}
-
-	return tools
+	if _, ok := scripts["lint"]; ok {
+		lint = append(lint, "npm run lint")
+	}
+	if _, ok := scripts["test"]; ok {
+		test = append(test, "npm test")
+	}
+	format = append(format, "prettier")
+	lint = append(lint, "eslint")
+	if _, ok := scripts["test"]; !ok {
+		test = append(test, "jest", "mocha")
+	}
+	return map[config.ToolType][]string{
+		config.ToolTypeFormat: availableCommands(format...),
+		config.ToolTypeLint:   availableCommands(lint...),
+		config.ToolTypeTest:   availableCommands(test...),
+	}
 }
 
 // JavaScriptDetector implements language detection for JavaScript projects.

--- a/devtools/devcheck/internal/detector/language_test.go
+++ b/devtools/devcheck/internal/detector/language_test.go
@@ -166,6 +166,7 @@ func TestGoDetector_DetectLanguage(t *testing.T) {
 }
 
 func TestGoDetector_GetTools(t *testing.T) {
+	withBinsOnPath(t, "gofumpt", "gofmt", "golangci-lint", "go")
 	detector := NewGoDetector()
 
 	// Create temporary directory for test

--- a/devtools/devcheck/internal/detector/language_test.go
+++ b/devtools/devcheck/internal/detector/language_test.go
@@ -8,6 +8,101 @@ import (
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
 )
 
+func TestTypeScriptDetector_GetToolsOmitsMissingNpmScripts(t *testing.T) {
+	withBinsOnPath(t, "npm", "prettier", "eslint", "jest")
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"package.json": `{"name":"app","scripts":{"test":"jest","format":"prettier --write ."}}`,
+		"src/main.ts":  "export const x = 1;",
+	})
+
+	tools := NewTypeScriptDetector().GetTools(dir)
+	assertContainsTool(t, tools[config.ToolTypeFormat], "npm run format")
+	assertContainsTool(t, tools[config.ToolTypeTest], "npm test")
+	assertNotContainsTool(t, tools[config.ToolTypeLint], "npm run lint")
+}
+
+func TestJavaScriptDetector_DetectLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected bool
+	}{
+		{
+			name:     "javascript files",
+			files:    map[string]string{"src/app.js": "console.log(1);"},
+			expected: true,
+		},
+		{
+			name: "package.json without typescript",
+			files: map[string]string{
+				"package.json": `{"name":"app"}`,
+			},
+			expected: true,
+		},
+		{
+			name: "typescript-only tree",
+			files: map[string]string{
+				"tsconfig.json": `{"compilerOptions":{}}`,
+				"src/main.ts":   "export const x = 1;",
+				"package.json":  `{"name":"app"}`,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeTree(t, dir, tt.files)
+
+			got, err := NewJavaScriptDetector().DetectLanguage(dir)
+			if err != nil {
+				t.Fatalf("DetectLanguage() error = %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("DetectLanguage() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGoDetector_GetToolsOmitsMissingBinaries(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "gofmt"))
+	writeExecutable(t, filepath.Join(binDir, "go"))
+	t.Setenv("PATH", binDir)
+
+	tools := NewGoDetector().GetTools(t.TempDir())
+	assertContainsTool(t, tools[config.ToolTypeFormat], "gofmt")
+	assertNotContainsTool(t, tools[config.ToolTypeFormat], "gofumpt")
+	assertNotContainsTool(t, tools[config.ToolTypeLint], "golangci-lint")
+	assertContainsTool(t, tools[config.ToolTypeTest], "go test")
+}
+
+func TestPythonDetector_GetToolsOmitsMissingBinaries(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "black"))
+	writeExecutable(t, filepath.Join(binDir, "pytest"))
+	t.Setenv("PATH", binDir)
+
+	tools := NewPythonDetector().GetTools(t.TempDir())
+	assertContainsTool(t, tools[config.ToolTypeFormat], "black")
+	assertNotContainsTool(t, tools[config.ToolTypeFormat], "ruff format")
+	assertNotContainsTool(t, tools[config.ToolTypeLint], "ruff check")
+	assertContainsTool(t, tools[config.ToolTypeTest], "pytest")
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGoDetector_DetectLanguage(t *testing.T) {
 	// Create temporary directory for test
 	tempDir, err := os.MkdirTemp("", "go_detector_test")

--- a/devtools/devcheck/internal/detector/patterns.go
+++ b/devtools/devcheck/internal/detector/patterns.go
@@ -67,7 +67,6 @@ func (pm *PatternMatcher) initializeDefaultPatterns() {
 	}
 
 	pm.languagePatterns[config.LanguageJavaScript] = []FilePattern{
-		{Pattern: "package.json", Language: config.LanguageJavaScript, Required: false},
 		{Pattern: "*.js", Language: config.LanguageJavaScript, Required: false},
 		{Pattern: "*.jsx", Language: config.LanguageJavaScript, Required: false},
 	}
@@ -121,7 +120,31 @@ func (pm *PatternMatcher) MatchLanguages(files []string) []config.Language {
 		}
 	}
 
+	if !hasLanguage(detected, config.LanguageJavaScript) &&
+		!hasLanguage(detected, config.LanguageTypeScript) &&
+		pm.hasBasename(files, "package.json") {
+		detected = append(detected, config.LanguageJavaScript)
+	}
+
 	return detected
+}
+
+func hasLanguage(languages []config.Language, want config.Language) bool {
+	for _, language := range languages {
+		if language == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (pm *PatternMatcher) hasBasename(files []string, name string) bool {
+	for _, file := range files {
+		if filepath.Base(file) == name {
+			return true
+		}
+	}
+	return false
 }
 
 // MatchBuildSystem detects the primary build system from the given files.
@@ -146,13 +169,17 @@ func (pm *PatternMatcher) MatchBuildSystem(files []string) config.BuildSystem {
 // MatchBuildSystemWithLocation detects the primary build system considering file locations.
 // It prioritizes build files in the root directory over those in subdirectories.
 func (pm *PatternMatcher) MatchBuildSystemWithLocation(files []string) config.BuildSystem {
-	// Priority order for build systems
-	buildSystemPriority := []config.BuildSystem{
-		config.BuildSystemBazel,
-		config.BuildSystemMake,
+	systems := pm.MatchBuildSystemsAtChosenDepth(files)
+	if len(systems) == 0 {
+		return config.BuildSystemNone
 	}
+	return systems[0]
+}
 
-	// Group files by directory depth
+// MatchBuildSystemsAtChosenDepth returns every build system present at the
+// shallowest directory depth that contains a build system. Bazel is listed
+// before Make when both exist at that depth.
+func (pm *PatternMatcher) MatchBuildSystemsAtChosenDepth(files []string) []config.BuildSystem {
 	filesByDepth := make(map[int][]string)
 	minDepth := -1
 	maxDepth := -1
@@ -168,29 +195,32 @@ func (pm *PatternMatcher) MatchBuildSystemWithLocation(files []string) config.Bu
 		filesByDepth[depth] = append(filesByDepth[depth], file)
 	}
 
-	// If no files found, return none
 	if minDepth == -1 {
-		return config.BuildSystemNone
+		return nil
 	}
 
-	// Check each depth level, starting from the shallowest (root)
+	order := []config.BuildSystem{
+		config.BuildSystemBazel,
+		config.BuildSystemMake,
+	}
 	for depth := minDepth; depth <= maxDepth; depth++ {
 		filesAtDepth, exists := filesByDepth[depth]
 		if !exists {
 			continue
 		}
-
-		// Check build systems in priority order at this depth
-		for _, buildSystem := range buildSystemPriority {
-			if patterns, exists := pm.buildSystemPatterns[buildSystem]; exists {
-				if pm.matchPatterns(filesAtDepth, patterns) {
-					return buildSystem
-				}
+		var matched []config.BuildSystem
+		for _, buildSystem := range order {
+			patterns, ok := pm.buildSystemPatterns[buildSystem]
+			if ok && pm.matchPatterns(filesAtDepth, patterns) {
+				matched = append(matched, buildSystem)
 			}
+		}
+		if len(matched) > 0 {
+			return matched
 		}
 	}
 
-	return config.BuildSystemNone
+	return nil
 }
 
 // MatchConfigFiles finds configuration files for the given tool.

--- a/devtools/devcheck/internal/detector/patterns_test.go
+++ b/devtools/devcheck/internal/detector/patterns_test.go
@@ -50,7 +50,22 @@ func TestPatternMatcher_MatchLanguages(t *testing.T) {
 		{
 			name:     "typescript project",
 			files:    []string{"tsconfig.json", "src/main.ts", "package.json"},
-			expected: []config.Language{config.LanguageTypeScript, config.LanguageJavaScript},
+			expected: []config.Language{config.LanguageTypeScript},
+		},
+		{
+			name:     "javascript from js files",
+			files:    []string{"src/main.js", "src/app.jsx"},
+			expected: []config.Language{config.LanguageJavaScript},
+		},
+		{
+			name:     "javascript from package.json without typescript",
+			files:    []string{"package.json", "README.md"},
+			expected: []config.Language{config.LanguageJavaScript},
+		},
+		{
+			name:     "typescript-only tree is not javascript",
+			files:    []string{"tsconfig.json", "src/main.ts"},
+			expected: []config.Language{config.LanguageTypeScript},
 		},
 		{
 			name:     "mixed project",

--- a/devtools/devcheck/internal/detector/probe.go
+++ b/devtools/devcheck/internal/detector/probe.go
@@ -1,0 +1,185 @@
+package detector
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
+)
+
+var (
+	bazelFormatLabels = []string{"//tools:format", "//:format"}
+	bazelLintLabels   = []string{"//tools:lint", "//:lint"}
+	makeTargetRe      = regexp.MustCompile(`^([A-Za-z0-9_./-]+)\s*:`)
+	bazelNameRe       = regexp.MustCompile(`name\s*=\s*"([^"]+)"`)
+)
+
+func selectBuildSystem(root string, candidates []config.BuildSystem) config.BuildSystem {
+	if len(candidates) == 0 {
+		return config.BuildSystemNone
+	}
+	hasBazel, hasMake := false, false
+	for _, candidate := range candidates {
+		switch candidate {
+		case config.BuildSystemBazel:
+			hasBazel = true
+		case config.BuildSystemMake:
+			hasMake = true
+		}
+	}
+	if hasBazel && hasMake {
+		if bazelHasFormatAndLint(root) {
+			return config.BuildSystemBazel
+		}
+		return config.BuildSystemMake
+	}
+	return candidates[0]
+}
+
+func bazelHasFormatAndLint(root string) bool {
+	return bazelHasAnyLabel(root, bazelFormatLabels) && bazelHasAnyLabel(root, bazelLintLabels)
+}
+
+func bazelHasAnyLabel(root string, labels []string) bool {
+	for _, label := range labels {
+		if bazelLabelExists(root, label) {
+			return true
+		}
+	}
+	return false
+}
+
+func bazelLabelExists(root, label string) bool {
+	pkg, name, ok := splitBazelLabel(label)
+	if !ok {
+		return false
+	}
+	dir := root
+	if pkg != "" {
+		dir = filepath.Join(root, filepath.FromSlash(pkg))
+	}
+	for _, build := range []string{"BUILD.bazel", "BUILD"} {
+		if packageHasBazelTarget(filepath.Join(dir, build), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitBazelLabel(label string) (pkg, name string, ok bool) {
+	if !strings.HasPrefix(label, "//") {
+		return "", "", false
+	}
+	pkg, name, found := strings.Cut(strings.TrimPrefix(label, "//"), ":")
+	if !found || name == "" {
+		return "", "", false
+	}
+	return pkg, name, true
+}
+
+func packageHasBazelTarget(buildFile, name string) bool {
+	data, err := os.ReadFile(buildFile)
+	if err != nil {
+		return false
+	}
+	for _, match := range bazelNameRe.FindAllStringSubmatch(string(data), -1) {
+		if match[1] == name {
+			return true
+		}
+	}
+	return false
+}
+
+func makefileHasTarget(root, target string) bool {
+	for _, name := range []string{"Makefile", "makefile"} {
+		if makefileContentHasTarget(filepath.Join(root, name), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func makefileContentHasTarget(path, target string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		match := makeTargetRe.FindStringSubmatch(strings.TrimRight(line, "\r"))
+		if len(match) == 2 && match[1] == target {
+			return true
+		}
+	}
+	return false
+}
+
+func availableCommands(specs ...string) []string {
+	var out []string
+	for _, spec := range specs {
+		if commandAvailable(spec) {
+			out = append(out, spec)
+		}
+	}
+	return out
+}
+
+func commandAvailable(spec string) bool {
+	fields := strings.Fields(spec)
+	if len(fields) == 0 {
+		return false
+	}
+	_, err := exec.LookPath(fields[0])
+	return err == nil
+}
+
+type npmPackage struct {
+	Scripts map[string]string `json:"scripts"`
+}
+
+func loadNpmScripts(rootPath string) map[string]string {
+	path, ok := findPackageJSON(rootPath)
+	if !ok {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg npmPackage
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+	return pkg.Scripts
+}
+
+func findPackageJSON(rootPath string) (string, bool) {
+	rootFile := filepath.Join(rootPath, "package.json")
+	if _, err := os.Stat(rootFile); err == nil {
+		return rootFile, true
+	}
+	scanner := NewScanner(DefaultScanOptions())
+	result, err := scanner.Scan(rootPath)
+	if err != nil {
+		return "", false
+	}
+	best := ""
+	bestDepth := -1
+	for _, file := range result.Files {
+		if filepath.Base(file) != "package.json" {
+			continue
+		}
+		depth := strings.Count(file, string(filepath.Separator))
+		if best == "" || depth < bestDepth {
+			best = file
+			bestDepth = depth
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	return filepath.Join(rootPath, best), true
+}


### PR DESCRIPTION
## Summary
- Probe Make targets and Bazel labels instead of assuming `bazel run //tools:format` / `//tools:lint` exist. When both build systems are at the same depth, prefer Make if those Bazel format/lint targets are missing (this repo).
- Parse `package.json` `scripts` before listing `npm run *`, and drop binaries that are not on `PATH`.
- Detect JavaScript from `*.js` / `*.jsx` (or a `package.json` that is not a TypeScript project), not from `package.json` alone.

Resolves #270

## Demo

Recorded against this repo. `main` always listed Bazel commands that do not exist here (`//tools:format`, `//tools:lint`) and reported JavaScript because of `my-ts-project/package.json`. This PR probes real entry points, so Make is the primary path and a TS-only tree is not JavaScript.

### Before (`main`)

`devcheck --dry-run .`

```
🔧 DevCheck Report

Repository Analysis:
- Build System: bazel
- Languages: typescript, javascript, go, python
- Strategy: Dry-run; commands were not executed

Tools that would run:
⏳ bazel run //tools:format - would run
⏳ bazel run //tools:lint - would run
⏳ bazel test //... - would run

Issues Found:
none
Next Steps for AI Agent:
1. Re-run without --dry-run to execute the selected tools

Status: dry-run (commands were not executed)
```

`devcheck --dry-run --format=summary .`

```
DevCheck: 3 passed, 0 failed
  dry-run bazel run //tools:format
  dry-run bazel run //tools:lint
  dry-run bazel test //...
```

### After (this PR)

`devcheck --dry-run .`

```
🔧 DevCheck Report

Repository Analysis:
- Build System: make
- Languages: go, python, typescript
- Strategy: Dry-run; commands were not executed

Tools that would run:
⏳ make format - would run
⏳ make lint - would run
⏳ make test - would run

Issues Found:
none
Next Steps for AI Agent:
1. Re-run without --dry-run to execute the selected tools

Status: dry-run (commands were not executed)
```

`devcheck --dry-run --format=summary .`

```
DevCheck: 3 passed, 0 failed
  dry-run make format
  dry-run make lint
  dry-run make test
```

## Test plan
- [x] `Detect()` on this repo reports Make as the primary format/lint/test path
- [x] A `package.json` without a `lint` script does not list `npm run lint`
- [x] A TS-only tree (`tsconfig.json` + `*.ts`, no `*.js`) does not list JavaScript
- [x] Missing `ruff` / `golangci-lint` is omitted, not presented as the thing to run
- [x] Bazel is still selected when `//tools:format` and `//tools:lint` both exist
- [x] `make check` is green (309 tests pass, lint/semgrep clean)