### PR TITLE
devcheck: scan once and drop unused language/build detectors

### DIFF
--- a/devtools/devcheck/internal/config/types.go
+++ b/devtools/devcheck/internal/config/types.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -25,6 +26,20 @@ const (
 	LanguageTypeScript Language = "typescript"
 	LanguageJavaScript Language = "javascript"
 )
+
+// Tool is a detected command the executor can run without re-parsing a shell string.
+type Tool struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args,omitempty"`
+}
+
+// String returns the command line as command plus args.
+func (t Tool) String() string {
+	if len(t.Args) == 0 {
+		return t.Command
+	}
+	return t.Command + " " + strings.Join(t.Args, " ")
+}
 
 // ToolType represents the type of development tool.
 type ToolType string
@@ -57,7 +72,7 @@ type ProjectConfig struct {
 	Languages []Language `json:"languages"`
 
 	// Tools maps tool types to their detected commands
-	Tools map[ToolType][]string `json:"tools"`
+	Tools map[ToolType][]Tool `json:"tools"`
 
 	// ConfigFiles maps languages/tools to their configuration files
 	ConfigFiles map[string]string `json:"configFiles"`

--- a/devtools/devcheck/internal/config/types_test.go
+++ b/devtools/devcheck/internal/config/types_test.go
@@ -24,7 +24,7 @@ func TestProjectConfig_Initialization(t *testing.T) {
 				RootPath:      "/test/path",
 				BuildSystem:   BuildSystemBazel,
 				Languages:     []Language{LanguageGo, LanguagePython},
-				Tools:         map[ToolType][]string{ToolTypeFormat: {"gofumpt"}},
+				Tools:         map[ToolType][]Tool{ToolTypeFormat: {{Command: "gofumpt"}}},
 				ConfigFiles:   map[string]string{"golangci-lint": ".golangci.yml"},
 				HasGit:        true,
 				DetectionTime: time.Now(),
@@ -71,7 +71,7 @@ func TestProjectConfig_Validate(t *testing.T) {
 				RootPath:    "/test/path",
 				BuildSystem: BuildSystemBazel,
 				Languages:   []Language{LanguageGo},
-				Tools:       map[ToolType][]string{ToolTypeLint: {"golangci-lint"}},
+				Tools:       map[ToolType][]Tool{ToolTypeLint: {{Command: "golangci-lint"}}},
 			},
 			wantErr: false,
 		},
@@ -111,7 +111,7 @@ func TestProjectConfig_Validate(t *testing.T) {
 			name: "invalid tool type",
 			pc: ProjectConfig{
 				RootPath: "/test/path",
-				Tools:    map[ToolType][]string{"invalid": {"tool"}},
+				Tools:    map[ToolType][]Tool{"invalid": {{Command: "tool"}}},
 			},
 			wantErr: true,
 			errMsg:  "invalid tool type",
@@ -137,7 +137,7 @@ func TestProjectConfig_JSON(t *testing.T) {
 		RootPath:      "/test/path",
 		BuildSystem:   BuildSystemBazel,
 		Languages:     []Language{LanguageGo, LanguagePython},
-		Tools:         map[ToolType][]string{ToolTypeFormat: {"gofumpt"}},
+		Tools:         map[ToolType][]Tool{ToolTypeFormat: {{Command: "gofumpt"}}},
 		ConfigFiles:   map[string]string{"golangci-lint": ".golangci.yml"},
 		HasGit:        true,
 		DetectionTime: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
@@ -167,85 +167,52 @@ func TestProjectConfig_JSON(t *testing.T) {
 	}
 }
 
-func TestBuildSystemConstants(t *testing.T) {
+func TestTool_StringKeepsCommandAndArgsSeparate(t *testing.T) {
 	tests := []struct {
-		name   string
-		bs     BuildSystem
-		expect string
+		name string
+		tool Tool
+		want string
 	}{
-		{"bazel", BuildSystemBazel, "bazel"},
-		{"make", BuildSystemMake, "make"},
-		{"none", BuildSystemNone, "none"},
+		{name: "command only", tool: Tool{Command: "gofumpt"}, want: "gofumpt"},
+		{name: "bazel", tool: Tool{Command: "bazel", Args: []string{"run", "//tools:format"}}, want: "bazel run //tools:format"},
+		{name: "make", tool: Tool{Command: "make", Args: []string{"format"}}, want: "make format"},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if string(tt.bs) != tt.expect {
-				t.Errorf("Expected %s, got %s", tt.expect, string(tt.bs))
+			if got := tt.tool.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+			if strings.Contains(tt.tool.Command, " ") {
+				t.Errorf("Command = %q, want no spaces so the executor does not need sh -c", tt.tool.Command)
 			}
 		})
 	}
 }
 
-func TestLanguageConstants(t *testing.T) {
-	tests := []struct {
-		name   string
-		lang   Language
-		expect string
-	}{
-		{"go", LanguageGo, "go"},
-		{"python", LanguagePython, "python"},
-		{"typescript", LanguageTypeScript, "typescript"},
-		{"javascript", LanguageJavaScript, "javascript"},
+func TestProjectConfig_JSONRoundTripPreservesToolArgs(t *testing.T) {
+	pc := ProjectConfig{
+		RootPath: "/test/path",
+		Tools: map[ToolType][]Tool{
+			ToolTypeFormat: {{Command: "bazel", Args: []string{"run", "//tools:format"}}},
+		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if string(tt.lang) != tt.expect {
-				t.Errorf("Expected %s, got %s", tt.expect, string(tt.lang))
-			}
-		})
+	data, err := json.Marshal(pc)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
 	}
-}
-
-func TestToolTypeConstants(t *testing.T) {
-	tests := []struct {
-		name   string
-		tool   ToolType
-		expect string
-	}{
-		{"format", ToolTypeFormat, "format"},
-		{"lint", ToolTypeLint, "lint"},
-		{"test", ToolTypeTest, "test"},
+	var got ProjectConfig
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if string(tt.tool) != tt.expect {
-				t.Errorf("Expected %s, got %s", tt.expect, string(tt.tool))
-			}
-		})
+	tools := got.Tools[ToolTypeFormat]
+	if len(tools) != 1 {
+		t.Fatalf("format tools = %v, want 1", tools)
 	}
-}
-
-func TestSeverityConstants(t *testing.T) {
-	tests := []struct {
-		name   string
-		sev    Severity
-		expect string
-	}{
-		{"error", SeverityError, "error"},
-		{"warning", SeverityWarning, "warning"},
-		{"info", SeverityInfo, "info"},
-		{"hint", SeverityHint, "hint"},
+	if tools[0].Command != "bazel" {
+		t.Errorf("Command = %q, want bazel", tools[0].Command)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if string(tt.sev) != tt.expect {
-				t.Errorf("Expected %s, got %s", tt.expect, string(tt.sev))
-			}
-		})
+	if strings.Join(tools[0].Args, " ") != "run //tools:format" {
+		t.Errorf("Args = %v, want [run //tools:format]", tools[0].Args)
 	}
 }
 

--- a/devtools/devcheck/internal/detector/detector.go
+++ b/devtools/devcheck/internal/detector/detector.go
@@ -2,7 +2,9 @@
 package detector
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -10,67 +12,30 @@ import (
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
 )
 
-// languageDetector defines the interface for language-specific detection.
-type languageDetector interface {
-	// DetectLanguage checks if the given path contains the specific language
-	DetectLanguage(rootPath string) (bool, error)
-
-	// GetLanguage returns the language this detector handles
-	GetLanguage() config.Language
-
-	// GetConfigFiles returns the configuration files for this language
-	GetConfigFiles(rootPath string) map[string]string
-
-	// GetTools returns the available tools for this language
-	GetTools(rootPath string) map[config.ToolType][]string
-}
-
-// buildSystemDetector defines the interface for build system detection.
-type buildSystemDetector interface {
-	// DetectBuildSystem checks if the given path uses this build system
-	DetectBuildSystem(rootPath string) (bool, error)
-
-	// GetBuildSystem returns the build system this detector handles
-	GetBuildSystem() config.BuildSystem
-
-	// GetTools returns the available tools for this build system
-	GetTools(rootPath string) map[config.ToolType][]string
+// directoryScanner walks a project tree once per Detect call.
+type directoryScanner interface {
+	Scan(rootPath string) (*ScanResult, error)
 }
 
 // ProjectDetector implements the main project detection logic.
 type ProjectDetector struct {
-	patternMatcher       *PatternMatcher
-	languageDetectors    map[config.Language]languageDetector
-	buildSystemDetectors map[config.BuildSystem]buildSystemDetector
+	scanner        directoryScanner
+	patternMatcher *PatternMatcher
+	languages      []languageProfile
+	buildTools     map[config.BuildSystem]func(string) map[config.ToolType][]config.Tool
 }
 
-// NewProjectDetector creates a new project detector with all language and build system detectors.
+// NewProjectDetector creates a project detector with the default language table and scanners.
 func NewProjectDetector() *ProjectDetector {
-	detector := &ProjectDetector{
-		patternMatcher:       NewPatternMatcher(),
-		languageDetectors:    make(map[config.Language]languageDetector),
-		buildSystemDetectors: make(map[config.BuildSystem]buildSystemDetector),
+	return &ProjectDetector{
+		scanner:        NewScanner(DefaultScanOptions()),
+		patternMatcher: NewPatternMatcher(),
+		languages:      languageProfiles,
+		buildTools: map[config.BuildSystem]func(string) map[config.ToolType][]config.Tool{
+			config.BuildSystemBazel: bazelTools,
+			config.BuildSystemMake:  makeTools,
+		},
 	}
-
-	// Register language detectors
-	goDetector := NewGoDetector()
-	pythonDetector := NewPythonDetector()
-	tsDetector := NewTypeScriptDetector()
-	jsDetector := NewJavaScriptDetector()
-
-	detector.languageDetectors[config.LanguageGo] = goDetector
-	detector.languageDetectors[config.LanguagePython] = pythonDetector
-	detector.languageDetectors[config.LanguageTypeScript] = tsDetector
-	detector.languageDetectors[config.LanguageJavaScript] = jsDetector
-
-	// Register build system detectors
-	bazelDetector := NewBazelDetector()
-	makeDetector := NewMakeDetector()
-
-	detector.buildSystemDetectors[config.BuildSystemBazel] = bazelDetector
-	detector.buildSystemDetectors[config.BuildSystemMake] = makeDetector
-
-	return detector
 }
 
 // Detect analyzes the given path and returns project configuration.
@@ -80,186 +45,140 @@ func (d *ProjectDetector) Detect(rootPath string) (*config.ProjectConfig, error)
 		return nil, fmt.Errorf("failed to resolve absolute path: %w", err)
 	}
 
-	scanResult, err := d.performInitialScan(absPath)
+	scanResult, err := d.scanner.Scan(absPath)
 	if err != nil {
+		return nil, fmt.Errorf("scan project: %w", err)
+	}
+	if err := scanErrors(scanResult); err != nil {
 		return nil, err
 	}
 
 	languages := d.patternMatcher.MatchLanguages(scanResult.Files)
 	buildSystem := selectBuildSystem(absPath, d.patternMatcher.MatchBuildSystemsAtChosenDepth(scanResult.Files))
-	hasGit := d.detectGitRepository(absPath)
+	hasGit, err := detectGitRepository(absPath)
+	if err != nil {
+		return nil, err
+	}
 
-	tools := d.aggregateTools(languages, buildSystem, absPath)
-	configFiles := d.collectConfigFiles(languages, absPath)
-
-	return &config.ProjectConfig{
+	cfg := &config.ProjectConfig{
 		RootPath:      absPath,
 		BuildSystem:   buildSystem,
 		Languages:     languages,
-		Tools:         tools,
-		ConfigFiles:   configFiles,
+		Tools:         d.aggregateTools(languages, buildSystem, absPath, scanResult),
+		ConfigFiles:   d.collectConfigFiles(languages, scanResult),
 		HasGit:        hasGit,
 		DetectionTime: time.Now(),
-	}, nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid project config: %w", err)
+	}
+	return cfg, nil
 }
 
-func (d *ProjectDetector) performInitialScan(absPath string) (*ScanResult, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	return scanner.Scan(absPath)
+func scanErrors(result *ScanResult) error {
+	if result == nil || len(result.Errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("scan errors: %w", errors.Join(result.Errors...))
 }
 
-func (d *ProjectDetector) detectGitRepository(absPath string) bool {
+func detectGitRepository(absPath string) (bool, error) {
 	_, err := os.Stat(filepath.Join(absPath, ".git"))
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("inspect git metadata: %w", err)
 }
 
-func (d *ProjectDetector) aggregateTools(languages []config.Language, buildSystem config.BuildSystem, absPath string) map[config.ToolType][]string {
-	tools := make(map[config.ToolType][]string)
-
-	// Add language-specific tools
-	d.addLanguageTools(tools, languages, absPath)
-
-	// Add build system tools (with priority)
+func (d *ProjectDetector) aggregateTools(languages []config.Language, buildSystem config.BuildSystem, absPath string, scan *ScanResult) map[config.ToolType][]config.Tool {
+	tools := make(map[config.ToolType][]config.Tool)
+	d.addLanguageTools(tools, languages, absPath, scan)
 	d.addBuildSystemTools(tools, buildSystem, absPath)
-
 	return tools
 }
 
-func (d *ProjectDetector) addLanguageTools(tools map[config.ToolType][]string, languages []config.Language, absPath string) {
-	for _, lang := range languages {
-		if detector, exists := d.languageDetectors[lang]; exists {
-			langTools := detector.GetTools(absPath)
-			for toolType, toolList := range langTools {
-				tools[toolType] = append(tools[toolType], toolList...)
-			}
+func (d *ProjectDetector) addLanguageTools(tools map[config.ToolType][]config.Tool, languages []config.Language, absPath string, scan *ScanResult) {
+	for _, profile := range d.languages {
+		if !hasLanguage(languages, profile.language) {
+			continue
+		}
+		for toolType, toolList := range profile.tools(absPath, scan) {
+			tools[toolType] = append(tools[toolType], toolList...)
 		}
 	}
 }
 
-func (d *ProjectDetector) addBuildSystemTools(tools map[config.ToolType][]string, buildSystem config.BuildSystem, absPath string) {
-	if detector, exists := d.buildSystemDetectors[buildSystem]; exists {
-		buildTools := detector.GetTools(absPath)
-		for toolType, toolList := range buildTools {
-			// Prepend build system tools to give them priority
-			tools[toolType] = append(toolList, tools[toolType]...)
-		}
+func (d *ProjectDetector) addBuildSystemTools(tools map[config.ToolType][]config.Tool, buildSystem config.BuildSystem, absPath string) {
+	lookup, exists := d.buildTools[buildSystem]
+	if !exists {
+		return
+	}
+	for toolType, toolList := range lookup(absPath) {
+		tools[toolType] = append(toolList, tools[toolType]...)
 	}
 }
 
-func (d *ProjectDetector) collectConfigFiles(languages []config.Language, absPath string) map[string]string {
+func (d *ProjectDetector) collectConfigFiles(languages []config.Language, scan *ScanResult) map[string]string {
 	configFiles := make(map[string]string)
-
-	for _, lang := range languages {
-		if detector, exists := d.languageDetectors[lang]; exists {
-			langConfigs := detector.GetConfigFiles(absPath)
-			for tool, file := range langConfigs {
-				configFiles[tool] = file
+	for _, profile := range d.languages {
+		if !hasLanguage(languages, profile.language) {
+			continue
+		}
+		for _, key := range profile.configKeys {
+			matches := d.patternMatcher.MatchConfigFiles(scan.Files, key)
+			if len(matches) > 0 {
+				configFiles[key] = matches[0]
 			}
 		}
+		if profile.extraConfig != nil {
+			profile.extraConfig(scan, configFiles)
+		}
 	}
-
 	return configFiles
 }
 
 // SupportedLanguages returns the list of languages this detector supports.
 func (d *ProjectDetector) SupportedLanguages() []config.Language {
-	languages := make([]config.Language, 0, len(d.languageDetectors))
-	for lang := range d.languageDetectors {
-		languages = append(languages, lang)
+	languages := make([]config.Language, 0, len(d.languages))
+	for _, profile := range d.languages {
+		languages = append(languages, profile.language)
 	}
 	return languages
 }
 
 // SupportedBuildSystems returns the list of build systems this detector supports.
 func (d *ProjectDetector) SupportedBuildSystems() []config.BuildSystem {
-	buildSystems := make([]config.BuildSystem, 0, len(d.buildSystemDetectors))
-	for bs := range d.buildSystemDetectors {
+	buildSystems := make([]config.BuildSystem, 0, len(d.buildTools))
+	for bs := range d.buildTools {
 		buildSystems = append(buildSystems, bs)
 	}
 	return buildSystems
 }
 
-// BazelDetector implements build system detection for Bazel.
-type BazelDetector struct {
-	patternMatcher *PatternMatcher
-}
-
-// NewBazelDetector creates a new Bazel build system detector.
-func NewBazelDetector() *BazelDetector {
-	return &BazelDetector{
-		patternMatcher: NewPatternMatcher(),
-	}
-}
-
-// DetectBuildSystem checks if the given path uses Bazel.
-func (d *BazelDetector) DetectBuildSystem(rootPath string) (bool, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return false, err
-	}
-
-	buildSystem := d.patternMatcher.MatchBuildSystem(result.Files)
-	return buildSystem == config.BuildSystemBazel, nil
-}
-
-// GetBuildSystem returns the build system this detector handles.
-func (d *BazelDetector) GetBuildSystem() config.BuildSystem {
-	return config.BuildSystemBazel
-}
-
-// GetTools returns the available tools for Bazel.
-func (d *BazelDetector) GetTools(rootPath string) map[config.ToolType][]string {
-	tools := make(map[config.ToolType][]string)
-	var format, lint []string
+func bazelTools(rootPath string) map[config.ToolType][]config.Tool {
+	var format, lint []config.Tool
 	for _, label := range bazelFormatLabels {
 		if bazelLabelExists(rootPath, label) {
-			format = append(format, "bazel run "+label)
+			format = append(format, config.Tool{Command: "bazel", Args: []string{"run", label}})
 		}
 	}
 	for _, label := range bazelLintLabels {
 		if bazelLabelExists(rootPath, label) {
-			lint = append(lint, "bazel run "+label)
+			lint = append(lint, config.Tool{Command: "bazel", Args: []string{"run", label}})
 		}
 	}
-	tools[config.ToolTypeFormat] = availableCommands(format...)
-	tools[config.ToolTypeLint] = availableCommands(lint...)
-	tools[config.ToolTypeTest] = availableCommands("bazel test //...")
-	return tools
-}
-
-// MakeDetector implements build system detection for Make.
-type MakeDetector struct {
-	patternMatcher *PatternMatcher
-}
-
-// NewMakeDetector creates a new Make build system detector.
-func NewMakeDetector() *MakeDetector {
-	return &MakeDetector{
-		patternMatcher: NewPatternMatcher(),
+	return map[config.ToolType][]config.Tool{
+		config.ToolTypeFormat: availableTools(format...),
+		config.ToolTypeLint:   availableTools(lint...),
+		config.ToolTypeTest:   availableTools(config.Tool{Command: "bazel", Args: []string{"test", "//..."}}),
 	}
 }
 
-// DetectBuildSystem checks if the given path uses Make.
-func (d *MakeDetector) DetectBuildSystem(rootPath string) (bool, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return false, err
-	}
-
-	buildSystem := d.patternMatcher.MatchBuildSystem(result.Files)
-	return buildSystem == config.BuildSystemMake, nil
-}
-
-// GetBuildSystem returns the build system this detector handles.
-func (d *MakeDetector) GetBuildSystem() config.BuildSystem {
-	return config.BuildSystemMake
-}
-
-// GetTools returns the available tools for Make.
-func (d *MakeDetector) GetTools(rootPath string) map[config.ToolType][]string {
-	tools := make(map[config.ToolType][]string)
+func makeTools(rootPath string) map[config.ToolType][]config.Tool {
+	tools := make(map[config.ToolType][]config.Tool)
 	targets := []struct {
 		toolType config.ToolType
 		target   string
@@ -270,7 +189,7 @@ func (d *MakeDetector) GetTools(rootPath string) map[config.ToolType][]string {
 	}
 	for _, item := range targets {
 		if makefileHasTarget(rootPath, item.target) {
-			tools[item.toolType] = availableCommands("make " + item.target)
+			tools[item.toolType] = availableTools(config.Tool{Command: "make", Args: []string{item.target}})
 		}
 	}
 	return tools

--- a/devtools/devcheck/internal/detector/detector_test.go
+++ b/devtools/devcheck/internal/detector/detector_test.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
@@ -411,31 +412,170 @@ func TestProjectDetector_DetectTSOnlyTreeDoesNotListJavaScript(t *testing.T) {
 	}
 }
 
-func TestBazelDetector_GetToolsOnlyListsExistingTargets(t *testing.T) {
+func TestBazelToolsOnlyListsExistingTargets(t *testing.T) {
 	withBinsOnPath(t, "bazel")
 	dir := t.TempDir()
 	writeTree(t, dir, map[string]string{
 		"BUILD.bazel": "alias(name = \"format\", actual = \":fmt\")\n",
 	})
 
-	tools := NewBazelDetector().GetTools(dir)
+	tools := bazelTools(dir)
 	assertContainsTool(t, tools[config.ToolTypeFormat], "bazel run //:format")
 	assertNotContainsTool(t, tools[config.ToolTypeFormat], "bazel run //tools:format")
 	assertNotContainsTool(t, tools[config.ToolTypeLint], "bazel run //tools:lint")
 	assertNotContainsTool(t, tools[config.ToolTypeLint], "bazel run //:lint")
 }
 
-func TestMakeDetector_GetToolsOnlyListsExistingTargets(t *testing.T) {
+func TestMakeToolsOnlyListsExistingTargets(t *testing.T) {
 	withBinsOnPath(t, "make")
 	dir := t.TempDir()
 	writeTree(t, dir, map[string]string{
 		"Makefile": "format:\ntest:\n",
 	})
 
-	tools := NewMakeDetector().GetTools(dir)
+	tools := makeTools(dir)
 	assertContainsTool(t, tools[config.ToolTypeFormat], "make format")
 	assertContainsTool(t, tools[config.ToolTypeTest], "make test")
 	assertNotContainsTool(t, tools[config.ToolTypeLint], "make lint")
+}
+
+func TestProjectDetector_DetectScansOnce(t *testing.T) {
+	dir := t.TempDir()
+	fake := &countingScanner{
+		result: &ScanResult{
+			Root: dir,
+			Files: []string{
+				"go.mod",
+				"main.go",
+				".golangci.yml",
+				"pyproject.toml",
+				"main.py",
+				"tsconfig.json",
+				"package.json",
+				"src/main.ts",
+				"src/app.js",
+			},
+		},
+	}
+	detector := NewProjectDetector()
+	detector.scanner = fake
+
+	result, err := detector.Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if fake.n != 1 {
+		t.Errorf("Scan called %d times, want 1", fake.n)
+	}
+	got, ok := result.ConfigFiles["golangci-lint"]
+	if !ok {
+		t.Fatalf("ConfigFiles = %v, want golangci-lint from the single scan result", result.ConfigFiles)
+	}
+	if got != ".golangci.yml" {
+		t.Errorf("ConfigFiles[golangci-lint] = %q, want .golangci.yml", got)
+	}
+	if result.ConfigFiles["typescript"] != "tsconfig.json" {
+		t.Errorf("ConfigFiles[typescript] = %q, want tsconfig.json from the scan result", result.ConfigFiles["typescript"])
+	}
+}
+
+func TestProjectDetector_DetectReturnsStructuredBuildSystemTools(t *testing.T) {
+	withBinsOnPath(t, "make", "bazel")
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"go.mod":            "module example",
+		"main.go":           "package main",
+		"MODULE.bazel":      "module(name = \"example\")",
+		"Makefile":          "format:\nlint:\ntest:\n",
+		"tools/BUILD.bazel": "sh_binary(name = \"format\", srcs = [\"format.sh\"])\nsh_binary(name = \"lint\", srcs = [\"lint.sh\"])\n",
+	})
+
+	result, err := NewProjectDetector().Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	assertStructuredTool(t, result, config.ToolTypeFormat, "bazel", []string{"run", "//tools:format"})
+	assertStructuredTool(t, result, config.ToolTypeLint, "bazel", []string{"run", "//tools:lint"})
+	assertStructuredTool(t, result, config.ToolTypeTest, "bazel", []string{"test", "//..."})
+}
+
+func TestProjectDetector_DetectFailsOnScanErrors(t *testing.T) {
+	dir := t.TempDir()
+	detector := NewProjectDetector()
+	detector.scanner = &countingScanner{
+		result: &ScanResult{
+			Root:   dir,
+			Files:  []string{"go.mod", "main.go"},
+			Errors: []error{os.ErrPermission},
+		},
+	}
+
+	_, err := detector.Detect(dir)
+	if err == nil {
+		t.Fatal("Detect() error = nil, want scan error")
+	}
+	if !strings.Contains(err.Error(), "scan errors") {
+		t.Errorf("error %q, want scan errors", err)
+	}
+}
+
+func TestProjectDetector_DetectFailsOnScanFailure(t *testing.T) {
+	dir := t.TempDir()
+	detector := NewProjectDetector()
+	detector.scanner = &countingScanner{err: os.ErrNotExist}
+
+	_, err := detector.Detect(dir)
+	if err == nil {
+		t.Fatal("Detect() error = nil, want scan failure")
+	}
+}
+
+func TestProjectDetector_DetectValidatesConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"go.mod":  "module example",
+		"main.go": "package main",
+	})
+
+	result, err := NewProjectDetector().Detect(dir)
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("Detect() returned config that fails Validate(): %v", err)
+	}
+}
+
+func TestProjectDetector_DetectFailsOnInvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"go.mod":  "module example",
+		"main.go": "package main",
+	})
+	detector := NewProjectDetector()
+	detector.patternMatcher.AddLanguagePattern("cobol", FilePattern{Pattern: "go.mod", Required: true})
+
+	_, err := detector.Detect(dir)
+	if err == nil {
+		t.Fatal("Detect() error = nil, want invalid project config")
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error %q, want invalid project config", err)
+	}
+}
+
+type countingScanner struct {
+	n      int
+	result *ScanResult
+	err    error
+}
+
+func (c *countingScanner) Scan(_ string) (*ScanResult, error) {
+	c.n++
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.result, nil
 }
 
 func withBinsOnPath(t *testing.T, names ...string) {
@@ -463,27 +603,56 @@ func writeTree(t *testing.T, dir string, files map[string]string) {
 func assertFirstTool(t *testing.T, result *config.ProjectConfig, toolType config.ToolType, want string) {
 	t.Helper()
 	got := result.Tools[toolType]
-	if len(got) == 0 || got[0] != want {
+	if len(got) == 0 || got[0].String() != want {
 		t.Errorf("Tools[%s] first = %v, want %q", toolType, got, want)
 	}
 }
 
-func assertContainsTool(t *testing.T, tools []string, want string) {
+func assertStructuredTool(t *testing.T, result *config.ProjectConfig, toolType config.ToolType, command string, args []string) {
+	t.Helper()
+	got := result.Tools[toolType]
+	if len(got) == 0 {
+		t.Fatalf("Tools[%s] is empty", toolType)
+	}
+	if got[0].Command != command {
+		t.Errorf("Tools[%s] Command = %q, want %q", toolType, got[0].Command, command)
+	}
+	if strings.Contains(got[0].Command, " ") {
+		t.Errorf("Tools[%s] Command = %q, want command and args separately", toolType, got[0].Command)
+	}
+	if !equalToolArgs(got[0].Args, args) {
+		t.Errorf("Tools[%s] Args = %v, want %v", toolType, got[0].Args, args)
+	}
+}
+
+func assertContainsTool(t *testing.T, tools []config.Tool, want string) {
 	t.Helper()
 	for _, tool := range tools {
-		if tool == want {
+		if tool.String() == want {
 			return
 		}
 	}
 	t.Errorf("tools %v, want to contain %q", tools, want)
 }
 
-func assertNotContainsTool(t *testing.T, tools []string, want string) {
+func assertNotContainsTool(t *testing.T, tools []config.Tool, want string) {
 	t.Helper()
 	for _, tool := range tools {
-		if tool == want {
+		if tool.String() == want {
 			t.Errorf("tools %v, want not to contain %q", tools, want)
 			return
 		}
 	}
+}
+
+func equalToolArgs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/devtools/devcheck/internal/detector/language.go
+++ b/devtools/devcheck/internal/detector/language.go
@@ -1,261 +1,100 @@
-// Package detector provides language-specific detection functionality.
 package detector
 
 import (
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
 )
 
-// GoDetector implements language detection for Go projects.
-type GoDetector struct {
-	patternMatcher *PatternMatcher
+// languageProfile is the table row for a supported language.
+type languageProfile struct {
+	language    config.Language
+	configKeys  []string
+	extraConfig func(*ScanResult, map[string]string)
+	tools       func(root string, scan *ScanResult) map[config.ToolType][]config.Tool
 }
 
-// NewGoDetector creates a new Go language detector.
-func NewGoDetector() *GoDetector {
-	return &GoDetector{
-		patternMatcher: NewPatternMatcher(),
-	}
+var languageProfiles = []languageProfile{
+	{
+		language:   config.LanguageGo,
+		configKeys: []string{"golangci-lint"},
+		tools:      goTools,
+	},
+	{
+		language:   config.LanguagePython,
+		configKeys: []string{"ruff"},
+		tools:      pythonTools,
+	},
+	{
+		language:    config.LanguageTypeScript,
+		configKeys:  []string{"eslint"},
+		extraConfig: recordTypeScriptConfig,
+		tools:       jsTools,
+	},
+	{
+		language:   config.LanguageJavaScript,
+		configKeys: []string{"eslint"},
+		tools:      jsTools,
+	},
 }
 
-// DetectLanguage checks if the given path contains a Go project.
-func (d *GoDetector) DetectLanguage(rootPath string) (bool, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return false, err
-	}
-
-	languages := d.patternMatcher.MatchLanguages(result.Files)
-	for _, lang := range languages {
-		if lang == config.LanguageGo {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// GetLanguage returns the language this detector handles.
-func (d *GoDetector) GetLanguage() config.Language {
-	return config.LanguageGo
-}
-
-// GetConfigFiles returns the configuration files for Go tools.
-func (d *GoDetector) GetConfigFiles(rootPath string) map[string]string {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return map[string]string{}
-	}
-
-	configFiles := make(map[string]string)
-
-	// Check for golangci-lint config
-	matches := d.patternMatcher.MatchConfigFiles(result.Files, "golangci-lint")
-	if len(matches) > 0 {
-		configFiles["golangci-lint"] = matches[0]
-	}
-
-	return configFiles
-}
-
-// GetTools returns the available tools for Go development.
-func (d *GoDetector) GetTools(_ string) map[config.ToolType][]string {
-	return map[config.ToolType][]string{
-		config.ToolTypeFormat: availableCommands("gofumpt", "gofmt"),
-		config.ToolTypeLint:   availableCommands("golangci-lint", "unnecessary-interface-assertion-linter"),
-		config.ToolTypeTest:   availableCommands("go test"),
+func goTools(_ string, _ *ScanResult) map[config.ToolType][]config.Tool {
+	return map[config.ToolType][]config.Tool{
+		config.ToolTypeFormat: availableTools(
+			config.Tool{Command: "gofumpt"},
+			config.Tool{Command: "gofmt"},
+		),
+		config.ToolTypeLint: availableTools(
+			config.Tool{Command: "golangci-lint"},
+			config.Tool{Command: "unnecessary-interface-assertion-linter"},
+		),
+		config.ToolTypeTest: availableTools(
+			config.Tool{Command: "go", Args: []string{"test"}},
+		),
 	}
 }
 
-// PythonDetector implements language detection for Python projects.
-type PythonDetector struct {
-	patternMatcher *PatternMatcher
-}
-
-// NewPythonDetector creates a new Python language detector.
-func NewPythonDetector() *PythonDetector {
-	return &PythonDetector{
-		patternMatcher: NewPatternMatcher(),
+func pythonTools(_ string, _ *ScanResult) map[config.ToolType][]config.Tool {
+	return map[config.ToolType][]config.Tool{
+		config.ToolTypeFormat: availableTools(
+			config.Tool{Command: "ruff", Args: []string{"format"}},
+			config.Tool{Command: "black"},
+		),
+		config.ToolTypeLint: availableTools(
+			config.Tool{Command: "ruff", Args: []string{"check"}},
+			config.Tool{Command: "flake8"},
+		),
+		config.ToolTypeTest: availableTools(
+			config.Tool{Command: "pytest"},
+			config.Tool{Command: "python", Args: []string{"-m", "unittest"}},
+		),
 	}
 }
 
-// DetectLanguage checks if the given path contains a Python project.
-func (d *PythonDetector) DetectLanguage(rootPath string) (bool, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return false, err
-	}
-
-	languages := d.patternMatcher.MatchLanguages(result.Files)
-	for _, lang := range languages {
-		if lang == config.LanguagePython {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// GetLanguage returns the language this detector handles.
-func (d *PythonDetector) GetLanguage() config.Language {
-	return config.LanguagePython
-}
-
-// GetConfigFiles returns the configuration files for Python tools.
-func (d *PythonDetector) GetConfigFiles(rootPath string) map[string]string {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return map[string]string{}
-	}
-
-	configFiles := make(map[string]string)
-
-	// Check for ruff config
-	matches := d.patternMatcher.MatchConfigFiles(result.Files, "ruff")
-	if len(matches) > 0 {
-		configFiles["ruff"] = matches[0]
-	}
-
-	return configFiles
-}
-
-// GetTools returns the available tools for Python development.
-func (d *PythonDetector) GetTools(_ string) map[config.ToolType][]string {
-	return map[config.ToolType][]string{
-		config.ToolTypeFormat: availableCommands("ruff format", "black"),
-		config.ToolTypeLint:   availableCommands("ruff check", "flake8"),
-		config.ToolTypeTest:   availableCommands("pytest", "python -m unittest"),
-	}
-}
-
-// TypeScriptDetector implements language detection for TypeScript projects.
-type TypeScriptDetector struct {
-	patternMatcher *PatternMatcher
-}
-
-// NewTypeScriptDetector creates a new TypeScript language detector.
-func NewTypeScriptDetector() *TypeScriptDetector {
-	return &TypeScriptDetector{
-		patternMatcher: NewPatternMatcher(),
-	}
-}
-
-// DetectLanguage checks if the given path contains a TypeScript project.
-func (d *TypeScriptDetector) DetectLanguage(rootPath string) (bool, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return false, err
-	}
-
-	languages := d.patternMatcher.MatchLanguages(result.Files)
-	for _, lang := range languages {
-		if lang == config.LanguageTypeScript {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// GetLanguage returns the language this detector handles.
-func (d *TypeScriptDetector) GetLanguage() config.Language {
-	return config.LanguageTypeScript
-}
-
-// GetConfigFiles returns the configuration files for TypeScript tools.
-func (d *TypeScriptDetector) GetConfigFiles(rootPath string) map[string]string {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return map[string]string{}
-	}
-
-	configFiles := make(map[string]string)
-
-	// Check for ESLint config
-	matches := d.patternMatcher.MatchConfigFiles(result.Files, "eslint")
-	if len(matches) > 0 {
-		configFiles["eslint"] = matches[0]
-	}
-
-	// Check for TypeScript config
-	if result.HasFile("tsconfig.json") {
-		configFiles["typescript"] = "tsconfig.json"
-	}
-
-	return configFiles
-}
-
-// GetTools returns the available tools for TypeScript development.
-func (d *TypeScriptDetector) GetTools(rootPath string) map[config.ToolType][]string {
-	var format, lint, test []string
-	scripts := loadNpmScripts(rootPath)
+func jsTools(rootPath string, scan *ScanResult) map[config.ToolType][]config.Tool {
+	var format, lint, test []config.Tool
+	scripts := loadNpmScripts(rootPath, scan)
 	if _, ok := scripts["format"]; ok {
-		format = append(format, "npm run format")
+		format = append(format, config.Tool{Command: "npm", Args: []string{"run", "format"}})
 	}
 	if _, ok := scripts["lint"]; ok {
-		lint = append(lint, "npm run lint")
+		lint = append(lint, config.Tool{Command: "npm", Args: []string{"run", "lint"}})
 	}
 	if _, ok := scripts["test"]; ok {
-		test = append(test, "npm test")
+		test = append(test, config.Tool{Command: "npm", Args: []string{"test"}})
 	}
-	format = append(format, "prettier")
-	lint = append(lint, "eslint")
+	format = append(format, config.Tool{Command: "prettier"})
+	lint = append(lint, config.Tool{Command: "eslint"})
 	if _, ok := scripts["test"]; !ok {
-		test = append(test, "jest", "mocha")
+		test = append(test, config.Tool{Command: "jest"}, config.Tool{Command: "mocha"})
 	}
-	return map[config.ToolType][]string{
-		config.ToolTypeFormat: availableCommands(format...),
-		config.ToolTypeLint:   availableCommands(lint...),
-		config.ToolTypeTest:   availableCommands(test...),
-	}
-}
-
-// JavaScriptDetector implements language detection for JavaScript projects.
-type JavaScriptDetector struct {
-	patternMatcher *PatternMatcher
-}
-
-// NewJavaScriptDetector creates a new JavaScript language detector.
-func NewJavaScriptDetector() *JavaScriptDetector {
-	return &JavaScriptDetector{
-		patternMatcher: NewPatternMatcher(),
+	return map[config.ToolType][]config.Tool{
+		config.ToolTypeFormat: availableTools(format...),
+		config.ToolTypeLint:   availableTools(lint...),
+		config.ToolTypeTest:   availableTools(test...),
 	}
 }
 
-// DetectLanguage checks if the given path contains a JavaScript project.
-func (d *JavaScriptDetector) DetectLanguage(rootPath string) (bool, error) {
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
-		return false, err
+func recordTypeScriptConfig(scan *ScanResult, files map[string]string) {
+	if scan.HasFile("tsconfig.json") {
+		files["typescript"] = "tsconfig.json"
 	}
-
-	languages := d.patternMatcher.MatchLanguages(result.Files)
-	for _, lang := range languages {
-		if lang == config.LanguageJavaScript {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// GetLanguage returns the language this detector handles.
-func (d *JavaScriptDetector) GetLanguage() config.Language {
-	return config.LanguageJavaScript
-}
-
-// GetConfigFiles returns the configuration files for JavaScript tools.
-func (d *JavaScriptDetector) GetConfigFiles(rootPath string) map[string]string {
-	return (&TypeScriptDetector{patternMatcher: d.patternMatcher}).GetConfigFiles(rootPath)
-}
-
-// GetTools returns the available tools for JavaScript development.
-func (d *JavaScriptDetector) GetTools(rootPath string) map[config.ToolType][]string {
-	return (&TypeScriptDetector{patternMatcher: d.patternMatcher}).GetTools(rootPath)
 }

--- a/devtools/devcheck/internal/detector/language_test.go
+++ b/devtools/devcheck/internal/detector/language_test.go
@@ -8,85 +8,41 @@ import (
 	"github.com/jaeyeom/experimental/devtools/devcheck/internal/config"
 )
 
-func TestTypeScriptDetector_GetToolsOmitsMissingNpmScripts(t *testing.T) {
+func TestJSToolsOmitsMissingNpmScripts(t *testing.T) {
 	withBinsOnPath(t, "npm", "prettier", "eslint", "jest")
 	dir := t.TempDir()
 	writeTree(t, dir, map[string]string{
 		"package.json": `{"name":"app","scripts":{"test":"jest","format":"prettier --write ."}}`,
 		"src/main.ts":  "export const x = 1;",
 	})
+	scan := mustScan(t, dir)
 
-	tools := NewTypeScriptDetector().GetTools(dir)
+	tools := jsTools(dir, scan)
 	assertContainsTool(t, tools[config.ToolTypeFormat], "npm run format")
 	assertContainsTool(t, tools[config.ToolTypeTest], "npm test")
 	assertNotContainsTool(t, tools[config.ToolTypeLint], "npm run lint")
 }
 
-func TestJavaScriptDetector_DetectLanguage(t *testing.T) {
-	tests := []struct {
-		name     string
-		files    map[string]string
-		expected bool
-	}{
-		{
-			name:     "javascript files",
-			files:    map[string]string{"src/app.js": "console.log(1);"},
-			expected: true,
-		},
-		{
-			name: "package.json without typescript",
-			files: map[string]string{
-				"package.json": `{"name":"app"}`,
-			},
-			expected: true,
-		},
-		{
-			name: "typescript-only tree",
-			files: map[string]string{
-				"tsconfig.json": `{"compilerOptions":{}}`,
-				"src/main.ts":   "export const x = 1;",
-				"package.json":  `{"name":"app"}`,
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			writeTree(t, dir, tt.files)
-
-			got, err := NewJavaScriptDetector().DetectLanguage(dir)
-			if err != nil {
-				t.Fatalf("DetectLanguage() error = %v", err)
-			}
-			if got != tt.expected {
-				t.Errorf("DetectLanguage() = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestGoDetector_GetToolsOmitsMissingBinaries(t *testing.T) {
+func TestGoToolsOmitsMissingBinaries(t *testing.T) {
 	binDir := t.TempDir()
 	writeExecutable(t, filepath.Join(binDir, "gofmt"))
 	writeExecutable(t, filepath.Join(binDir, "go"))
 	t.Setenv("PATH", binDir)
 
-	tools := NewGoDetector().GetTools(t.TempDir())
+	tools := goTools("", nil)
 	assertContainsTool(t, tools[config.ToolTypeFormat], "gofmt")
 	assertNotContainsTool(t, tools[config.ToolTypeFormat], "gofumpt")
 	assertNotContainsTool(t, tools[config.ToolTypeLint], "golangci-lint")
 	assertContainsTool(t, tools[config.ToolTypeTest], "go test")
 }
 
-func TestPythonDetector_GetToolsOmitsMissingBinaries(t *testing.T) {
+func TestPythonToolsOmitsMissingBinaries(t *testing.T) {
 	binDir := t.TempDir()
 	writeExecutable(t, filepath.Join(binDir, "black"))
 	writeExecutable(t, filepath.Join(binDir, "pytest"))
 	t.Setenv("PATH", binDir)
 
-	tools := NewPythonDetector().GetTools(t.TempDir())
+	tools := pythonTools("", nil)
 	assertContainsTool(t, tools[config.ToolTypeFormat], "black")
 	assertNotContainsTool(t, tools[config.ToolTypeFormat], "ruff format")
 	assertNotContainsTool(t, tools[config.ToolTypeLint], "ruff check")
@@ -103,231 +59,24 @@ func writeExecutable(t *testing.T, path string) {
 	}
 }
 
-func TestGoDetector_DetectLanguage(t *testing.T) {
-	// Create temporary directory for test
-	tempDir, err := os.MkdirTemp("", "go_detector_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	tests := []struct {
-		name     string
-		files    []string
-		expected bool
-	}{
-		{
-			name:     "go project with go.mod",
-			files:    []string{"go.mod", "main.go"},
-			expected: true,
-		},
-		{
-			name:     "go files without go.mod",
-			files:    []string{"main.go", "utils.go"},
-			expected: false,
-		},
-		{
-			name:     "no go files",
-			files:    []string{"README.md", "Makefile"},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create test directory
-			testDir := filepath.Join(tempDir, tt.name)
-			err := os.MkdirAll(testDir, 0o755)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Create test files
-			for _, file := range tt.files {
-				filePath := filepath.Join(testDir, file)
-				err := os.WriteFile(filePath, []byte("test content"), 0o600)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			detector := NewGoDetector()
-			result, err := detector.DetectLanguage(testDir)
-			if err != nil {
-				t.Errorf("DetectLanguage() error = %v", err)
-				return
-			}
-
-			if result != tt.expected {
-				t.Errorf("DetectLanguage() = %v, expected %v", result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestGoDetector_GetTools(t *testing.T) {
+func TestGoToolsListsFormatters(t *testing.T) {
 	withBinsOnPath(t, "gofumpt", "gofmt", "golangci-lint", "go")
-	detector := NewGoDetector()
 
-	// Create temporary directory for test
-	tempDir, err := os.MkdirTemp("", "go_tools_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	tools := detector.GetTools(tempDir)
-
-	// Should have format and lint tools
+	tools := goTools("", nil)
 	if len(tools[config.ToolTypeFormat]) == 0 {
 		t.Error("Expected format tools for Go")
 	}
-
 	if len(tools[config.ToolTypeLint]) == 0 {
 		t.Error("Expected lint tools for Go")
 	}
-
-	// Check for specific tools
-	formatTools := tools[config.ToolTypeFormat]
-	found := false
-	for _, tool := range formatTools {
-		if tool == "gofumpt" || tool == "gofmt" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("Expected gofumpt or gofmt in format tools")
-	}
+	assertContainsTool(t, tools[config.ToolTypeFormat], "gofumpt")
 }
 
-func TestPythonDetector_DetectLanguage(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "python_detector_test")
+func mustScan(t *testing.T, dir string) *ScanResult {
+	t.Helper()
+	result, err := NewScanner(DefaultScanOptions()).Scan(dir)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Scan() error = %v", err)
 	}
-	defer os.RemoveAll(tempDir)
-
-	tests := []struct {
-		name     string
-		files    []string
-		expected bool
-	}{
-		{
-			name:     "python project with pyproject.toml",
-			files:    []string{"pyproject.toml", "main.py"},
-			expected: true,
-		},
-		{
-			name:     "python project with requirements.txt",
-			files:    []string{"requirements.txt", "script.py"},
-			expected: true,
-		},
-		{
-			name:     "python files only",
-			files:    []string{"main.py", "utils.py"},
-			expected: true,
-		},
-		{
-			name:     "no python files",
-			files:    []string{"README.md", "Makefile"},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testDir := filepath.Join(tempDir, tt.name)
-			err := os.MkdirAll(testDir, 0o755)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			for _, file := range tt.files {
-				filePath := filepath.Join(testDir, file)
-				err := os.WriteFile(filePath, []byte("test content"), 0o600)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			detector := NewPythonDetector()
-			result, err := detector.DetectLanguage(testDir)
-			if err != nil {
-				t.Errorf("DetectLanguage() error = %v", err)
-				return
-			}
-
-			if result != tt.expected {
-				t.Errorf("DetectLanguage() = %v, expected %v", result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestTypeScriptDetector_DetectLanguage(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "ts_detector_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	tests := []struct {
-		name     string
-		files    []string
-		expected bool
-	}{
-		{
-			name:     "typescript project",
-			files:    []string{"tsconfig.json", "src/main.ts"},
-			expected: true,
-		},
-		{
-			name:     "typescript files without tsconfig",
-			files:    []string{"main.ts", "utils.ts"},
-			expected: false,
-		},
-		{
-			name:     "no typescript files",
-			files:    []string{"README.md", "package.json"},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testDir := filepath.Join(tempDir, tt.name)
-			err := os.MkdirAll(testDir, 0o755)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Create subdirectories if needed
-			for _, file := range tt.files {
-				filePath := filepath.Join(testDir, file)
-				dir := filepath.Dir(filePath)
-				if dir != testDir {
-					err := os.MkdirAll(dir, 0o755)
-					if err != nil {
-						t.Fatal(err)
-					}
-				}
-				err := os.WriteFile(filePath, []byte("test content"), 0o600)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			detector := NewTypeScriptDetector()
-			result, err := detector.DetectLanguage(testDir)
-			if err != nil {
-				t.Errorf("DetectLanguage() error = %v", err)
-				return
-			}
-
-			if result != tt.expected {
-				t.Errorf("DetectLanguage() = %v, expected %v", result, tt.expected)
-			}
-		})
-	}
+	return result
 }

--- a/devtools/devcheck/internal/detector/patterns_test.go
+++ b/devtools/devcheck/internal/detector/patterns_test.go
@@ -43,6 +43,26 @@ func TestPatternMatcher_MatchLanguages(t *testing.T) {
 			expected: []config.Language{config.LanguageGo},
 		},
 		{
+			name:     "go files without go.mod",
+			files:    []string{"main.go", "utils.go"},
+			expected: []config.Language{},
+		},
+		{
+			name:     "python files only",
+			files:    []string{"main.py", "utils.py"},
+			expected: []config.Language{config.LanguagePython},
+		},
+		{
+			name:     "python project with requirements.txt",
+			files:    []string{"requirements.txt", "script.py"},
+			expected: []config.Language{config.LanguagePython},
+		},
+		{
+			name:     "typescript files without tsconfig",
+			files:    []string{"main.ts", "utils.ts"},
+			expected: []config.Language{},
+		},
+		{
 			name:     "python project",
 			files:    []string{"pyproject.toml", "main.py", "requirements.txt"},
 			expected: []config.Language{config.LanguagePython},

--- a/devtools/devcheck/internal/detector/probe.go
+++ b/devtools/devcheck/internal/detector/probe.go
@@ -117,22 +117,21 @@ func makefileContentHasTarget(path, target string) bool {
 	return false
 }
 
-func availableCommands(specs ...string) []string {
-	var out []string
+func availableTools(specs ...config.Tool) []config.Tool {
+	var out []config.Tool
 	for _, spec := range specs {
-		if commandAvailable(spec) {
+		if commandAvailable(spec.Command) {
 			out = append(out, spec)
 		}
 	}
 	return out
 }
 
-func commandAvailable(spec string) bool {
-	fields := strings.Fields(spec)
-	if len(fields) == 0 {
+func commandAvailable(command string) bool {
+	if command == "" {
 		return false
 	}
-	_, err := exec.LookPath(fields[0])
+	_, err := exec.LookPath(command)
 	return err == nil
 }
 
@@ -140,8 +139,8 @@ type npmPackage struct {
 	Scripts map[string]string `json:"scripts"`
 }
 
-func loadNpmScripts(rootPath string) map[string]string {
-	path, ok := findPackageJSON(rootPath)
+func loadNpmScripts(rootPath string, scan *ScanResult) map[string]string {
+	path, ok := findPackageJSON(rootPath, scan)
 	if !ok {
 		return nil
 	}
@@ -156,19 +155,13 @@ func loadNpmScripts(rootPath string) map[string]string {
 	return pkg.Scripts
 }
 
-func findPackageJSON(rootPath string) (string, bool) {
-	rootFile := filepath.Join(rootPath, "package.json")
-	if _, err := os.Stat(rootFile); err == nil {
-		return rootFile, true
-	}
-	scanner := NewScanner(DefaultScanOptions())
-	result, err := scanner.Scan(rootPath)
-	if err != nil {
+func findPackageJSON(rootPath string, scan *ScanResult) (string, bool) {
+	if scan == nil {
 		return "", false
 	}
 	best := ""
 	bestDepth := -1
-	for _, file := range result.Files {
+	for _, file := range scan.Files {
 		if filepath.Base(file) != "package.json" {
 			continue
 		}

--- a/devtools/devcheck/internal/runner/plan.go
+++ b/devtools/devcheck/internal/runner/plan.go
@@ -99,26 +99,28 @@ func selectTool(project *config.ProjectConfig, toolType config.ToolType, opts Op
 	var tried []string
 	skippedForFiles := false
 	for _, spec := range candidates {
-		command, args := splitSpec(spec)
-		if opts.ForceFallback && isBuildSystemCommand(command) {
+		if opts.ForceFallback && isBuildSystemCommand(spec.Command) {
 			continue
 		}
-		tried = append(tried, spec)
-		if exec != nil && !exec.IsAvailable(command) {
+		tried = append(tried, spec.String())
+		if exec != nil && !exec.IsAvailable(spec.Command) {
 			continue
 		}
-		if skipForChangedFiles(command, opts) {
+		if skipForChangedFiles(spec.Command, opts) {
 			skippedForFiles = true
 			continue
 		}
-		cfg := buildConfig(command, args, toolType, project.RootPath, opts.ChangedFiles)
+		args := append([]string(nil), spec.Args...)
+		cfg := buildConfig(spec.Command, args, toolType, project.RootPath, opts.ChangedFiles)
 		return PlannedTool{Type: toolType, Config: cfg}, nil
 	}
 	if skippedForFiles {
 		return PlannedTool{}, errNoMatchingFiles
 	}
 	if len(tried) == 0 {
-		tried = candidates
+		for _, spec := range candidates {
+			tried = append(tried, spec.String())
+		}
 	}
 	return PlannedTool{}, fmt.Errorf("missing required %s tool (tried: %s)", toolType, strings.Join(tried, ", "))
 }
@@ -128,14 +130,6 @@ func skipForChangedFiles(command string, opts Options) bool {
 		return false
 	}
 	return len(filterFilesForCommand(command, opts.ChangedFiles)) == 0
-}
-
-func splitSpec(spec string) (string, []string) {
-	fields := strings.Fields(spec)
-	if len(fields) == 0 {
-		return spec, nil
-	}
-	return fields[0], append([]string(nil), fields[1:]...)
 }
 
 func isBuildSystemCommand(command string) bool {

--- a/devtools/devcheck/internal/runner/plan_test.go
+++ b/devtools/devcheck/internal/runner/plan_test.go
@@ -13,10 +13,10 @@ func TestPlan_MapsDetectedToolsToStructuredConfigs(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath:    "/repo",
 		BuildSystem: config.BuildSystemBazel,
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"bazel run //tools:format", "gofumpt"},
-			config.ToolTypeLint:   {"bazel run //tools:lint", "golangci-lint"},
-			config.ToolTypeTest:   {"bazel test //...", "go test"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("bazel", "run", "//tools:format"), tool("gofumpt")},
+			config.ToolTypeLint:   {tool("bazel", "run", "//tools:lint"), tool("golangci-lint")},
+			config.ToolTypeTest:   {tool("bazel", "test", "//..."), tool("go", "test")},
 		},
 	}
 	exec := availableExec(t, "bazel")
@@ -50,9 +50,9 @@ func TestPlan_ForceFallbackSkipsBuildSystemTools(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath:    "/repo",
 		BuildSystem: config.BuildSystemMake,
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"make format", "gofumpt", "gofmt"},
-			config.ToolTypeLint:   {"make lint", "golangci-lint"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("make", "format"), tool("gofumpt"), tool("gofmt")},
+			config.ToolTypeLint:   {tool("make", "lint"), tool("golangci-lint")},
 		},
 	}
 	exec := availableExec(t, "make", "gofumpt", "gofmt", "golangci-lint")
@@ -105,8 +105,8 @@ func TestPlan_FallsBackWhenPreferredBinaryMissing(t *testing.T) {
 func TestPlan_MissingRequiredTool(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeLint: {"golangci-lint"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeLint: {tool("golangci-lint")},
 		},
 	}
 	exec := availableExec(t)
@@ -123,8 +123,8 @@ func TestPlan_MissingRequiredTool(t *testing.T) {
 func TestPlan_EnhancesParserFriendlyArgs(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeLint: {"golangci-lint", "ruff check"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeLint: {tool("golangci-lint"), tool("ruff", "check")},
 		},
 	}
 	exec := availableExec(t, "golangci-lint")
@@ -148,8 +148,8 @@ func TestPlan_EnhancesParserFriendlyArgs(t *testing.T) {
 func TestPlan_EnhancesRuffCheckJSON(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeLint: {"ruff check"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeLint: {tool("ruff", "check")},
 		},
 	}
 	exec := availableExec(t, "ruff")
@@ -167,9 +167,9 @@ func TestPlan_EnhancesRuffCheckJSON(t *testing.T) {
 func TestPlan_ChangedOnlySkipsToolsWithoutMatchingFiles(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"gofumpt"},
-			config.ToolTypeLint:   {"ruff check"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("gofumpt")},
+			config.ToolTypeLint:   {tool("ruff", "check")},
 		},
 	}
 	exec := availableExec(t, "gofumpt", "ruff")
@@ -210,12 +210,16 @@ func bazelGoProject() *config.ProjectConfig {
 	return &config.ProjectConfig{
 		RootPath:    "/repo",
 		BuildSystem: config.BuildSystemBazel,
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"bazel run //tools:format", "gofumpt", "gofmt"},
-			config.ToolTypeLint:   {"bazel run //tools:lint", "golangci-lint"},
-			config.ToolTypeTest:   {"bazel test //...", "go test"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("bazel", "run", "//tools:format"), tool("gofumpt"), tool("gofmt")},
+			config.ToolTypeLint:   {tool("bazel", "run", "//tools:lint"), tool("golangci-lint")},
+			config.ToolTypeTest:   {tool("bazel", "test", "//..."), tool("go", "test")},
 		},
 	}
+}
+
+func tool(command string, args ...string) config.Tool {
+	return config.Tool{Command: command, Args: args}
 }
 
 func availableExec(t *testing.T, commands ...string) executor.Executor {

--- a/devtools/devcheck/internal/runner/run_test.go
+++ b/devtools/devcheck/internal/runner/run_test.go
@@ -47,9 +47,9 @@ func TestRun_DryRunDoesNotExecute(t *testing.T) {
 func TestRun_RecordsSuccessAndFailure(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"gofumpt"},
-			config.ToolTypeLint:   {"golangci-lint"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("gofumpt")},
+			config.ToolTypeLint:   {tool("golangci-lint")},
 		},
 	}
 	mock := executor.NewMockExecutor()
@@ -87,8 +87,8 @@ func TestRun_ChangedOnlyRequiresGit(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
 		HasGit:   false,
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"gofumpt"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("gofumpt")},
 		},
 	}
 	mock := availableExec(t, "gofumpt").(*executor.MockExecutor)
@@ -106,8 +106,8 @@ func TestRun_ChangedOnlyAppendsMatchingFiles(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
 		HasGit:   true,
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"gofumpt"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("gofumpt")},
 		},
 	}
 	mock := executor.NewMockExecutor()
@@ -146,8 +146,8 @@ func TestRun_ChangedOnlyAppendsMatchingFiles(t *testing.T) {
 func TestRun_AttachesRawOutputWhenUnparsed(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeLint: {"make lint"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeLint: {tool("make", "lint")},
 		},
 	}
 	mock := executor.NewMockExecutor()
@@ -173,8 +173,8 @@ func TestRun_AttachesRawOutputWhenUnparsed(t *testing.T) {
 func TestRun_ExecutionErrorFailsReport(t *testing.T) {
 	project := &config.ProjectConfig{
 		RootPath: "/repo",
-		Tools: map[config.ToolType][]string{
-			config.ToolTypeFormat: {"gofumpt"},
+		Tools: map[config.ToolType][]config.Tool{
+			config.ToolTypeFormat: {tool("gofumpt")},
 		},
 	}
 	mock := executor.NewMockExecutor()


### PR DESCRIPTION
## Summary
- Scan the project tree once per `Detect()` and reuse that `ScanResult` for language/build matching, config lookup, and tool lookup.
- Delete unused `DetectLanguage` / `DetectBuildSystem` copy-paste detectors and collapse language support into a table of patterns, config files, and default tools.
- Store detected tools as `command` + `args` (`config.Tool`) so the runner does not re-parse combined strings like `bazel run //tools:format`.
- Call `ProjectConfig.Validate()` after detect, and surface `filepath.Abs` / scan / git-stat errors instead of swallowing them.

Resolves #263

## Demo

Recorded against this repo. Default `devcheck --dry-run` still selects Make. The change is that detection no longer re-walks the tree per language and no longer stores `"make format"` as a single string.

### Before (`main`)

`Detect()` stored combined command strings and re-scanned for each language's config/tools:

```
Tools: map[ToolType][]string{
  format: ["make format", "gofumpt", ...],
}
```

`devcheck --dry-run .`

```
🔧 DevCheck Report

Repository Analysis:
- Build System: make
- Languages: go, python, typescript
- Strategy: Dry-run; commands were not executed

Tools that would run:
⏳ make format - would run
⏳ make lint - would run
⏳ make test - would run

Issues Found:
none
Next Steps for AI Agent:
1. Re-run without --dry-run to execute the selected tools

Status: dry-run (commands were not executed)
```

`devcheck --force-fallback --filter=format --dry-run .` picked the first language formatter from map-iteration order (this run: `ruff format`).

### After (this PR)

`Detect()` stores structured tools the executor can run without `sh -c`:

```
Tools: map[ToolType][]Tool{
  format: [{Command: "make", Args: ["format"]}, {Command: "gofumpt"}, ...],
}
```

`devcheck --dry-run .` (unchanged user-facing default):

```
🔧 DevCheck Report

Repository Analysis:
- Build System: make
- Languages: go, python, typescript
- Strategy: Dry-run; commands were not executed

Tools that would run:
⏳ make format - would run
⏳ make lint - would run
⏳ make test - would run

Issues Found:
none
Next Steps for AI Agent:
1. Re-run without --dry-run to execute the selected tools

Status: dry-run (commands were not executed)
```

`devcheck --dry-run --format=json --filter=format .` (command and args separate):

```
{
  "tools": [
    {
      "command": "make",
      "args": ["format"]
    }
  ]
}
```

`devcheck --force-fallback --filter=format --dry-run .` now follows the language table (Go, Python, TypeScript, JavaScript), so this repo's first fallback formatter is `gofumpt -w .`.

## Test plan
- [x] One `Scan` per `Detect()` (fake scanner + config files taken from that scan)
- [x] `DetectLanguage` / `DetectBuildSystem` are gone; matching stays in `PatternMatcher`
- [x] Bazel/Make tools have `Command` and `Args` separately
- [x] Invalid `ProjectConfig` from `Detect()` fails the call
- [x] `make check` is green (309 tests pass, lint/semgrep clean)
