### PR TITLE
make check: oserrorsgodernize crashes on Go 1.27 (package without types)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,4 +46,9 @@ sh_binary(
     srcs = ["check-bazel-src-files.sh"],
 )
 
+sh_binary(
+    name = "check-oserrorsgodernize",
+    srcs = ["check-oserrorsgodernize.sh"],
+)
+
 org_lint_tests(["README.org"])

--- a/Makefile
+++ b/Makefile
@@ -43,16 +43,21 @@ lint: lint-golangci lint-ruff lint-mypy lint-shellcheck check-spacemacs
 fix: fix-golangci fix-ruff lint-mypy lint-shellcheck check-spacemacs
 
 # Go targets
-.PHONY: lint-golangci fix-golangci verify-golangci-config check-bazel-go-files
+.PHONY: lint-golangci fix-golangci verify-golangci-config verify-oserrorsgodernize check-bazel-go-files
 GOLANGCI_CONFIG_HASH_FILE := .tmp/golangci.yml.hash
 
-lint-golangci: verify-golangci-config
+# oserrorsgodernize must be built against golang.org/x/tools >= v0.49.0
+# (Go 1.27 "package without types" crash; see #283).
+lint-golangci: verify-golangci-config verify-oserrorsgodernize
 	GOPACKAGESDRIVER= golangci-lint run ./...
 	oserrorsgodernize ./...
 
-fix-golangci: verify-golangci-config
+fix-golangci: verify-golangci-config verify-oserrorsgodernize
 	GOPACKAGESDRIVER= golangci-lint run --fix ./...
 	oserrorsgodernize --fix ./...
+
+verify-oserrorsgodernize:
+	@./check-oserrorsgodernize.sh
 
 verify-golangci-config:
 	@CURRENT_HASH=$$(shasum -a 256 .golangci.yml | cut -d' ' -f1); \

