### PR TITLE
fix(deps): bump soupsieve to 2.9.2 for Dependabot CVEs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -900,10 +900,10 @@
     },
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "QJFB+mMz+t0T5ZE+NVHTr0Wjox4gvFuVw9JFRbUw0kY=",
+        "bzlTransitiveDigest": "0jTfGPNFoJXBH0gaNQgUVV0NnztNNlhQDOVZ6DKK/3s=",
         "usagesDigest": "WOZnVFaSaggvdghKbbmzzdfOKpYf9JZIGavfIsthLQg=",
         "recordedFileInputs": {
-          "@@//requirements.txt": "9b75f1f24b535ae2be44cb8f11ae447d785e9c078df874942bacc3546ad3c4ab",
+          "@@//requirements.txt": "5a055f29aa3d39219d2f94d5db249fec9b31e57924793d71bb5e88dd85bff9f0",
           "@@protobuf+//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
           "@@rules_fuzzing+//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
           "@@rules_python+//tools/publish/requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",
@@ -949,7 +949,7 @@
               "dep_template": "@main_pip_deps//{name}:{target}",
               "python_interpreter_target": "@@rules_python++python+python_3_11_host//:python",
               "repo": "main_pip_deps_311",
-              "requirement": "soupsieve==2.6"
+              "requirement": "soupsieve==2.9.2"
             }
           },
           "main_pip_deps_311_typing_extensions": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -508,14 +508,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9.2"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
-    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
+    {file = "soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823"},
+    {file = "soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74"},
 ]
 
 [[package]]
@@ -554,4 +554,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "0854cf2e49cdc7b402924de2b068b8bd9a472d8d4c0b873e88eaa57313e0e149"
+content-hash = "11a1b67bb5a8746dc43db760397ffcb611966fe7a32c0dd8e4a2cb1ea1a0aa3d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.org"
 python = "^3.10"
 beautifulsoup4 = "^4.12.3"
 cssutils = "^2.11.1"
+soupsieve = ">=2.8.4"
 buf = {version = "*", markers = "sys_platform == 'linux-android'"}
 protovalidate = "^0.6.0"
 grpcio = {version = "*", markers = "sys_platform == 'linux-android'"}

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,5 @@
 # Base dependencies for html_convert
 beautifulsoup4
 cssutils
+# Floor for GHSA-2wc2-fm75-p42x / GHSA-836r-79rf-4m37 (CVE-2026-49476, CVE-2026-49477)
+soupsieve>=2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ cssutils==2.11.1
     # via -r requirements.in
 more-itertools==10.6.0
     # via cssutils
-soupsieve==2.6
-    # via beautifulsoup4
+soupsieve==2.9.2
+    # via
+    #   -r requirements.in
+    #   beautifulsoup4
 typing-extensions==4.13.2
     # via beautifulsoup4


### PR DESCRIPTION
## Summary

- Pin soupsieve `>=2.8.4` so pip/poetry cannot resolve the versions affected by [GHSA-2wc2-fm75-p42x](https://github.com/advisories/GHSA-2wc2-fm75-p42x) and [GHSA-836r-79rf-4m37](https://github.com/advisories/GHSA-836r-79rf-4m37) (CVE-2026-49476, CVE-2026-49477).
- Lock `requirements.txt` and `MODULE.bazel.lock` from 2.6 to 2.9.2. Those were the remaining open Dependabot alerts ([#54](https://github.com/jaeyeom/experimental/security/dependabot/54), [#55](https://github.com/jaeyeom/experimental/security/dependabot/55)).
- `poetry.lock` was already on 2.8.4 from #191; bump it to 2.9.2 so both Python lockfiles match. That should also close the stale poetry alerts ([#52](https://github.com/jaeyeom/experimental/security/dependabot/52), [#53](https://github.com/jaeyeom/experimental/security/dependabot/53)).

## Test plan

- [x] Confirmed soupsieve is 2.9.2 in `requirements.txt`, `poetry.lock`, and `MODULE.bazel.lock`
- [x] `make check` is green (309 tests pass, lint/semgrep clean)