--- a/README.org
+++ b/README.org
@@ -33,8 +33,18 @@ The Go module path is =github.com/jaeyeom/experimental=. You will need:
 
 - [[https://bazel.build/install/bazelisk][Bazelisk]] (pinned via =.bazeliskrc=) — primary build and test driver.
 - =goimports= — Go formatting.
-- =golangci-lint=, =ruff=, =mypy=, =shellcheck=, =semgrep= — linters (run by =make lint= / =make check=).
+- =golangci-lint=, =oserrorsgodernize=, =ruff=, =mypy=, =shellcheck=, =semgrep= — linters (run by =make lint= / =make check=).
 - =uv= — Python lockfile tool (`uv.lock`; checked by =make check=).
+
+=oserrorsgodernize= must be built with the current Go toolchain against
+=golang.org/x/tools= v0.49.0 or newer (Go 1.27 fatals with =package without
+types= otherwise; see [[https://github.com/jaeyeom/experimental/issues/283][#283]]).
+=make lint= checks this. Reinstall after upgrading Go:
+
+#+begin_src sh
+go install github.com/jaeyeom/godernize/oserrors/cmd/oserrorsgodernize@latest
+# or: cd devtools/setup-dev/ansible && ./ensure.sh oserrorsgodernize
+#+end_src
 
 Clone the repo and run the test suite to verify your setup:
 
@@ -51,15 +61,15 @@ underneath for hermetic, reproducible builds.
 ** GNU Make
 =Makefile= exposes the common entry points:
 
-| Command              | Purpose                                                              |
-|----------------------+----------------------------------------------------------------------|
-| =make check=         | Run all pre-commit checks: format, tests, lint, semgrep, generators. |
-| =make test=          | Run all Bazel tests (=bazel test //...=).                            |
-| =make format=        | Format code (=goimports= + Bazel =buildifier=).                      |
-| =make lint=          | Run golangci-lint, ruff, mypy, shellcheck, and Spacemacs checks.     |
-| =make fix=           | Best-effort autofix for lint issues.                                 |
-| =make all=           | Regenerate, format, fix, then test and lint.                         |
-| =make coverage-html= | Generate an HTML coverage report under =coverage/html/=.             |
+| Command              | Purpose                                                                         |
+|----------------------+---------------------------------------------------------------------------------|
+| =make check=         | Run all pre-commit checks: format, tests, lint, semgrep, generators.            |
+| =make test=          | Run all Bazel tests (=bazel test //...=).                                       |
+| =make format=        | Format code (=goimports= + Bazel =buildifier=).                                 |
+| =make lint=          | Run golangci-lint, oserrorsgodernize, ruff, mypy, shellcheck, Spacemacs checks. |
+| =make fix=           | Best-effort autofix for lint issues.                                            |
+| =make all=           | Regenerate, format, fix, then test and lint.                                    |
+| =make coverage-html= | Generate an HTML coverage report under =coverage/html/=.                        |
 
 ** Bazel
 This repository is experimenting with Bazel and the goal is to make it fully

--- a/check-oserrorsgodernize.sh
+++ b/check-oserrorsgodernize.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Fail if oserrorsgodernize is missing, built against an old golang.org/x/tools,
+# or built with a different Go major.minor than the current toolchain.
+# Go 1.27 fatals with "package without types" when the analyzer uses x/tools
+# older than v0.49.0 (see #283). A binary built with an older Go can also fail
+# to load current stdlib packages (e.g. math/rand/v2).
+
+set -euo pipefail
+
+MIN_XTOOLS="${OSERRORS_MIN_XTOOLS:-v0.49.0}"
+
+install_hint() {
+	echo "Reinstall with:" >&2
+	echo "  go install github.com/jaeyeom/godernize/oserrors/cmd/oserrorsgodernize@latest" >&2
+	echo "or:" >&2
+	echo "  cd devtools/setup-dev/ansible && ./ensure.sh oserrorsgodernize" >&2
+}
+
+# go1.26.7 -> go1.26
+go_major_minor() {
+	sed -n 's/^go\([0-9][0-9]*\.[0-9][0-9]*\).*/go\1/p' <<<"$1"
+}
+
+# Returns 0 if $1 < $2 (dotted versions, optional leading v).
+version_lt() {
+	local a=${1#v}
+	local b=${2#v}
+	local a1 a2 a3 b1 b2 b3
+	IFS=. read -r a1 a2 a3 _ <<<"${a}..."
+	IFS=. read -r b1 b2 b3 _ <<<"${b}..."
+	a1=${a1:-0}
+	a2=${a2:-0}
+	a3=${a3:-0}
+	b1=${b1:-0}
+	b2=${b2:-0}
+	b3=${b3:-0}
+	if [ "$a1" -lt "$b1" ]; then
+		return 0
+	fi
+	if [ "$a1" -gt "$b1" ]; then
+		return 1
+	fi
+	if [ "$a2" -lt "$b2" ]; then
+		return 0
+	fi
+	if [ "$a2" -gt "$b2" ]; then
+		return 1
+	fi
+	[ "$a3" -lt "$b3" ]
+}
+
+bin=$(command -v oserrorsgodernize) || {
+	echo "oserrorsgodernize not found." >&2
+	install_hint
+	exit 1
+}
+
+xtools=$(go version -m "$bin" 2>/dev/null | awk '$2 == "golang.org/x/tools" { print $3; exit }')
+if [ -z "$xtools" ]; then
+	echo "Could not determine golang.org/x/tools version of $bin" >&2
+	install_hint
+	exit 1
+fi
+
+if version_lt "$xtools" "$MIN_XTOOLS"; then
+	echo "oserrorsgodernize was built with golang.org/x/tools $xtools; need >= $MIN_XTOOLS on Go 1.27+." >&2
+	install_hint
+	exit 1
+fi
+
+bin_go=$(go version -m "$bin" 2>/dev/null | awk 'NR==1 { print $2; exit }')
+cur_go=$(go version | awk '{ print $3 }')
+bin_mm=$(go_major_minor "$bin_go")
+cur_mm=$(go_major_minor "$cur_go")
+if [ -z "$bin_mm" ] || [ -z "$cur_mm" ]; then
+	echo "Could not determine Go versions (binary=$bin_go current=$cur_go)" >&2
+	install_hint
+	exit 1
+fi
+if [ "$bin_mm" != "$cur_mm" ]; then
+	echo "oserrorsgodernize was built with $bin_go but the current toolchain is $cur_go." >&2
+	echo "Rebuild the analyzer with the current Go toolchain." >&2
+	install_hint
+	exit 1
+fi


### PR DESCRIPTION
## Summary

<!-- What changed and why. Reviewers should understand the purpose from this
     section alone. Use bullets. Link the issue if there is one. -->

- `make lint` / `make check` now refuse to run `oserrorsgodernize` unless it is built with the current Go major.minor and `golang.org/x/tools` >= v0.49.0.
- Document the required analyzer toolchain and the ansible / `go install` reinstall path in `README.org`.
- The crash itself is fixed in [godernize v0.1.0](https://github.com/jaeyeom/godernize/releases/tag/v0.1.0) (`golang.org/x/tools` v0.49.0). `devtools/setup-dev/ansible/oserrorsgodernize.yml` already installs `@latest`, which now resolves to that release.

Resolves #283

## Demo

<!-- Optional. Before/after output for CLI or user-visible behavior.
     Delete this section if it would not help a reviewer. -->

Before (Go 1.27, analyzer built against x/tools v0.28.0):

```text
$ GOTOOLCHAIN=go1.27.0 oserrorsgodernize ./...
oserrors: internal error: package "sync" without types was imported from "github.com/jaeyeom/experimental/memocache"
# exit 1
```

After godernize v0.1.0, rebuilt with the current toolchain, the same command exits 0. Stale binaries fail the new preflight instead of the cryptic internal error:

```text
$ GOTOOLCHAIN=go1.27.0 make verify-oserrorsgodernize
oserrorsgodernize was built with go1.26.7 but the current toolchain is go1.27.0.
Rebuild the analyzer with the current Go toolchain.
Reinstall with:
  go install github.com/jaeyeom/godernize/oserrors/cmd/oserrorsgodernize@latest
or:
  cd devtools/setup-dev/ansible && ./ensure.sh oserrorsgodernize
```

## Test plan

<!-- Fill in what you actually ran. Do not check an item unless you ran that
     command and looked at the output.

     Confirm the test really ran. A green suite is not enough if the new test
     never executed (missing BUILD target, wrong package, skip, or filter).
     The test name should appear in the output.

     For new or changed coverage, also confirm failure: watch the test fail
     for the expected reason (missing behavior or the bug), then pass after
     the change. If it passed on the first run, it may not be testing what
     you think.

     If a test might be flaky (timing, concurrency, network, filesystem,
     ordering), attach a flakiness sweep below. -->

- [x] Reproduced the crash with the old binary: `GOTOOLCHAIN=go1.27.0 oserrorsgodernize ./...` exited 1 (`package "sync" without types` from `memocache`)
- [x] After godernize v0.1.0 built with Go 1.27, `GOTOOLCHAIN=go1.27.0 oserrorsgodernize ./...` exits 0
- [x] `./check-oserrorsgodernize.sh` passes on the current toolchain with x/tools v0.49.0
- [x] `OSERRORS_MIN_XTOOLS=v0.99.0 ./check-oserrorsgodernize.sh` fails with the rebuild hint
- [x] `GOTOOLCHAIN=go1.27.0 ./check-oserrorsgodernize.sh` fails when the binary was built with go1.26.7
- [x] `shellcheck -x check-oserrorsgodernize.sh`
- [x] `make check` is green

## Reviewer notes

<!-- Optional. Risky files, tricky logic, or decisions you want a second
     opinion on. Delete if none. -->

The analyzer fix lives in https://github.com/jaeyeom/godernize/pull/5 (released as v0.1.0). This PR only documents the required toolchain and fails `make lint` early when the installed binary is stale, so a Go upgrade does not surface as `package without types`.
